### PR TITLE
Consolidate as v0.1.0, unhide wired CLI flags, update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.1.1] - 2026-02-04
-
-### Fixed
-
-- **Streaming regression** — Downloads now start immediately as assets arrive from the API, rather than waiting for all photos to be enumerated first. This fixes a regression introduced in v0.1.0 where large libraries experienced significant delay before the first download began.
-
-### Changed
-
-- Replaced blocking collection loop with channel-based producer-consumer pattern for true streaming behavior
-- Switched from batch `upsert_seen_batch` to per-asset `upsert_seen` calls (trades some DB efficiency for streaming)
-
----
-
-## [0.1.0] - 2025-02-03
+## [0.1.0] - 2026-02-08
 
 Initial release. A ground-up Rust rewrite of [icloud-photos-downloader](https://github.com/icloud-photos-downloader/icloud_photos_downloader) with full photo/video download capabilities and SQLite state tracking.
 
@@ -67,6 +54,8 @@ Initial release. A ground-up Rust rewrite of [icloud-photos-downloader](https://
 #### Content & Organization
 
 - Photo, video, and live photo MOV downloads with size variants
+- Shared and private library selection (`--library`) with zone discovery (`--list-libraries`)
+- Force exact size variant or skip (`--force-size`)
 - RAW file alignment (`--align-raw`: as-is, original, alternative)
 - Live photo MOV filename policies (`--live-photo-mov-filename-policy`: suffix, original)
 - Independent live photo video size (`--live-photo-size`)
@@ -74,8 +63,9 @@ Initial release. A ground-up Rust rewrite of [icloud-photos-downloader](https://
 - Smart album support (favorites, bursts, time-lapse, slo-mo, videos)
 - Date-based folder structures (`--folder-structure %Y/%m/%d`)
 - EXIF date tag read/write (`--set-exif-datetime`)
-- Filename sanitization (strips invalid characters)
+- Filename sanitization with Unicode control (`--keep-unicode-in-filenames`)
 - Both plain-text and base64-encoded CloudKit filenames supported
+- Fingerprint-based fallback filenames when CloudKit filename is absent
 
 #### Operations
 
@@ -125,13 +115,9 @@ The following Python icloudpd features are not yet available. Links go to tracki
 - [#37](https://github.com/rhoopr/icloudpd-rs/issues/37) — Python LWPCookieJar session import
 
 #### Content & Downloads
-- [#20](https://github.com/rhoopr/icloudpd-rs/issues/20) — Shared library downloads
 - [#19](https://github.com/rhoopr/icloudpd-rs/issues/19) — XMP sidecar export (`--xmp-sidecar`)
 - [#14](https://github.com/rhoopr/icloudpd-rs/issues/14) — Multiple size downloads (`--size` accepting multiple values)
-- [#15](https://github.com/rhoopr/icloudpd-rs/issues/15) — Force size without fallback (`--force-size`)
-- [#25](https://github.com/rhoopr/icloudpd-rs/issues/25) — Keep Unicode in filenames (`--keep-unicode-in-filenames`)
 - [#17](https://github.com/rhoopr/icloudpd-rs/issues/17) — Print filenames only (`--only-print-filenames`)
-- [#35](https://github.com/rhoopr/icloudpd-rs/issues/35) — Fingerprint fallback filenames
 - [#52](https://github.com/rhoopr/icloudpd-rs/issues/52) — HEIC to JPEG conversion (`--convert-heic`)
 
 #### iCloud Lifecycle
@@ -164,3 +150,4 @@ The following Python icloudpd features are not yet available. Links go to tracki
 ---
 
 [0.1.0]: https://github.com/rhoopr/icloudpd-rs/releases/tag/v0.1.0
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "async-trait"
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "icloudpd-rs"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1593,9 +1593,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -2313,9 +2313,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-width"
@@ -2490,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2877,18 +2877,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2957,6 +2957,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icloudpd-rs"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Run `icloudpd-rs --help` for the complete option reference.
 Planned enhancements include:
 
 - XMP sidecar export for metadata preservation
-- Shared library downloads
 - OS keyring integration for secure password storage
 - Docker images and systemd/launchd service files
 - iCloud lifecycle management (delete-after-download)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,8 +105,7 @@ pub struct SyncArgs {
     pub skip_live_photos: bool,
 
     /// Only download requested size (don't fall back to original)
-    /// NOTE: Parsed but not yet wired up - hidden until implemented
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub force_size: bool,
 
     /// Folder structure for organizing downloads
@@ -130,8 +129,7 @@ pub struct SyncArgs {
     pub no_progress_bar: bool,
 
     /// Keep Unicode in filenames
-    /// NOTE: Parsed but not yet wired up - hidden until implemented
-    #[arg(long, hide = true)]
+    #[arg(long)]
     pub keep_unicode_in_filenames: bool,
 
     /// Live photo MOV filename policy


### PR DESCRIPTION
## Summary

- Collapse v0.1.0 + v0.1.1 into a single v0.1.0 release (rewriting history for clean initial release)
- Unhide `--force-size` and `--keep-unicode-in-filenames` CLI flags (both already wired to download pipeline)
- Remove "Shared library downloads" from README roadmap (implemented in #78)
- Update CHANGELOG: add shared library/force-size/keep-unicode/fingerprint-fallback to Added section, remove resolved items from Not Implemented
- Version bump back to 0.1.0 in Cargo.toml + Cargo.lock

Also done outside this PR:
- Closed resolved issues: #26 (warn log level), #39 (failed asset tracking), #27 (ID7 dedup), #25 (keep-unicode), #15 (force-size)
- Wiki: added `--library`, `--force-size`, `--keep-unicode-in-filenames` pages; updated Sidebar/Home

## Test plan

- [x] `cargo fmt -- --check && cargo clippy && cargo test` — 230 tests pass, zero warnings