### PR TITLE
Add SHA-1 checksum support for Apple's 21-byte format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "smallvec",
  "thiserror 2.0.18",
@@ -1966,6 +1967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 toml = "0.8"
 
 # Crypto (SRP auth)
+sha1 = "0.10"
 sha2 = "0.10"
 pbkdf2 = { version = "0.12", features = ["simple"] }
 hmac = "0.12"

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use base64::Engine;
 use futures_util::StreamExt;
 use reqwest::Client;
+use sha1::Sha1;
 use sha2::{Digest, Sha256};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
@@ -68,9 +69,10 @@ pub async fn download_file(
     result
 }
 
-/// Rebuild SHA256 hash state by re-reading an existing .part file.
-/// Returns the hasher and byte count, or None if the file doesn't exist or is empty.
-async fn resume_hash_state(part_path: &Path) -> Option<(Sha256, u64)> {
+/// Rebuild hash state by re-reading an existing .part file.
+/// Returns both SHA-256 and SHA-1 hashers and byte count, or None if the
+/// file doesn't exist or is empty.
+async fn resume_hash_state(part_path: &Path) -> Option<(Sha256, Sha1, u64)> {
     let meta = fs::metadata(part_path).await.ok()?;
     let existing_len = meta.len();
     if existing_len == 0 {
@@ -79,7 +81,8 @@ async fn resume_hash_state(part_path: &Path) -> Option<(Sha256, u64)> {
 
     let file = fs::File::open(part_path).await.ok()?;
     let mut reader = tokio::io::BufReader::new(file);
-    let mut hasher = Sha256::new();
+    let mut sha256 = Sha256::new();
+    let mut sha1 = Sha1::new();
     let mut buf = [0u8; 262_144]; // 256 KiB for faster resume hashing
     loop {
         let n = tokio::io::AsyncReadExt::read(&mut reader, &mut buf)
@@ -88,9 +91,10 @@ async fn resume_hash_state(part_path: &Path) -> Option<(Sha256, u64)> {
         if n == 0 {
             break;
         }
-        hasher.update(&buf[..n]);
+        sha256.update(&buf[..n]);
+        sha1.update(&buf[..n]);
     }
-    Some((hasher, existing_len))
+    Some((sha256, sha1, existing_len))
 }
 
 /// Single download attempt with checksum verification and resume support.
@@ -108,7 +112,7 @@ async fn attempt_download(
     let path_str = download_path.display().to_string();
 
     let resume_state = resume_hash_state(part_path).await;
-    let resume_offset = resume_state.as_ref().map(|(_, len)| *len).unwrap_or(0);
+    let resume_offset = resume_state.as_ref().map(|(_, _, len)| *len).unwrap_or(0);
 
     let mut request = client.get(url);
     if resume_offset > 0 {
@@ -134,12 +138,12 @@ async fn attempt_download(
     // `effective_offset` tracks the actual byte offset used for the content-length
     // check. When the server ignores Range and returns 200, we restart from zero
     // so effective_offset must be 0 (not the stale resume_offset).
-    let (mut hasher, mut bytes_written, truncate, effective_offset) = match (
+    let (mut sha256, mut sha1_hasher, mut bytes_written, truncate, effective_offset) = match (
         status,
         resume_offset,
         resume_state,
     ) {
-        (206, offset, Some((h, len))) if offset > 0 => (h, len, false, offset),
+        (206, offset, Some((h256, h1, len))) if offset > 0 => (h256, h1, len, false, offset),
         (_, _, _) if response.status().is_success() => {
             if resume_offset > 0 {
                 tracing::info!(
@@ -148,7 +152,7 @@ async fn attempt_download(
                         path_str,
                     );
             }
-            (Sha256::new(), 0u64, true, 0u64)
+            (Sha256::new(), Sha1::new(), 0u64, true, 0u64)
         }
         _ => {
             return Err(DownloadError::HttpStatus {
@@ -180,7 +184,8 @@ async fn attempt_download(
             content_length,
             bytes_written,
         })?;
-        hasher.update(&chunk);
+        sha256.update(&chunk);
+        sha1_hasher.update(&chunk);
         file.write_all(&chunk).await?;
         bytes_written += chunk.len() as u64;
     }
@@ -204,22 +209,25 @@ async fn attempt_download(
     }
 
     if let Ok(expected_hash) = base64::engine::general_purpose::STANDARD.decode(checksum) {
-        let actual_hash = hasher.finalize();
-
-        // Apple uses two checksum formats: raw 32-byte SHA-256, or 33-byte
-        // with a 1-byte type prefix (0x01 = SHA-256). Handle both.
-        let matches = if expected_hash.len() == 32 {
-            actual_hash.as_slice() == expected_hash.as_slice()
-        } else if expected_hash.len() == 33 {
-            actual_hash.as_slice() == &expected_hash[1..]
-        } else {
-            tracing::warn!(
-                len = expected_hash.len(),
-                path = %download_path.display(),
-                "Unknown checksum format ({} bytes), skipping verification",
-                expected_hash.len()
-            );
-            true
+        // Apple uses several checksum formats:
+        //   - 32 bytes: raw SHA-256
+        //   - 33 bytes: 0x01 prefix + SHA-256
+        //   - 20 bytes: raw SHA-1
+        //   - 21 bytes: 0x01 prefix + SHA-1
+        let matches = match expected_hash.len() {
+            32 => sha256.finalize().as_slice() == expected_hash.as_slice(),
+            33 => sha256.finalize().as_slice() == &expected_hash[1..],
+            20 => sha1_hasher.finalize().as_slice() == expected_hash.as_slice(),
+            21 => sha1_hasher.finalize().as_slice() == &expected_hash[1..],
+            _ => {
+                tracing::warn!(
+                    len = expected_hash.len(),
+                    path = %download_path.display(),
+                    "Unknown checksum format ({} bytes), skipping verification",
+                    expected_hash.len()
+                );
+                true
+            }
         };
 
         if !matches {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ mod types;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use anyhow::Context;
+use base64::Engine;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
@@ -320,32 +322,51 @@ async fn run_verify(args: cli::VerifyArgs, toml: &Option<TomlConfig>) -> anyhow:
     Ok(())
 }
 
-/// Verify a file's SHA256 checksum.
+/// Verify a file's checksum against Apple's expected value.
+///
+/// Apple uses several checksum formats (after base64-decoding):
+///   - 32 bytes: raw SHA-256
+///   - 33 bytes: 0x01 prefix + SHA-256
+///   - 20 bytes: raw SHA-1
+///   - 21 bytes: 0x01 prefix + SHA-1
 async fn verify_checksum(path: &Path, expected: &str) -> anyhow::Result<bool> {
+    use sha1::Sha1;
     use sha2::{Digest, Sha256};
 
     let path = path.to_path_buf();
     let expected = expected.to_string();
 
     tokio::task::spawn_blocking(move || {
-        let mut file = std::fs::File::open(&path)?;
-        let mut hasher = Sha256::new();
-        std::io::copy(&mut file, &mut hasher)?;
-        let hash = hasher.finalize();
-        use std::fmt::Write;
-        let computed = hash.iter().fold(String::with_capacity(64), |mut s, b| {
-            let _ = write!(s, "{b:02x}");
-            s
-        });
+        let expected_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&expected)
+            .context("Failed to decode base64 checksum")?;
 
-        // Apple sometimes uses a 33-byte format with a leading byte
-        let expected_normalized = if expected.len() == 66 && expected.starts_with("01") {
-            &expected[2..]
-        } else {
-            &expected
+        // Determine which hash algorithm to use based on checksum length
+        let (use_sha1, expected_hash) = match expected_bytes.len() {
+            32 => (false, &expected_bytes[..]),
+            33 => (false, &expected_bytes[1..]),
+            20 => (true, &expected_bytes[..]),
+            21 => (true, &expected_bytes[1..]),
+            len => {
+                tracing::warn!(
+                    len,
+                    path = %path.display(),
+                    "Unknown checksum format ({len} bytes), skipping verification",
+                );
+                return Ok(true);
+            }
         };
 
-        Ok(computed.eq_ignore_ascii_case(expected_normalized))
+        let mut file = std::fs::File::open(&path)?;
+        if use_sha1 {
+            let mut hasher = Sha1::new();
+            std::io::copy(&mut file, &mut hasher)?;
+            Ok(hasher.finalize().as_slice() == expected_hash)
+        } else {
+            let mut hasher = Sha256::new();
+            std::io::copy(&mut file, &mut hasher)?;
+            Ok(hasher.finalize().as_slice() == expected_hash)
+        }
     })
     .await?
 }
@@ -1039,5 +1060,97 @@ mod tests {
     fn pid_file_guard_handles_missing_parent() {
         let path = std::env::temp_dir().join("nonexistent_dir_abc123/test.pid");
         assert!(PidFileGuard::new(path).is_err());
+    }
+
+    #[tokio::test]
+    async fn verify_checksum_sha256_raw_32_bytes() {
+        use sha2::Digest;
+
+        let dir = PathBuf::from("/tmp/claude/checksum_tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("sha256_raw.bin");
+        let content = b"hello world";
+        std::fs::write(&file_path, content).unwrap();
+
+        let hash = sha2::Sha256::digest(content);
+        // Raw 32-byte SHA-256, base64-encoded
+        let checksum = base64::engine::general_purpose::STANDARD.encode(hash.as_slice());
+        assert!(verify_checksum(&file_path, &checksum).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn verify_checksum_sha256_prefixed_33_bytes() {
+        use sha2::Digest;
+
+        let dir = PathBuf::from("/tmp/claude/checksum_tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("sha256_prefixed.bin");
+        let content = b"hello world";
+        std::fs::write(&file_path, content).unwrap();
+
+        let hash = sha2::Sha256::digest(content);
+        // 0x01 prefix + 32-byte SHA-256
+        let mut prefixed = vec![0x01];
+        prefixed.extend_from_slice(hash.as_slice());
+        let checksum = base64::engine::general_purpose::STANDARD.encode(&prefixed);
+        assert!(verify_checksum(&file_path, &checksum).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn verify_checksum_sha1_raw_20_bytes() {
+        use sha1::Digest;
+
+        let dir = PathBuf::from("/tmp/claude/checksum_tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("sha1_raw.bin");
+        let content = b"hello world";
+        std::fs::write(&file_path, content).unwrap();
+
+        let hash = sha1::Sha1::digest(content);
+        // Raw 20-byte SHA-1, base64-encoded
+        let checksum = base64::engine::general_purpose::STANDARD.encode(hash.as_slice());
+        assert!(verify_checksum(&file_path, &checksum).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn verify_checksum_sha1_prefixed_21_bytes() {
+        use sha1::Digest;
+
+        let dir = PathBuf::from("/tmp/claude/checksum_tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("sha1_prefixed.bin");
+        let content = b"hello world";
+        std::fs::write(&file_path, content).unwrap();
+
+        let hash = sha1::Sha1::digest(content);
+        // 0x01 prefix + 20-byte SHA-1 (Apple's actual format)
+        let mut prefixed = vec![0x01];
+        prefixed.extend_from_slice(hash.as_slice());
+        let checksum = base64::engine::general_purpose::STANDARD.encode(&prefixed);
+        assert!(verify_checksum(&file_path, &checksum).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn verify_checksum_mismatch_returns_false() {
+        let dir = PathBuf::from("/tmp/claude/checksum_tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("mismatch.bin");
+        std::fs::write(&file_path, b"hello world").unwrap();
+
+        // Wrong SHA-256 (all zeros)
+        let wrong = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
+        assert!(!verify_checksum(&file_path, &wrong).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn verify_checksum_unknown_length_skips() {
+        let dir = PathBuf::from("/tmp/claude/checksum_tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("unknown_len.bin");
+        std::fs::write(&file_path, b"hello world").unwrap();
+
+        // 10-byte unknown format — should return true (skip verification)
+        let unknown = base64::engine::general_purpose::STANDARD.encode([0u8; 10]);
+        assert!(verify_checksum(&file_path, &unknown).await.unwrap());
     }
 }


### PR DESCRIPTION
## Summary

- **BUG-2 (Critical)**: Apple returns 21-byte checksums (0x01 prefix + 20-byte SHA-1) for most assets, but only SHA-256 (32/33-byte) was handled. All other lengths were silently skipped with a warning, meaning no downloads were integrity-verified and `verify --checksums` reported every file as corrupted.
- Fix: Dual-hash downloads with both SHA-256 and SHA-1 during streaming. The correct algorithm is selected at verification time based on the decoded checksum length. The `verify_checksum()` function now decodes base64 first and dispatches by byte length.

## Changes

- `Cargo.toml`: Added `sha1 = "0.10"` dependency
- `src/download/file.rs`: Dual-hash streaming with SHA-256 + SHA-1; resume state also tracks both hashers; verification handles 20/21-byte SHA-1 formats
- `src/main.rs`: `verify_checksum()` rewritten to decode base64 checksum first, then select SHA-1 or SHA-256 based on length

## Test plan

- [x] `cargo fmt -- --check && cargo clippy` — zero warnings
- [x] `cargo test` — 443 tests pass
- [x] New unit tests: `verify_checksum_sha256_raw_32_bytes`, `verify_checksum_sha256_prefixed_33_bytes`, `verify_checksum_sha1_raw_20_bytes`, `verify_checksum_sha1_prefixed_21_bytes`, `verify_checksum_mismatch_returns_false`, `verify_checksum_unknown_length_skips`
- [ ] Authenticated test: download files and confirm no "Unknown checksum format" warnings; `verify --checksums` should report files as OK