### PR TITLE
Remove trust token expiry prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Authentication
 - SRP-6a authentication with Apple's custom protocol variants
 - Two-factor authentication (trusted device code) with trust persistence
-- Session persistence with cookie management, lock files, and proactive token refresh
+- Session persistence with cookie management and lock files
 
 > [!IMPORTANT]
-> **Change from Python:** Lock files prevent concurrent instances from corrupting session state; trust token age is tracked with warnings before expiry; expired cookies are pruned on load
+> **Change from Python:** Lock files prevent concurrent instances from corrupting session state; expired cookies are pruned on load
 
 ### Downloads
 - Streaming download pipeline with configurable concurrent downloads (`--threads-num`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,20 +189,6 @@ async fn main() -> anyhow::Result<()> {
             break;
         }
 
-        // Check trust token expiry before each download cycle
-        {
-            let session = shared_session.read().await;
-            if session.trust_token_expires_soon(7) {
-                if let Some(age) = session.trust_token_age() {
-                    tracing::warn!(
-                        "Trust token is {} days old and may expire soon — \
-                         consider re-authenticating with --auth-only",
-                        age.as_secs() / 86400
-                    );
-                }
-            }
-        }
-
         let client = shared_session.read().await.http_client();
         download::download_photos(&client, &albums, &download_config, shutdown_token.clone())
             .await?;


### PR DESCRIPTION
## Summary
- Remove trust token age tracking and expiry prediction based on an unfounded 30-day lifetime estimate
- Apple's trust token lifetime is undocumented; predicting expiry with a guessed value would produce false warnings

## Changes
- Remove `trust_token_age()` and `trust_token_expires_soon()` from `Session`
- Remove `trust_token_timestamp` tracking from header capture
- Remove pre-download trust token expiry check in `main.rs`
- Update CHANGELOG to remove references to proactive token refresh

## Test plan
- [x] Existing tests pass (`cargo test`)
- [x] No functional change to auth flow — trust tokens still work, just no speculative warnings