### PR TITLE
Downgrade IndexingNotFinished from hard error to warning

### DIFF
--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -4,8 +4,6 @@ use thiserror::Error;
 pub enum ICloudError {
     #[error("Connection error: {0}")]
     Connection(String),
-    #[error("Photo library not finished indexing")]
-    IndexingNotFinished,
     #[error(
         "iCloud service not activated ({code}): {reason}\n\n\
          This usually means one of:\n  \
@@ -55,16 +53,6 @@ mod tests {
         assert!(
             display.contains("timeout reached"),
             "expected display to contain the message, got: {display}"
-        );
-    }
-
-    #[test]
-    fn indexing_not_finished_display_contains_indexing() {
-        let err = ICloudError::IndexingNotFinished;
-        let display = err.to_string();
-        assert!(
-            display.to_lowercase().contains("indexing"),
-            "expected display to mention indexing, got: {display}"
         );
     }
 

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use base64::Engine;
 use serde_json::{json, Value};
+use tracing::warn;
 
 use super::album::{PhotoAlbum, PhotoAlbumConfig};
 use super::queries::encode_params;
@@ -54,7 +55,7 @@ impl std::fmt::Debug for PhotoLibrary {
 }
 
 impl PhotoLibrary {
-    /// Create a new `PhotoLibrary`, verifying that indexing has finished.
+    /// Create a new `PhotoLibrary`, warning if indexing has not finished.
     pub async fn new(
         service_endpoint: String,
         params: Arc<HashMap<String, Value>>,
@@ -99,7 +100,11 @@ impl PhotoLibrary {
             .and_then(|r| r.fields["state"]["value"].as_str())
             .unwrap_or("");
         if indexing_state != "FINISHED" {
-            return Err(ICloudError::IndexingNotFinished);
+            warn!(
+                state = indexing_state,
+                "Photo library indexing state is not FINISHED — proceeding anyway, \
+                 results may be incomplete"
+            );
         }
 
         Ok(Self {


### PR DESCRIPTION
## Summary
- Demotes the `CheckIndexingState` gate from a fatal `ICloudError::IndexingNotFinished` to a `tracing::warn`, so users are informed but not blocked
- Removes the now-unused `IndexingNotFinished` error variant and its test

## Context
Per #144, the `CheckIndexingState` query returns non-`FINISHED` for sessions that are only seconds old (see [ostash's report](https://github.com/rhoopr/icloudpd-rs/issues/144#issuecomment-2769780099)), blocking all photo operations even though the iCloud API serves photos normally. The Python icloudpd has the same check but ostash reports it works — suggesting the state field is unreliable as a hard gate.

## Test plan
- [x] `cargo fmt --check && cargo clippy` — zero warnings
- [x] All 684 unit tests pass
- [ ] Manual test: run with a session that previously returned "not finished indexing" and confirm it now proceeds with a warning