### PR TITLE
Fix configurable temp suffix and live photo dedup consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WEBP file type recognition** — WEBP images (`org.webmproject.webp`) are now correctly classified as images instead of defaulting to movie, preventing `--skip-videos` from incorrectly excluding WEBP photos ([#90])
 - **Large video download integrity** — Downloads now verify content-length against bytes received before checksum comparison, catching CDN truncation (e.g. Apple silently cutting off videos at ~1 GB) earlier and triggering automatic retry ([#91])
 - **CAS Op-Lock / TRY_AGAIN_LATER retry** — CloudKit server errors (`TRY_AGAIN_LATER`, `CAS_OP_LOCK`, `RETRY_LATER`, `THROTTLED`) embedded in JSON responses are now detected and automatically retried with exponential backoff, preventing silent page loss during photo enumeration ([#94])
+- **Configurable temp file suffix** — Partial downloads now use `.icloudpd-tmp` by default instead of `.part`, avoiding conflicts with Nextcloud/WebDAV sync clients that reject `.part` files. Configurable via `--temp-suffix` ([#92])
+- **Live photo dedup suffix consistency** — When two live photos share the same base filename and size-based deduplication adds a suffix to the HEIC, the MOV companion now derives from the deduped HEIC name, keeping the pair visually matched on disk ([#102])
 
 [#90]: https://github.com/rhoopr/icloudpd-rs/issues/90
 [#91]: https://github.com/rhoopr/icloudpd-rs/issues/91
+[#92]: https://github.com/rhoopr/icloudpd-rs/issues/92
 [#94]: https://github.com/rhoopr/icloudpd-rs/issues/94
+[#102]: https://github.com/rhoopr/icloudpd-rs/issues/102
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,6 +164,11 @@ pub struct SyncArgs {
     /// Initial retry delay in seconds (default: 5)
     #[arg(long, default_value_t = 5)]
     pub retry_delay: u64,
+
+    /// Temp file suffix for partial downloads (default: .icloudpd-tmp).
+    /// Change if the default conflicts with your filesystem (e.g. Nextcloud rejects .part).
+    #[arg(long, default_value = ".icloudpd-tmp")]
+    pub temp_suffix: String,
 }
 
 /// Arguments for the status command.
@@ -334,6 +339,7 @@ pub struct LegacyCli {
     pub only_print_filenames: bool,
     pub max_retries: u32,
     pub retry_delay: u64,
+    pub temp_suffix: String,
 }
 
 impl From<Cli> for LegacyCli {
@@ -374,6 +380,7 @@ impl From<Cli> for LegacyCli {
                     only_print_filenames: sync.only_print_filenames,
                     max_retries: sync.max_retries,
                     retry_delay: sync.retry_delay,
+                    temp_suffix: sync.temp_suffix,
                 }
             }
             // For other commands, provide defaults (they won't use these fields)
@@ -412,6 +419,7 @@ impl From<Cli> for LegacyCli {
                 only_print_filenames: false,
                 max_retries: 3,
                 retry_delay: 5,
+                temp_suffix: ".icloudpd-tmp".to_string(),
             },
             Command::ResetState(args) => Self {
                 username: args.auth.username,
@@ -448,6 +456,7 @@ impl From<Cli> for LegacyCli {
                 only_print_filenames: false,
                 max_retries: 3,
                 retry_delay: 5,
+                temp_suffix: ".icloudpd-tmp".to_string(),
             },
             Command::ImportExisting(args) => Self {
                 username: args.auth.username,
@@ -484,6 +493,7 @@ impl From<Cli> for LegacyCli {
                 only_print_filenames: false,
                 max_retries: 3,
                 retry_delay: 5,
+                temp_suffix: ".icloudpd-tmp".to_string(),
             },
             Command::Verify(args) => Self {
                 username: args.auth.username,
@@ -520,6 +530,7 @@ impl From<Cli> for LegacyCli {
                 only_print_filenames: false,
                 max_retries: 3,
                 retry_delay: 5,
+                temp_suffix: ".icloudpd-tmp".to_string(),
             },
         }
     }
@@ -646,6 +657,22 @@ mod tests {
         let cli = parse(&args);
         let legacy: LegacyCli = cli.into();
         assert_eq!(legacy.retry_delay, 15);
+    }
+
+    #[test]
+    fn test_temp_suffix_default() {
+        let cli = parse(&base_args());
+        let legacy: LegacyCli = cli.into();
+        assert_eq!(legacy.temp_suffix, ".icloudpd-tmp");
+    }
+
+    #[test]
+    fn test_temp_suffix_custom() {
+        let mut args = base_args();
+        args.extend(["--temp-suffix", ".downloading"]);
+        let cli = parse(&args);
+        let legacy: LegacyCli = cli.into();
+        assert_eq!(legacy.temp_suffix, ".downloading");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub folder_structure: String,
     pub albums: Vec<String>,
     pub library: String,
+    pub temp_suffix: String,
 
     // DateTime fields
     pub skip_created_before: Option<DateTime<Local>>,
@@ -140,6 +141,7 @@ impl Config {
             only_print_filenames: cli.only_print_filenames,
             max_retries: cli.max_retries,
             retry_delay_secs: cli.retry_delay,
+            temp_suffix: cli.temp_suffix,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -779,6 +779,7 @@ async fn main() -> anyhow::Result<()> {
         file_match_policy: config.file_match_policy,
         force_size: config.force_size,
         keep_unicode_in_filenames: config.keep_unicode_in_filenames,
+        temp_suffix: config.temp_suffix.clone(),
         state_db,
     };
 


### PR DESCRIPTION
## Summary

- **`--temp-suffix` CLI flag** (default `.icloudpd-tmp`): Partial downloads now use a configurable suffix instead of hardcoded `.part`, avoiding conflicts with Nextcloud/WebDAV sync clients that reject `.part` files. Threaded through CLI → Config → DownloadConfig → PassConfig → download pipeline.
- **Live photo dedup suffix consistency**: When size-based deduplication adds a suffix to a HEIC filename (e.g. `IMG_0001-4000.HEIC`), the MOV companion now derives from the deduped name (`IMG_0001-4000_HEVC.MOV`) instead of the original base name, keeping them visually paired on disk.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] All 258 tests pass (including new tests for both fixes)
- [ ] Manual test: verify `--temp-suffix .custom` creates temp files with that suffix
- [ ] Manual test: download two live photos with same base filename, verify MOV derives from deduped HEIC name

Fixes #92
Fixes #102