### PR TITLE
Fix live photo MOV filename collision with regular videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Resumable partial downloads via HTTP Range requests with SHA256 verification
 - Retry with exponential backoff and transient/permanent error classification (`--max-retries`, `--retry-delay`)
 - Progress bar tracking download progress, auto-hidden in non-TTY environments (`--no-progress-bar`)
+- Live photo MOV collision detection — when a regular video occupies the same filename, the companion MOV is saved with an asset ID suffix (e.g. `IMG_0001-ASSET_ID.MOV`)
 - Two-phase cleanup pass — retries failures with fresh CDN URLs
 - Low memory streaming for large libraries (100k+ photos)
 

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -68,12 +68,19 @@ pub fn remove_unicode_chars(filename: &str) -> String {
 /// If the filename has no extension, the suffix is simply appended.
 #[allow(dead_code)] // for --file-match-policy (parsed but not yet wired)
 pub fn add_dedup_suffix(path: &str, size: u64) -> String {
+    insert_suffix(path, &size.to_string())
+}
+
+/// Add a string suffix before the file extension.
+///
+/// For example, `"photo.jpg"` with suffix `"abc"` becomes `"photo-abc.jpg"`.
+pub fn insert_suffix(path: &str, suffix: &str) -> String {
     match path.rfind('.') {
         Some(dot_pos) => {
             let (stem, ext) = path.split_at(dot_pos);
-            format!("{}-{}{}", stem, size, ext)
+            format!("{}-{}{}", stem, suffix, ext)
         }
-        None => format!("{}-{}", path, size),
+        None => format!("{}-{}", path, suffix),
     }
 }
 
@@ -163,5 +170,15 @@ mod tests {
         assert_eq!(add_dedup_suffix("photo.jpg", 12345), "photo-12345.jpg");
         assert_eq!(add_dedup_suffix("photo", 100), "photo-100");
         assert_eq!(add_dedup_suffix("my.photo.png", 999), "my.photo-999.png");
+    }
+
+    #[test]
+    fn test_insert_suffix() {
+        assert_eq!(
+            insert_suffix("IMG_0001.MOV", "ASSET_ID"),
+            "IMG_0001-ASSET_ID.MOV"
+        );
+        assert_eq!(insert_suffix("photo", "123"), "photo-123");
+        assert_eq!(insert_suffix("a.b.mov", "id"), "a.b-id.mov");
     }
 }


### PR DESCRIPTION
## Summary
- When a regular video and a live photo companion resolve to the same filename, the live photo MOV was silently skipped because the file already existed
- Now detects collisions by comparing on-disk file size with the expected live photo size
- On mismatch, deduplicates by appending the asset ID before the extension (e.g. `IMG_0001-ASSET_ID.MOV`)

## Changes
- `src/download/mod.rs`: collision detection and dedup logic in `filter_asset_to_tasks`; updated existing test to use matching file size; added new collision test
- `src/download/paths.rs`: extracted `insert_suffix()` from `add_dedup_suffix()` for reuse with arbitrary suffixes

## Test plan
- [x] Existing live photo skip test updated to verify size-based matching
- [x] New test: `test_filter_deduplicates_live_photo_mov_collision` verifies dedup path contains asset ID
- [x] New test: `test_insert_suffix` covers the helper function