### PR TITLE
Fix retry-failed downloading entire library instead of only failed assets

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -151,6 +151,9 @@ pub struct DownloadConfig {
     pub(crate) temp_suffix: String,
     /// State database for tracking download progress.
     pub(crate) state_db: Option<Arc<dyn StateDb>>,
+    /// When true (retry-failed mode), only download assets already known to the
+    /// state DB. Skip new assets discovered from iCloud that were never synced.
+    pub(crate) retry_only: bool,
 }
 
 impl std::fmt::Debug for DownloadConfig {
@@ -181,6 +184,7 @@ impl std::fmt::Debug for DownloadConfig {
             .field("keep_unicode_in_filenames", &self.keep_unicode_in_filenames)
             .field("temp_suffix", &self.temp_suffix)
             .field("state_db", &self.state_db.is_some())
+            .field("retry_only", &self.retry_only)
             .finish()
     }
 }
@@ -226,11 +230,14 @@ struct DownloadContext {
     /// Nested map: asset_id -> (version_size -> checksum) for downloaded assets.
     /// Used to detect checksum changes (iCloud asset updated) without DB queries.
     downloaded_checksums: FxHashMap<Box<str>, FxHashMap<Box<str>, Box<str>>>,
+    /// All asset IDs known to the state DB (any status). Used in retry-only mode
+    /// to skip new assets that were never synced.
+    known_ids: FxHashSet<Box<str>>,
 }
 
 impl DownloadContext {
     /// Load the download context from the state database.
-    async fn load(db: &dyn StateDb) -> Self {
+    async fn load(db: &dyn StateDb, retry_only: bool) -> Self {
         // Build nested map structure for zero-allocation lookups
         let mut downloaded_ids: FxHashMap<Box<str>, FxHashSet<Box<str>>> = FxHashMap::default();
         for (asset_id, version_size) in db.get_downloaded_ids().await.unwrap_or_default() {
@@ -251,9 +258,23 @@ impl DownloadContext {
                 .insert(version_size.into_boxed_str(), checksum.into_boxed_str());
         }
 
+        // In retry-only mode, load all known asset IDs so we can skip new
+        // assets that were never synced before.
+        let known_ids = if retry_only {
+            db.get_all_known_ids()
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(String::into_boxed_str)
+                .collect()
+        } else {
+            FxHashSet::default()
+        };
+
         Self {
             downloaded_ids,
             downloaded_checksums,
+            known_ids,
         }
     }
 
@@ -828,7 +849,7 @@ async fn stream_and_download(
     // Pre-load download context for O(1) skip decisions
     let download_ctx = if let Some(db) = &state_db {
         tracing::debug!("Pre-loading download state from database");
-        DownloadContext::load(db.as_ref()).await
+        DownloadContext::load(db.as_ref(), config.retry_only).await
     } else {
         DownloadContext::default()
     };
@@ -889,6 +910,14 @@ async fn stream_and_download(
                         producer_pb.inc(1);
                     } else {
                         for task in tasks {
+                            // In retry-only mode, skip assets not already in the state DB
+                            if config.retry_only
+                                && !download_ctx.known_ids.contains(task.asset_id.as_ref())
+                            {
+                                producer_pb.inc(1);
+                                continue;
+                            }
+
                             // Record asset in state DB
                             if let Some(db) = &producer_state_db {
                                 let media_type = determine_media_type(task.version_size, &asset);
@@ -1643,6 +1672,7 @@ mod tests {
             keep_unicode_in_filenames: false,
             temp_suffix: ".icloudpd-tmp".to_string(),
             state_db: None,
+            retry_only: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -808,9 +808,11 @@ async fn main() -> anyhow::Result<()> {
                         Ok(count) if count > 0 => {
                             tracing::info!(count, "Reset failed assets to pending");
                         }
-                        Ok(_) => {
+                        Ok(0) => {
                             tracing::info!("No failed assets to retry");
+                            return Ok(());
                         }
+                        Ok(_) => unreachable!(),
                         Err(e) => {
                             tracing::warn!("Failed to reset failed assets: {}", e);
                         }
@@ -861,6 +863,7 @@ async fn main() -> anyhow::Result<()> {
         keep_unicode_in_filenames: config.keep_unicode_in_filenames,
         temp_suffix: config.temp_suffix.clone(),
         state_db,
+        retry_only: is_retry_failed,
     });
 
     let shutdown_token = shutdown::install_signal_handler(&sd_notifier)?;

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -92,6 +92,12 @@ pub trait StateDb: Send + Sync {
     /// Used at sync start to pre-load downloaded state for O(1) skip decisions.
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError>;
 
+    /// Get all known asset IDs (any status: downloaded, pending, failed).
+    ///
+    /// Used in retry-only mode to distinguish assets that were previously
+    /// synced from new assets discovered on iCloud.
+    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError>;
+
     /// Get downloaded asset IDs with their checksums.
     ///
     /// Returns a map of (id, version_size) -> checksum for downloaded assets.
@@ -519,6 +525,25 @@ impl StateDb for SqliteStateDb {
             .query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
+            .map_err(StateError::query)?
+            .collect::<Result<HashSet<_>, _>>()
+            .map_err(StateError::query)?;
+
+        Ok(ids)
+    }
+
+    async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| StateError::Query(e.to_string()))?;
+
+        let mut stmt = conn
+            .prepare_cached("SELECT DISTINCT id FROM assets")
+            .map_err(StateError::query)?;
+
+        let ids = stmt
+            .query_map([], |row| row.get::<_, String>(0))
             .map_err(StateError::query)?
             .collect::<Result<HashSet<_>, _>>()
             .map_err(StateError::query)?;
@@ -1133,6 +1158,154 @@ mod tests {
             checksums.get(&("DL_1".to_string(), "original".to_string())),
             Some(&"checksum_1".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_all_known_ids() {
+        let dir = test_dir("get_all_known_ids");
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // Create downloaded assets
+        for i in 0..2 {
+            let record = AssetRecord::new_pending(
+                format!("DL_{}", i),
+                VersionSizeKey::Original,
+                format!("checksum_{}", i),
+                format!("photo_{}.jpg", i),
+                Utc::now(),
+                None,
+                1000,
+                MediaType::Photo,
+            );
+            db.upsert_seen(&record).await.unwrap();
+            let path = dir.join(format!("photo_{}.jpg", i));
+            fs::write(&path, b"content").unwrap();
+            db.mark_downloaded(&format!("DL_{}", i), "original", &path)
+                .await
+                .unwrap();
+        }
+
+        // Create a pending asset
+        let pending = AssetRecord::new_pending(
+            "PENDING_1".to_string(),
+            VersionSizeKey::Original,
+            "pending_ck".to_string(),
+            "pending.jpg".to_string(),
+            Utc::now(),
+            None,
+            1000,
+            MediaType::Photo,
+        );
+        db.upsert_seen(&pending).await.unwrap();
+
+        // Create a failed asset
+        let failed = AssetRecord::new_pending(
+            "FAILED_1".to_string(),
+            VersionSizeKey::Original,
+            "failed_ck".to_string(),
+            "failed.jpg".to_string(),
+            Utc::now(),
+            None,
+            1000,
+            MediaType::Photo,
+        );
+        db.upsert_seen(&failed).await.unwrap();
+        db.mark_failed("FAILED_1", "original", "test error")
+            .await
+            .unwrap();
+
+        let known_ids = db.get_all_known_ids().await.unwrap();
+        // Should include all 4 assets regardless of status
+        assert_eq!(known_ids.len(), 4);
+        assert!(known_ids.contains("DL_0"));
+        assert!(known_ids.contains("DL_1"));
+        assert!(known_ids.contains("PENDING_1"));
+        assert!(known_ids.contains("FAILED_1"));
+
+        // get_downloaded_ids should only return 2
+        let downloaded_ids = db.get_downloaded_ids().await.unwrap();
+        assert_eq!(downloaded_ids.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_retry_failed_returns_zero_when_no_failures() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // With no assets at all, reset_failed returns 0
+        let count = db.reset_failed().await.unwrap();
+        assert_eq!(count, 0);
+
+        // Add a downloaded asset — still no failures
+        let record = AssetRecord::new_pending(
+            "DL_1".to_string(),
+            VersionSizeKey::Original,
+            "ck".to_string(),
+            "photo.jpg".to_string(),
+            Utc::now(),
+            None,
+            1000,
+            MediaType::Photo,
+        );
+        db.upsert_seen(&record).await.unwrap();
+        let dir = test_dir("retry_no_failures");
+        let path = dir.join("photo.jpg");
+        fs::write(&path, b"content").unwrap();
+        db.mark_downloaded("DL_1", "original", &path).await.unwrap();
+
+        let count = db.reset_failed().await.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_retry_failed_resets_only_failed() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let dir = test_dir("retry_resets_failed");
+
+        // Add a downloaded asset
+        let dl = AssetRecord::new_pending(
+            "DL_1".to_string(),
+            VersionSizeKey::Original,
+            "ck1".to_string(),
+            "photo1.jpg".to_string(),
+            Utc::now(),
+            None,
+            1000,
+            MediaType::Photo,
+        );
+        db.upsert_seen(&dl).await.unwrap();
+        let path = dir.join("photo1.jpg");
+        fs::write(&path, b"content").unwrap();
+        db.mark_downloaded("DL_1", "original", &path).await.unwrap();
+
+        // Add a failed asset
+        let failed = AssetRecord::new_pending(
+            "FAIL_1".to_string(),
+            VersionSizeKey::Original,
+            "ck2".to_string(),
+            "photo2.jpg".to_string(),
+            Utc::now(),
+            None,
+            1000,
+            MediaType::Photo,
+        );
+        db.upsert_seen(&failed).await.unwrap();
+        db.mark_failed("FAIL_1", "original", "download error")
+            .await
+            .unwrap();
+
+        // reset_failed should reset exactly 1
+        let count = db.reset_failed().await.unwrap();
+        assert_eq!(count, 1);
+
+        // After reset, the failed asset should be in known_ids but not downloaded_ids
+        let known = db.get_all_known_ids().await.unwrap();
+        assert_eq!(known.len(), 2);
+        assert!(known.contains("DL_1"));
+        assert!(known.contains("FAIL_1"));
+
+        let downloaded = db.get_downloaded_ids().await.unwrap();
+        assert_eq!(downloaded.len(), 1);
+        assert!(downloaded.contains(&("DL_1".to_string(), "original".to_string())));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **BUG-1 (Critical)**: `retry-failed` was downloading the entire iCloud library instead of only retrying failed assets. When no assets were marked as failed, it correctly logged "No failed assets to retry" but then proceeded to enumerate all photos and download everything not already in the state DB.
- Root cause: the download pipeline had no concept of "only process assets already known to the DB". Assets not in the DB (i.e., never attempted) were treated as needing download.
- Fix: Added `retry_only` mode to `DownloadConfig` that loads known asset IDs from the DB and skips any asset not already tracked. Also added early exit when `reset_failed()` returns 0.

## Changes

- `src/state/db.rs`: Added `get_all_known_ids()` to `StateDb` trait + implementation
- `src/download/mod.rs`: Added `retry_only` flag and `known_ids` set to `DownloadContext`; skips unknown assets in producer task
- `src/main.rs`: Early exit when no failed assets; passes `retry_only: true` for retry-failed command

## Test plan

- [x] `cargo fmt -- --check && cargo clippy` — zero warnings
- [x] `cargo test` — 440 tests pass
- [x] New unit tests: `test_get_all_known_ids`, `test_retry_failed_returns_zero_when_no_failures`, `test_retry_failed_resets_only_failed`
- [ ] Authenticated test: run `sync --recent 5`, then `retry-failed` with 0 failures — should exit immediately without downloading