### PR TITLE
Detect ADP and surface actionable error for iCloud service not activated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CAS Op-Lock / TRY_AGAIN_LATER retry** — CloudKit server errors (`TRY_AGAIN_LATER`, `CAS_OP_LOCK`, `RETRY_LATER`, `THROTTLED`) embedded in JSON responses are now detected and automatically retried with exponential backoff, preventing silent page loss during photo enumeration ([#94])
 - **Configurable temp file suffix** — Partial downloads now use `.icloudpd-tmp` by default instead of `.part`, avoiding conflicts with Nextcloud/WebDAV sync clients that reject `.part` files. Configurable via `--temp-suffix` ([#92])
 - **Live photo dedup suffix consistency** — When two live photos share the same base filename and size-based deduplication adds a suffix to the HEIC, the MOV companion now derives from the deduped HEIC name, keeping the pair visually matched on disk ([#102])
+- **ADP detection and error handling** — Users with Advanced Data Protection (ADP) enabled now receive a clear, actionable error message explaining the incompatibility and how to resolve it, instead of a generic API failure. Detects `ZONE_NOT_FOUND`, `AUTHENTICATION_FAILED`, `ACCESS_DENIED`, and "private db access disabled" responses from CloudKit ([#99])
 
 [#90]: https://github.com/rhoopr/icloudpd-rs/issues/90
 [#91]: https://github.com/rhoopr/icloudpd-rs/issues/91
 [#92]: https://github.com/rhoopr/icloudpd-rs/issues/92
 [#94]: https://github.com/rhoopr/icloudpd-rs/issues/94
+[#99]: https://github.com/rhoopr/icloudpd-rs/issues/99
 [#102]: https://github.com/rhoopr/icloudpd-rs/issues/102
 
 ---

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -6,6 +6,16 @@ pub enum ICloudError {
     Connection(String),
     #[error("Photo library not finished indexing")]
     IndexingNotFinished,
+    #[error(
+        "iCloud service not activated ({code}): {reason}\n\n\
+         This usually means one of:\n  \
+         1. Advanced Data Protection (ADP) is enabled, which blocks third-party iCloud access.\n     \
+            → Disable ADP in Settings > Apple Account > iCloud > Advanced Data Protection,\n     \
+            or enable \"Access iCloud Data on the Web\" (Settings > Apple Account > iCloud).\n  \
+         2. iCloud setup is incomplete.\n     \
+            → Log into https://icloud.com/ and finish setting up your iCloud service."
+    )]
+    ServiceNotActivated { code: String, reason: String },
     #[error(transparent)]
     Http(#[from] reqwest::Error),
     #[error(transparent)]


### PR DESCRIPTION
## Summary

- Detect CloudKit error codes that indicate Advanced Data Protection (ADP) is enabled or iCloud setup is incomplete: `ZONE_NOT_FOUND`, `AUTHENTICATION_FAILED`, `ACCESS_DENIED`, and the `private db access disabled` reason text
- Add `ICloudError::ServiceNotActivated` variant with a clear, actionable error message explaining how to resolve (disable ADP or enable 'Access iCloud Data on the Web')
- Add `service_not_activated` flag to `CloudKitServerError` so the library initialization can distinguish ADP errors from generic connection failures
- Convert matching errors in `PhotoLibrary::new()` to the new typed error instead of generic `ICloudError::Connection`

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] All 262 tests pass (4 new ADP detection tests)
- [ ] Manual test with ADP-enabled account to verify the error message surfaces correctly

Fixes #99