### PR TITLE
Add markdown alerts to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 - SRP-6a authentication with Apple's custom protocol variants
 - Two-factor authentication (trusted device code) with trust persistence
 - Session persistence with cookie management, lock files, and proactive token refresh
-- **Change from Python:** Lock files prevent concurrent instances from corrupting session state; trust token age is tracked with warnings before expiry; expired cookies are pruned on load
+
+> [!IMPORTANT]
+> **Change from Python:** Lock files prevent concurrent instances from corrupting session state; trust token age is tracked with warnings before expiry; expired cookies are pruned on load
 
 ### Downloads
 - Streaming download pipeline with configurable concurrent downloads (`--threads-num`)
@@ -14,19 +16,33 @@
 - Retry with exponential backoff and transient/permanent error classification (`--max-retries`, `--retry-delay`)
 - Two-phase cleanup pass — retries failures with fresh CDN URLs
 - Low memory streaming for large libraries (100k+ photos)
-- **Change from Python:** Downloads begin as soon as the first API page returns, rather than enumerating the entire library before starting — eliminates multi-minute startup delays on large libraries
-- **Change from Python:** `PhotoAsset` no longer retains raw JSON blobs; version URLs are pre-parsed at construction, reducing per-asset memory
-- **Change from Python:** Partial `.part` files are resumed via HTTP Range; existing bytes are hashed on resume so the final SHA256 checksum covers the entire file
-- **Change from Python:** Failed downloads get a cleanup pass that re-fetches URLs from iCloud before retrying, fixing expired CDN URL failures on large syncs
-- **Change from Python:** API calls (album fetch, zone list) retry automatically on 5xx/429 errors
-- **Change from Python:** Album photo fetching runs concurrently (bounded by `--threads-num`) instead of sequentially
+
+> [!IMPORTANT]
+> **Change from Python:** Downloads begin as soon as the first API page returns, rather than enumerating the entire library before starting — eliminates multi-minute startup delays on large libraries
+
+> [!TIP]
+> **Change from Python:** `PhotoAsset` no longer retains raw JSON blobs; version URLs are pre-parsed at construction, reducing per-asset memory
+
+> [!IMPORTANT]
+> **Change from Python:** Partial `.part` files are resumed via HTTP Range; existing bytes are hashed on resume so the final SHA256 checksum covers the entire file
+
+> [!TIP]
+> **Change from Python:** Failed downloads get a cleanup pass that re-fetches URLs from iCloud before retrying, fixing expired CDN URL failures on large syncs
+
+> [!NOTE]
+> **Change from Python:** API calls (album fetch, zone list) retry automatically on 5xx/429 errors
+
+> [!NOTE]
+> **Change from Python:** Album photo fetching runs concurrently (bounded by `--threads-num`) instead of sequentially
 
 ### Photos & Media
 - Photo, video, and live photo MOV downloads with size variants
 - RAW file alignment (`--align-raw`: as-is, original, alternative)
 - Live photo MOV filename policies (suffix, original)
 - Content filtering by media type, date range, album, and recency
-- **Change from Python:** Live photo MOV size is independently configurable (`--live-photo-size`)
+
+> [!TIP]
+> **Change from Python:** Live photo MOV size is independently configurable (`--live-photo-size`)
 
 ### Organization
 - Date-based folder structures (`--folder-structure`)
@@ -38,5 +54,9 @@
 - Watch mode with session validation between cycles
 - Album and shared library enumeration
 - Log level control, domain selection (com/cn), custom cookie directory
-- **Change from Python:** `--recent N` stops fetching from the API after N photos instead of enumerating the entire library first
-- **Change from Python:** `--until-found` removed — will be replaced by stateful incremental sync with local database
+
+> [!TIP]
+> **Change from Python:** `--recent N` stops fetching from the API after N photos instead of enumerating the entire library first
+
+> [!CAUTION]
+> **Change from Python:** `--until-found` removed — will be replaced by stateful incremental sync with local database


### PR DESCRIPTION
## Summary
- Add GitHub markdown alerts (NOTE, TIP, IMPORTANT, WARNING, CAUTION) to "Change from Python" items in CHANGELOG.md for better visual distinction

## Test plan
- [x] Verify changelog renders correctly on GitHub with alert callouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)