### PR TITLE
Wrap rpassword prompt in block_in_place for async safety

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,7 @@ async fn main() -> anyhow::Result<()> {
         let pw = config.password;
         move || -> Option<String> {
             pw.clone().or_else(|| {
-                // Note: This closure is called from an async context but
-                // rpassword blocks. The caller should wrap in spawn_blocking
-                // if needed. For CLI startup this is acceptable.
-                rpassword::prompt_password("iCloud Password: ").ok()
+                tokio::task::block_in_place(|| rpassword::prompt_password("iCloud Password: ").ok())
             })
         }
     };


### PR DESCRIPTION
## Summary
- Wraps the blocking `rpassword::prompt_password` call in `tokio::task::block_in_place` so it won't stall the async runtime during watch-mode re-authentication.

Closes #8

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` — no new failures (9 pre-existing failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)