### PR TITLE
fix: restore streaming download behavior

### DIFF
--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -123,7 +123,7 @@ impl PhotoAlbum {
     pub fn photo_stream(
         &self,
         limit: Option<u32>,
-    ) -> Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + '_>> {
+    ) -> Pin<Box<dyn Stream<Item = anyhow::Result<PhotoAsset>> + Send + 'static>> {
         let (tx, rx) = tokio::sync::mpsc::channel::<anyhow::Result<PhotoAsset>>(self.page_size);
 
         // The spawned task must be 'static, so clone all needed state.


### PR DESCRIPTION
## Summary

- Fixes regression from 90eb7f8 where downloads didn't start until all photos were fetched
- Downloads now start immediately as assets arrive from the API
- Uses channel-based producer-consumer pattern for true streaming

## Changes

- Replace blocking collection loop with mpsc channel streaming
- Producer task processes assets and sends download tasks to channel
- Consumer downloads from channel with `buffer_unordered` concurrency
- Switch from batch `upsert_seen_batch` to per-asset `upsert_seen` calls
- Change `photo_stream` return type to `'static` (stream doesn't borrow from self)
- Add `Clone` derive to `DownloadConfig` for producer task
- Remove unused `upsert_seen_batch` trait method

## Trade-offs

This trades some DB batch efficiency for streaming behavior. For most users, the improved latency (time to first download) outweighs the slightly increased DB operations.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes (no warnings)
- [x] `cargo test` passes (217 tests)