### PR TITLE
Fix code review quality issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +873,7 @@ dependencies = [
  "chrono",
  "clap",
  "cookie",
+ "data-encoding",
  "dirs",
  "fs4",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,4 @@ rusqlite = { version = "0.38", features = ["bundled"] }
 # Memory optimization
 smallvec = "1.15"
 rustc-hash = "2.1"
+data-encoding = "2.10.0"

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io::{self, Write};
 
 use anyhow::{Context, Result};
@@ -45,14 +44,13 @@ pub async fn request_2fa_code(
         }
     });
 
-    let mut accept_override = HashMap::new();
-    accept_override.insert("Accept".to_string(), "application/json".to_string());
+    let accept_override: [(&str, &str); 1] = [("Accept", "application/json")];
 
     let headers = get_auth_headers(
         domain,
         client_id,
         &session.session_data,
-        Some(accept_override),
+        Some(&accept_override),
     )?;
 
     let url = format!("{}/verify/trusteddevice/securitycode", endpoints.auth);

--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -163,7 +163,7 @@ pub(crate) const VIDEO_VERSION_LOOKUP: &[(AssetVersionSize, &str)] = &[
 
 pub(crate) fn encode_params(params: &HashMap<String, Value>) -> String {
     use std::borrow::Cow;
-    let pairs: Vec<String> = params
+    let mut pairs: Vec<String> = params
         .iter()
         .map(|(k, v)| {
             let val: Cow<'_, str> = match v {
@@ -175,6 +175,7 @@ pub(crate) fn encode_params(params: &HashMap<String, Value>) -> String {
             format!("{}={}", urlencoding::encode(k), urlencoding::encode(&val))
         })
         .collect();
+    pairs.sort();
     pairs.join("&")
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,8 +494,10 @@ async fn run_import_existing(args: cli::ImportArgs) -> anyhow::Result<()> {
 async fn main() -> anyhow::Result<()> {
     let cli = cli::Cli::parse();
 
+    // Scope debug/info to the app crate so dependency crates stay quieter.
+    // Users can override with RUST_LOG env var for full control.
     let filter = match cli.log_level {
-        types::LogLevel::Debug => "debug",
+        types::LogLevel::Debug => "icloudpd_rs=debug,info",
         types::LogLevel::Info => "info",
         types::LogLevel::Warn => "warn",
         types::LogLevel::Error => "error",


### PR DESCRIPTION
## Summary

Addresses all outstanding code-quality items from the deep code review (logic bugs, idiom issues, and the fingerprint fallback data-loss path).

- **Fingerprint fallback filenames**: Assets missing `filenameEnc` now get a fallback filename generated from the asset ID (matching Python's `generate_fingerprint_filename()`), instead of being silently skipped. Closes #35.
- **`should_download_fast` dead arm**: Split `Some(true)|Some(false)` into separate match arms — `Some(false)` now defensively skips instead of downloading.
- **Replace manual base32 with `data-encoding` crate**: Removes hand-rolled encoder in favor of battle-tested library.
- **Add fsync after download**: `sync_data()` call after `flush()` for crash durability of `.part` files.
- **Optimize cookie/session persistence**: Only writes session and cookie files when values actually changed, avoiding redundant I/O during album pagination.
- **Fix `row_to_asset_record` error swallowing**: Propagates `rusqlite::Error` via `?` instead of silently falling back to defaults with `unwrap_or_default()`.
- **Optimize `get_auth_headers` overrides**: Changed from `Option<HashMap<String, String>>` to `Option<&[(&str, &str)]>`, eliminating per-call heap allocation.
- **Deterministic query param order**: `encode_params` now sorts pairs before joining.
- **Scope debug logging**: `--log-level debug` now uses `icloudpd_rs=debug,info` so dependency crates stay at info level.
- **Fix misleading comment**: Corrected `SqliteStateDb` doc claiming all ops use `spawn_blocking`.

## Test plan

- [ ] All 228 existing tests pass, 0 clippy warnings, formatting clean
- [ ] New tests for `item_type_extension`, `generate_fingerprint_filename` (4 tests in paths.rs)
- [ ] Updated test verifies fingerprint fallback with special-char asset ID (`AB/CD+EF==GH` → `AB_CD_EF__GH.JPG`)
- [ ] Verify real download against iCloud account to confirm no regressions