### PR TITLE
Improve lock error message for Docker users

### DIFF
--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -124,7 +124,9 @@ impl Session {
                     .with_context(|| format!("Failed to acquire lock: {}", lock_path.display()))?;
                 if !acquired {
                     anyhow::bail!(
-                        "Another icloudpd-rs instance is running for this account (lock: {})",
+                        "Another icloudpd-rs instance is running for this account (lock: {}). \
+                         If running in Docker, check for orphaned containers with \
+                         `docker ps` and stop them with `docker stop <name>`.",
                         lock_path.display()
                     );
                 }


### PR DESCRIPTION
## Summary

- The lock contention error message now suggests checking for orphaned Docker containers with `docker ps` and stopping them with `docker stop`.
- Investigation confirmed the lock mechanism already uses OS-level `flock(2)` via the `fs4` crate, which auto-releases on process exit. The "stale lock" issue reported during testing was caused by an orphaned container still holding the flock.

## Test plan

- [x] `cargo fmt -- --check && cargo clippy` — zero warnings
- [x] `cargo test` — 437 tests pass