### PR TITLE
Wire --library flag to select download zone

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,8 +73,7 @@ pub struct SyncArgs {
     pub albums: Vec<String>,
 
     /// Library to download (default: PrimarySync)
-    /// NOTE: Parsed but not yet wired up - hidden until implemented
-    #[arg(long, default_value = "PrimarySync", hide = true)]
+    #[arg(long, default_value = "PrimarySync")]
     pub library: String,
 
     /// Image size to download
@@ -539,6 +538,22 @@ mod tests {
 
     fn base_args() -> Vec<&'static str> {
         vec!["icloudpd-rs", "--username", "test@example.com"]
+    }
+
+    #[test]
+    fn test_library_default_primary_sync() {
+        let cli = parse(&base_args());
+        let legacy: LegacyCli = cli.into();
+        assert_eq!(legacy.library, "PrimarySync");
+    }
+
+    #[test]
+    fn test_library_accepts_custom_value() {
+        let mut args = base_args();
+        args.extend(["--library", "SharedSync-ABCD1234"]);
+        let cli = parse(&args);
+        let legacy: LegacyCli = cli.into();
+        assert_eq!(legacy.library, "SharedSync-ABCD1234");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,6 @@ pub struct Config {
     pub cookie_directory: PathBuf,
     pub folder_structure: String,
     pub albums: Vec<String>,
-    #[allow(dead_code)] // CLI flag parsed but not yet wired
     pub library: String,
 
     // DateTime fields


### PR DESCRIPTION
## Summary

- Add `get_library()` method to `PhotosService` that resolves a library by zone name (checks primary, then private, then shared)
- Wire `config.library` through the sync flow in `main.rs` so `--library` selects which zone to download from
- Unhide `--library` from `--help` and remove `#[allow(dead_code)]` from the config field
- Add CLI tests for the flag

Closes #20

## Test plan

- [x] `cargo fmt -- --check && cargo clippy` passes with zero warnings
- [x] `cargo test` — 230 tests pass (2 new: `test_library_default_primary_sync`, `test_library_accepts_custom_value`)
- [ ] Manual test: `--list-libraries` still works
- [ ] Manual test: `--library SharedSync-XXXX` downloads from the shared library zone
- [ ] Manual test: `--library BadName` gives a clear error with suggestion to use `--list-libraries`