### PR TITLE
Fix WEBP misclassification, large video truncation, and CAS Op-Lock retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Resume restart logging** — When a server ignores an HTTP Range header and returns 200 instead of 206, the restart is now logged at info level
 - **Password redaction in logs** — Passwords provided via `--password` or `ICLOUD_PASSWORD` are redacted from all tracing output, replacing occurrences with `********`
 - **AM/PM filename matching** — Files with whitespace variants before AM/PM (regular space, narrow no-break space U+202F, or no space) are now recognized as the same file, preventing duplicate downloads of macOS screenshots across locale configurations
+- **WEBP file type recognition** — WEBP images (`org.webmproject.webp`) are now correctly classified as images instead of defaulting to movie, preventing `--skip-videos` from incorrectly excluding WEBP photos ([#90])
+- **Large video download integrity** — Downloads now verify content-length against bytes received before checksum comparison, catching CDN truncation (e.g. Apple silently cutting off videos at ~1 GB) earlier and triggering automatic retry ([#91])
+- **CAS Op-Lock / TRY_AGAIN_LATER retry** — CloudKit server errors (`TRY_AGAIN_LATER`, `CAS_OP_LOCK`, `RETRY_LATER`, `THROTTLED`) embedded in JSON responses are now detected and automatically retried with exponential backoff, preventing silent page loss during photo enumeration ([#94])
+
+[#90]: https://github.com/rhoopr/icloudpd-rs/issues/90
+[#91]: https://github.com/rhoopr/icloudpd-rs/issues/91
+[#94]: https://github.com/rhoopr/icloudpd-rs/issues/94
 
 ---
 

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -230,6 +230,7 @@ const ITEM_TYPE_EXTENSIONS: &[(&str, &str)] = &[
     ("com.olympus.raw-image", "ORF"),
     ("com.canon.cr3-raw-image", "CR3"),
     ("com.olympus.or-raw-image", "ORF"),
+    ("org.webmproject.webp", "WEBP"),
 ];
 
 /// Replace a filename's extension based on the UTI `asset_type` string.
@@ -489,6 +490,14 @@ mod tests {
     }
 
     #[test]
+    fn test_map_filename_extension_webp() {
+        assert_eq!(
+            map_filename_extension("photo.webp", "org.webmproject.webp"),
+            "photo.WEBP"
+        );
+    }
+
+    #[test]
     fn test_map_filename_extension_unknown_type() {
         assert_eq!(
             map_filename_extension("photo.xyz", "com.unknown.type"),
@@ -551,6 +560,7 @@ mod tests {
         assert_eq!(item_type_extension("public.jpeg"), "JPG");
         assert_eq!(item_type_extension("public.heic"), "HEIC");
         assert_eq!(item_type_extension("com.apple.quicktime-movie"), "MOV");
+        assert_eq!(item_type_extension("org.webmproject.webp"), "WEBP");
         assert_eq!(item_type_extension("unknown.type"), "unknown");
     }
 

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -75,6 +75,7 @@ fn resolve_item_type(fields: &Value, filename: &Option<String>) -> Option<AssetI
             || lower.ends_with(".png")
             || lower.ends_with(".jpg")
             || lower.ends_with(".jpeg")
+            || lower.ends_with(".webp")
         {
             return Some(AssetItemType::Image);
         }
@@ -338,6 +339,27 @@ mod tests {
             json!({"fields": {
                 "itemType": {"value": "unknown.type"},
                 "filenameEnc": {"value": "photo.heic", "type": "STRING"}
+            }}),
+            json!({}),
+        );
+        assert_eq!(asset.item_type(), Some(AssetItemType::Image));
+    }
+
+    #[test]
+    fn test_item_type_webp_from_uti() {
+        let asset = make_asset(
+            json!({"fields": {"itemType": {"value": "org.webmproject.webp"}}}),
+            json!({}),
+        );
+        assert_eq!(asset.item_type(), Some(AssetItemType::Image));
+    }
+
+    #[test]
+    fn test_item_type_webp_from_extension_fallback() {
+        let asset = make_asset(
+            json!({"fields": {
+                "itemType": {"value": "unknown.type"},
+                "filenameEnc": {"value": "photo.webp", "type": "STRING"}
             }}),
             json!({}),
         );

--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -136,7 +136,8 @@ pub(crate) fn item_type_from_str(s: &str) -> Option<AssetItemType> {
         | "com.nikon.raw-image"
         | "com.olympus.raw-image"
         | "com.canon.cr3-raw-image"
-        | "com.olympus.or-raw-image" => Some(AssetItemType::Image),
+        | "com.olympus.or-raw-image"
+        | "org.webmproject.webp" => Some(AssetItemType::Image),
         "com.apple.quicktime-movie" => Some(AssetItemType::Movie),
         _ => None,
     }
@@ -196,6 +197,14 @@ mod tests {
         assert_eq!(item_type_from_str("public.png"), Some(AssetItemType::Image));
         assert_eq!(
             item_type_from_str("com.canon.cr2-raw-image"),
+            Some(AssetItemType::Image)
+        );
+    }
+
+    #[test]
+    fn test_item_type_from_str_webp() {
+        assert_eq!(
+            item_type_from_str("org.webmproject.webp"),
             Some(AssetItemType::Image)
         );
     }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -65,9 +65,84 @@ impl PhotosSession for crate::auth::SharedSession {
     }
 }
 
-/// Classify API errors for retry: network failures and server-side errors
-/// (5xx, 429) are transient; client errors (4xx) indicate a real problem.
+/// CloudKit server error codes that indicate a transient condition.
+/// These arrive as HTTP 200 with a `serverErrorCode` field in the JSON body.
+const RETRYABLE_SERVER_ERRORS: &[&str] =
+    &["RETRY_LATER", "TRY_AGAIN_LATER", "CAS_OP_LOCK", "THROTTLED"];
+
+/// Error type for CloudKit server errors embedded in the JSON response body.
+/// These are distinct from HTTP-level errors and represent API-level failures.
+#[derive(Debug, thiserror::Error)]
+#[error("CloudKit server error: {code} — {reason}")]
+pub struct CloudKitServerError {
+    pub code: String,
+    pub reason: String,
+    pub retryable: bool,
+}
+
+/// Check a CloudKit JSON response for `serverErrorCode` or per-record errors.
+/// Returns `Err` if a server error is found, `Ok(response)` otherwise.
+fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
+    // Top-level serverErrorCode (e.g. from CAS Op-Lock)
+    if let Some(code) = response["serverErrorCode"].as_str() {
+        let reason = response["reason"]
+            .as_str()
+            .or_else(|| response["serverErrorMessage"].as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let retryable = RETRYABLE_SERVER_ERRORS
+            .iter()
+            .any(|&s| s.eq_ignore_ascii_case(code));
+        tracing::warn!(
+            error_code = code,
+            retryable,
+            "CloudKit server error: {reason}"
+        );
+        return Err(CloudKitServerError {
+            code: code.to_string(),
+            reason,
+            retryable,
+        }
+        .into());
+    }
+
+    // Per-record errors in the records array
+    if let Some(records) = response["records"].as_array() {
+        for record in records {
+            if let Some(code) = record["serverErrorCode"].as_str() {
+                let reason = record["reason"].as_str().unwrap_or("unknown").to_string();
+                let retryable = RETRYABLE_SERVER_ERRORS
+                    .iter()
+                    .any(|&s| s.eq_ignore_ascii_case(code));
+                tracing::warn!(
+                    error_code = code,
+                    retryable,
+                    "CloudKit per-record error: {reason}"
+                );
+                return Err(CloudKitServerError {
+                    code: code.to_string(),
+                    reason,
+                    retryable,
+                }
+                .into());
+            }
+        }
+    }
+
+    Ok(response)
+}
+
+/// Classify API errors for retry: network failures, server-side errors
+/// (5xx, 429), and retryable CloudKit server errors are transient;
+/// client errors (4xx) and non-retryable server errors are permanent.
 fn classify_api_error(e: &anyhow::Error) -> RetryAction {
+    if let Some(ck_err) = e.downcast_ref::<CloudKitServerError>() {
+        return if ck_err.retryable {
+            RetryAction::Retry
+        } else {
+            RetryAction::Abort
+        };
+    }
     if let Some(reqwest_err) = e.downcast_ref::<reqwest::Error>() {
         if let Some(status) = reqwest_err.status() {
             if status.as_u16() == 429 || status.as_u16() >= 500 {
@@ -81,6 +156,10 @@ fn classify_api_error(e: &anyhow::Error) -> RetryAction {
 }
 
 /// Retry a `session.post()` call with default exponential backoff.
+///
+/// Inspects each response for CloudKit server errors (`serverErrorCode`)
+/// and converts retryable ones (e.g. `TRY_AGAIN_LATER`, `CAS_OP_LOCK`)
+/// into transient errors that trigger automatic retry.
 pub async fn retry_post(
     session: &dyn PhotosSession,
     url: &str,
@@ -88,8 +167,9 @@ pub async fn retry_post(
     headers: &[(&str, &str)],
 ) -> anyhow::Result<Value> {
     let config = RetryConfig::default();
-    retry::retry_with_backoff(&config, classify_api_error, || {
-        session.post(url, body, headers)
+    retry::retry_with_backoff(&config, classify_api_error, || async {
+        let response = session.post(url, body, headers).await?;
+        check_cloudkit_errors(response)
     })
     .await
 }
@@ -129,6 +209,75 @@ mod tests {
 
         // Verify clone_box produces a valid trait object
         let _cloned2 = _cloned.clone_box();
+    }
+
+    #[test]
+    fn test_check_cloudkit_errors_pass_through_normal() {
+        let response = serde_json::json!({"records": [{"recordName": "A"}]});
+        let result = check_cloudkit_errors(response.clone());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), response);
+    }
+
+    #[test]
+    fn test_check_cloudkit_errors_top_level_retryable() {
+        let response = serde_json::json!({
+            "serverErrorCode": "TRY_AGAIN_LATER",
+            "reason": "Sync zone CAS Op-Lock failed"
+        });
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert_eq!(ck_err.code, "TRY_AGAIN_LATER");
+        assert!(ck_err.retryable);
+        assert_eq!(classify_api_error(&err), RetryAction::Retry);
+    }
+
+    #[test]
+    fn test_check_cloudkit_errors_top_level_non_retryable() {
+        let response = serde_json::json!({
+            "serverErrorCode": "ZONE_NOT_FOUND",
+            "reason": "Zone not found"
+        });
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert!(!ck_err.retryable);
+        assert_eq!(classify_api_error(&err), RetryAction::Abort);
+    }
+
+    #[test]
+    fn test_check_cloudkit_errors_per_record() {
+        let response = serde_json::json!({
+            "records": [
+                {"recordName": "A"},
+                {"serverErrorCode": "RETRY_LATER", "reason": "busy"}
+            ]
+        });
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert_eq!(ck_err.code, "RETRY_LATER");
+        assert!(ck_err.retryable);
+    }
+
+    #[test]
+    fn test_check_cloudkit_errors_cas_op_lock() {
+        let response = serde_json::json!({
+            "serverErrorCode": "CAS_OP_LOCK",
+            "reason": "concurrent write rejected"
+        });
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert!(ck_err.retryable);
+    }
+
+    #[test]
+    fn test_check_cloudkit_errors_throttled() {
+        let response = serde_json::json!({
+            "serverErrorCode": "THROTTLED",
+            "reason": "rate limited"
+        });
+        let err = check_cloudkit_errors(response).unwrap_err();
+        let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
+        assert!(ck_err.retryable);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **WEBP file type recognition** — WEBP images (`org.webmproject.webp`) are now correctly classified as `Image` instead of defaulting to `Movie`, preventing `--skip-videos` from incorrectly excluding WEBP photos. Fixes #90
- **Large video download integrity** — Downloads now verify `Content-Length` against bytes received before checksum comparison, catching CDN truncation (e.g. Apple silently cutting off videos at ~1 GB) earlier and triggering automatic retry via the new `ContentLengthMismatch` error variant. Fixes #91
- **CAS Op-Lock / TRY_AGAIN_LATER retry** — CloudKit server errors (`TRY_AGAIN_LATER`, `CAS_OP_LOCK`, `RETRY_LATER`, `THROTTLED`) embedded in JSON responses are now detected and automatically retried with exponential backoff, preventing silent page loss during photo enumeration. Fixes #94

## Changes

| File | What |
|------|------|
| `src/download/paths.rs` | Add `org.webmproject.webp` → `WEBP` to `ITEM_TYPE_EXTENSIONS` |
| `src/icloud/photos/queries.rs` | Add `org.webmproject.webp` to `item_type_from_str()` as `Image` |
| `src/icloud/photos/asset.rs` | Add `.webp` to filename extension fallback in `resolve_item_type()` |
| `src/download/error.rs` | Add `ContentLengthMismatch` variant (retryable) |
| `src/download/file.rs` | Add content-length vs bytes-received guard before checksum verification |
| `src/icloud/photos/session.rs` | Add `CloudKitServerError` type, `check_cloudkit_errors()`, and retryable server error classification |
| `CHANGELOG.md` | Document all three fixes |

## Test plan

- [x] All 253 existing tests pass
- [x] New tests for WEBP extension mapping (`test_map_filename_extension_webp`, `test_item_type_extension` updated)
- [x] New tests for WEBP UTI classification (`test_item_type_from_str_webp`, `test_item_type_webp_from_uti`, `test_item_type_webp_from_extension_fallback`)
- [x] New test for content-length mismatch retryability (`test_content_length_mismatch_retryable`)
- [x] New tests for CloudKit error detection (`test_check_cloudkit_errors_pass_through_normal`, `_top_level_retryable`, `_top_level_non_retryable`, `_per_record`, `_cas_op_lock`, `_throttled`)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy` zero warnings