### PR TITLE
Add filter flags, live photo mode, and full strftime folder structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.7.0] - 2026-04-11
 
 ### Added
 
@@ -17,12 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`KEI_*` environment variables** - Every CLI flag has an env var (`KEI_DIRECTORY`, `KEI_DATA_DIR`, `KEI_SIZE`, etc.). Useful for Docker. ([#118])
 - **`--data-dir`** - Global flag replacing `--cookie-directory` for session/state/credential storage.
 - **`sync --retry-failed`** - Flag on sync replacing the `retry-failed` subcommand.
+- **`--live-photo-mode`** - Control live photo handling: `both` (default), `image-only`, `video-only`, `skip`. Replaces `--skip-live-photos`.
+- **`--exclude-album`** - Exclude specific albums from sync. Multi-value, comma-separated. [env: `KEI_EXCLUDE_ALBUM`]
+- **`--filename-exclude`** - Exclude files matching glob patterns (e.g., `*.AAE`, `Screenshot*`). Case-insensitive, multi-value. [env: `KEI_FILENAME_EXCLUDE`]
+- **`{album}` token in `--folder-structure`** - Organize downloads by album name (e.g., `{album}/%Y/%m`).
+- **Full strftime support in `--folder-structure`** - All standard strftime specifiers now work (`%B`, `%A`, `%j`, etc.), not just the six previously supported.
+- **Auto-config on first run** - When no config file exists, kei creates a minimal `~/.config/kei/config.toml` from CLI arguments. Opt out with `KEI_NO_AUTO_CONFIG=1`.
 
 ### Changed
 
 - **`--username`, `--domain` are now global** - Accepted on all subcommands, not just sync.
 - **Docker CMD** - Uses `--data-dir` instead of `--cookie-directory`.
 - **`password` replaces `credential`** - `kei password set|clear|backend`. Old `credential` subcommand still works as hidden alias.
+- **Folder structure token expansion** uses `chrono::strftime` instead of manual parsing. Behavior is unchanged for existing templates.
+- **Filename exclude patterns** are compiled once at config build time for performance.
 
 ### Deprecated
 
@@ -30,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--auth-only` (use `kei login`)
 - `--list-albums` / `--list-libraries` (use `kei list albums` / `kei list libraries`)
 - `--reset-sync-token` flag on sync (use `kei reset sync-token`)
-- `--skip-live-photos` (hidden, still accepted)
+- `--skip-live-photos` (use `--live-photo-mode skip`)
 - Top-level `get-code`, `submit-code`, `credential`, `retry-failed`, `reset-state`, `reset-sync-token`, `setup` subcommands (use new grouped equivalents)
 
 All deprecated syntax continues to work and prints a one-line warning to stderr.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1405,7 @@ dependencies = [
  "dotenvy",
  "fs4",
  "futures-util",
+ "glob",
  "hmac",
  "http",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "kei"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ rand = "0.10"
 # File locking
 fs4 = "0.13"
 
+# Glob pattern matching
+glob = "0.3"
+
 # Misc
 url = "2"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kei"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   <a href="LICENSE.md"><img src="https://img.shields.io/github/license/rhoopr/kei?color=8b959e" alt="License: MIT"></a>
   <a href="https://github.com/rhoopr/homebrew-kei"><img src="https://img.shields.io/badge/homebrew-tap-FBB040?logo=homebrew" alt="Homebrew"></a>
   <a href="https://ghcr.io/rhoopr/kei"><img src="https://img.shields.io/badge/ghcr.io-kei-blue?logo=docker" alt="Docker"></a>
+  <a href="https://github.com/rhoopr/kei/releases"><img src="https://img.shields.io/github/downloads/rhoopr/kei/total?logo=github&label=downloads" alt="Downloads"></a>
+  <img src="https://img.shields.io/badge/built_with-Rust-dea584?logo=rust" alt="Built with Rust">
 </p>
 
 Fast, parallel photo sync from the cloud to local storage. Single binary, runs unattended.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="LICENSE.md"><img src="https://img.shields.io/github/license/rhoopr/kei?color=8b959e" alt="License: MIT"></a>
   <a href="https://github.com/rhoopr/kei/releases"><img src="https://img.shields.io/github/v/release/rhoopr/kei?color=blue&label=version" alt="Version"></a>
   <a href="https://github.com/rhoopr/kei/actions/workflows/docker.yml"><img src="https://img.shields.io/github/actions/workflow/status/rhoopr/kei/docker.yml?branch=main&label=build&logo=github" alt="Build"></a>
+  <br>
   <a href="https://github.com/rhoopr/kei/releases"><img src="https://img.shields.io/github/downloads/rhoopr/kei/total?logo=github&label=downloads" alt="Downloads"></a>
   <a href="https://github.com/rhoopr/homebrew-kei"><img src="https://img.shields.io/badge/homebrew-tap-FBB040?logo=homebrew" alt="Homebrew"></a>
   <a href="https://ghcr.io/rhoopr/kei"><img src="https://img.shields.io/badge/ghcr.io-kei-blue?logo=docker" alt="Docker"></a>

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ State lives in a SQLite database alongside your session data (see `--data-dir`).
 - Watch mode with systemd notify, PID file, graceful shutdown
 - Multi-library sync (`--library all` for personal + shared)
 - Flexible password sources: prompt, env var, file, shell command, OS keyring
-- Content filtering: skip videos/photos/live photos, date ranges, albums, `--recent N`
-- Date-based folder structure, live photo MOV pairing, EXIF datetime stamping
+- Content filtering: live photo mode, filename globs, album exclusions, date ranges, `--recent N`
+- Flexible folder structure with `{album}` token and full strftime support, EXIF datetime stamping
 - Multi-arch Docker images (amd64/arm64) with headless 2FA
 - Notification scripts on events (2FA required, sync complete, failures)
 - TOML config with env var overrides (`KEI_*`) for every flag

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <h1 align="center">kei: photo sync engine</h1>
 
 <p align="center">
+  <img src="https://img.shields.io/badge/built_with-Rust-dea584?logo=rust" alt="Built with Rust">
+  <a href="LICENSE.md"><img src="https://img.shields.io/github/license/rhoopr/kei?color=8b959e" alt="License: MIT"></a>
   <a href="https://github.com/rhoopr/kei/releases"><img src="https://img.shields.io/github/v/release/rhoopr/kei?color=blue&label=version" alt="Version"></a>
   <a href="https://github.com/rhoopr/kei/actions/workflows/docker.yml"><img src="https://img.shields.io/github/actions/workflow/status/rhoopr/kei/docker.yml?branch=main&label=build&logo=github" alt="Build"></a>
-  <a href="LICENSE.md"><img src="https://img.shields.io/github/license/rhoopr/kei?color=8b959e" alt="License: MIT"></a>
+  <a href="https://github.com/rhoopr/kei/releases"><img src="https://img.shields.io/github/downloads/rhoopr/kei/total?logo=github&label=downloads" alt="Downloads"></a>
   <a href="https://github.com/rhoopr/homebrew-kei"><img src="https://img.shields.io/badge/homebrew-tap-FBB040?logo=homebrew" alt="Homebrew"></a>
   <a href="https://ghcr.io/rhoopr/kei"><img src="https://img.shields.io/badge/ghcr.io-kei-blue?logo=docker" alt="Docker"></a>
-  <a href="https://github.com/rhoopr/kei/releases"><img src="https://img.shields.io/github/downloads/rhoopr/kei/total?logo=github&label=downloads" alt="Downloads"></a>
-  <img src="https://img.shields.io/badge/built_with-Rust-dea584?logo=rust" alt="Built with Rust">
 </p>
 
 Fast, parallel photo sync from the cloud to local storage. Single binary, runs unattended.

--- a/docs/migration-from-python.md
+++ b/docs/migration-from-python.md
@@ -22,7 +22,7 @@ The import is idempotent - running it multiple times is safe. It uses `upsert` o
 kei sync --username you@example.com --directory ~/Photos/iCloud
 ```
 
-You'll need to authenticate fresh - kei can't reuse Python's `~/.pyicloud` session cookies (different format). After the first 2FA approval, sessions are persisted to `~/.config/kei/cookies/` and reused on subsequent runs.
+You'll need to authenticate fresh - kei can't reuse Python's `~/.pyicloud` session cookies (different format). After the first 2FA approval, sessions are persisted to `~/.config/kei/` (see `--data-dir`) and reused on subsequent runs.
 
 ## CLI flag mapping
 
@@ -42,7 +42,7 @@ Most flags are the same or very close. Here's the full mapping:
 | `--recent` | |
 | `--skip-videos` | |
 | `--skip-photos` | |
-| `--skip-live-photos` | Hidden; still accepted |
+| `--skip-live-photos` | Deprecated; use `--live-photo-mode skip` |
 | `--skip-created-before` | ISO date (`2024-01-01`) or relative interval (`20d`) |
 | `--skip-created-after` | ISO date (`2024-01-01`) or relative interval (`20d`) |
 | `--set-exif-datetime` | |
@@ -110,6 +110,10 @@ Most flags are the same or very close. Here's the full mapping:
 | `verify` | Verify downloads exist and optionally check checksums |
 | `config show` | Dump resolved config as TOML |
 | `config setup` | Interactive config wizard (was top-level `setup`) |
+| `--live-photo-mode` | Control live photo handling: `both`, `image-only`, `video-only`, `skip`. Replaces `--skip-live-photos`. |
+| `--exclude-album` | Exclude specific albums from sync. Multi-value. |
+| `--filename-exclude` | Exclude files by glob pattern (e.g., `*.AAE`, `Screenshot*`). Case-insensitive, multi-value. |
+| `{album}` in `--folder-structure` | Organize by album name: `--folder-structure "{album}/%Y/%m"`. |
 | `KEI_*` env vars | Every CLI flag has an env var (`KEI_DIRECTORY`, `KEI_DATA_DIR`, `KEI_SIZE`, etc.). Useful for Docker. |
 
 ## Docker migration

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    Domain, FileMatchPolicy, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
+    Domain, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
     RawTreatmentPolicy, VersionSize,
 };
 use clap::{Parser, Subcommand};
@@ -25,7 +25,7 @@ fn parse_2fa_code(s: &str) -> Result<String, String> {
 }
 
 /// Print a deprecation warning to stderr.
-fn deprecation_warning(old: &str, new: &str) {
+pub(crate) fn deprecation_warning(old: &str, new: &str) {
     eprintln!("warning: `{old}` is deprecated, use `{new}` instead");
 }
 
@@ -69,6 +69,14 @@ pub struct SyncArgs {
     #[arg(short = 'a', long = "album", env = "KEI_ALBUM", value_parser = non_empty_string)]
     pub albums: Vec<String>,
 
+    /// Album(s) to exclude from sync
+    #[arg(long = "exclude-album", env = "KEI_EXCLUDE_ALBUM", value_parser = non_empty_string)]
+    pub exclude_albums: Vec<String>,
+
+    /// Exclude files matching glob pattern(s) (e.g. "*.AAE", "Screenshot*")
+    #[arg(long = "filename-exclude", env = "KEI_FILENAME_EXCLUDE", value_parser = non_empty_string)]
+    pub filename_exclude: Vec<String>,
+
     /// Library to download (default: `PrimarySync`, use "all" for all libraries)
     #[arg(long, env = "KEI_LIBRARY")]
     pub library: Option<String>,
@@ -97,7 +105,11 @@ pub struct SyncArgs {
     #[arg(long, env = "KEI_SKIP_PHOTOS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub skip_photos: Option<bool>,
 
-    /// Don't download live photos (pass `false` to override config file)
+    /// Live photo handling: both, image-only, video-only, skip
+    #[arg(long, env = "KEI_LIVE_PHOTO_MODE", value_enum)]
+    pub live_photo_mode: Option<LivePhotoMode>,
+
+    /// Deprecated: use `--live-photo-mode skip` instead
     #[arg(long, env = "KEI_SKIP_LIVE_PHOTOS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true, hide = true)]
     pub skip_live_photos: Option<bool>,
 
@@ -1781,5 +1793,67 @@ mod tests {
         } else {
             panic!("Expected Verify command");
         }
+    }
+
+    // ── New filter flags ───────────────────────────────────────────
+
+    #[test]
+    fn test_live_photo_mode_all_variants() {
+        for (flag, expected) in [
+            ("both", LivePhotoMode::Both),
+            ("image-only", LivePhotoMode::ImageOnly),
+            ("video-only", LivePhotoMode::VideoOnly),
+            ("skip", LivePhotoMode::Skip),
+        ] {
+            let mut args = base_args();
+            args.extend(["--live-photo-mode", flag]);
+            let cli = parse(&args);
+            assert_eq!(cli.sync.live_photo_mode, Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_skip_live_photos_compat_still_parses() {
+        let mut args = base_args();
+        args.push("--skip-live-photos");
+        let cli = parse(&args);
+        assert_eq!(cli.sync.skip_live_photos, Some(true));
+    }
+
+    #[test]
+    fn test_filename_exclude_single() {
+        let mut args = base_args();
+        args.extend(["--filename-exclude", "*.AAE"]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.filename_exclude, vec!["*.AAE"]);
+    }
+
+    #[test]
+    fn test_filename_exclude_multiple() {
+        let mut args = base_args();
+        args.extend([
+            "--filename-exclude",
+            "*.AAE",
+            "--filename-exclude",
+            "Screenshot*",
+        ]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.filename_exclude, vec!["*.AAE", "Screenshot*"]);
+    }
+
+    #[test]
+    fn test_exclude_album_single() {
+        let mut args = base_args();
+        args.extend(["--exclude-album", "Hidden"]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.exclude_albums, vec!["Hidden"]);
+    }
+
+    #[test]
+    fn test_exclude_album_multiple() {
+        let mut args = base_args();
+        args.extend(["--exclude-album", "Hidden", "--exclude-album", "Trash"]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.exclude_albums, vec!["Hidden", "Trash"]);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -200,6 +200,10 @@ pub struct SyncArgs {
     #[arg(long, conflicts_with_all = ["dry_run", "watch_with_interval"])]
     pub retry_failed: bool,
 
+    /// Maximum download attempts per asset before skipping (default: 10)
+    #[arg(long, env = "KEI_MAX_DOWNLOAD_ATTEMPTS")]
+    pub max_download_attempts: Option<u32>,
+
     // ── Hidden compat flags (deprecated, still parse) ──────────────
     /// Deprecated: use `kei login` instead
     #[arg(long, hide = true, conflicts_with_all = ["watch_with_interval"])]
@@ -1092,6 +1096,36 @@ mod tests {
                 assert_eq!(sync.directory, Some("/photos".to_string()));
             }
             _ => panic!("Expected Sync with retry_failed"),
+        }
+    }
+
+    #[test]
+    fn test_max_download_attempts_cli_parse() {
+        let cli = Cli::try_parse_from([
+            "kei",
+            "sync",
+            "--max-download-attempts",
+            "5",
+            "--directory",
+            "/photos",
+        ])
+        .unwrap();
+        match cli.effective_command() {
+            Command::Sync { sync, .. } => {
+                assert_eq!(sync.max_download_attempts, Some(5));
+            }
+            _ => panic!("Expected Sync"),
+        }
+    }
+
+    #[test]
+    fn test_max_download_attempts_defaults_to_none() {
+        let cli = Cli::try_parse_from(["kei", "sync", "--directory", "/photos"]).unwrap();
+        match cli.effective_command() {
+            Command::Sync { sync, .. } => {
+                assert_eq!(sync.max_download_attempts, None);
+            }
+            _ => panic!("Expected Sync"),
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,11 +70,11 @@ pub struct SyncArgs {
     pub albums: Vec<String>,
 
     /// Album(s) to exclude from sync
-    #[arg(long = "exclude-album", env = "KEI_EXCLUDE_ALBUM", value_parser = non_empty_string)]
+    #[arg(long = "exclude-album", env = "KEI_EXCLUDE_ALBUM", value_delimiter = ',', value_parser = non_empty_string)]
     pub exclude_albums: Vec<String>,
 
     /// Exclude files matching glob pattern(s) (e.g. "*.AAE", "Screenshot*")
-    #[arg(long = "filename-exclude", env = "KEI_FILENAME_EXCLUDE", value_parser = non_empty_string)]
+    #[arg(long = "filename-exclude", env = "KEI_FILENAME_EXCLUDE", value_delimiter = ',', value_parser = non_empty_string)]
     pub filename_exclude: Vec<String>,
 
     /// Library to download (default: `PrimarySync`, use "all" for all libraries)
@@ -117,7 +117,7 @@ pub struct SyncArgs {
     #[arg(long, env = "KEI_FORCE_SIZE", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub force_size: Option<bool>,
 
-    /// Folder structure for organizing downloads
+    /// Folder structure for organizing downloads (e.g., "%Y/%m/%d", "{album}/%Y/%B", "none")
     #[arg(long, env = "KEI_FOLDER_STRUCTURE")]
     pub folder_structure: Option<String>,
 
@@ -157,7 +157,7 @@ pub struct SyncArgs {
     #[arg(long, env = "KEI_SKIP_CREATED_BEFORE")]
     pub skip_created_before: Option<String>,
 
-    /// Skip assets created after this ISO date or interval
+    /// Skip assets created after this ISO date or interval (e.g., 2025-01-02 or 20d)
     #[arg(long, env = "KEI_SKIP_CREATED_AFTER")]
     pub skip_created_after: Option<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,6 +235,23 @@ pub(crate) fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+/// Reject system directories that should never be used as a download target.
+fn validate_directory(path: &Path) -> anyhow::Result<()> {
+    const DENIED: &[&str] = &[
+        "/bin", "/sbin", "/usr", "/etc", "/dev", "/proc", "/sys", "/boot", "/lib", "/lib64",
+        "/var", "/root",
+    ];
+    let s = path.to_string_lossy();
+    let trimmed = s.trim_end_matches('/');
+    if trimmed.is_empty() || DENIED.contains(&trimmed) {
+        anyhow::bail!(
+            "Refusing to use system directory '{}' as download directory",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// Pick CLI value, then TOML value, then hardcoded default.
 fn resolve<T>(cli: Option<T>, toml: Option<T>, default: T) -> T {
     cli.or(toml).unwrap_or(default)
@@ -454,6 +471,9 @@ impl Config {
             .or_else(|| toml_dl.and_then(|d| d.directory.clone()))
             .map(|d| expand_tilde(&d))
             .unwrap_or_default();
+        if !directory.as_os_str().is_empty() {
+            validate_directory(&directory)?;
+        }
         let folder_structure = resolve(
             sync.folder_structure,
             toml_dl.and_then(|d| d.folder_structure.clone()),
@@ -3431,5 +3451,32 @@ mod tests {
         .unwrap();
         let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
         assert_eq!(patterns, vec!["*.TMP"]);
+    }
+
+    #[test]
+    fn test_validate_directory_rejects_root() {
+        assert!(validate_directory(Path::new("/")).is_err());
+    }
+
+    #[test]
+    fn test_validate_directory_rejects_system_paths() {
+        for path in ["/usr", "/etc", "/boot", "/sys", "/proc", "/dev", "/var"] {
+            assert!(
+                validate_directory(Path::new(path)).is_err(),
+                "should reject {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_directory_rejects_trailing_slash() {
+        assert!(validate_directory(Path::new("/etc/")).is_err());
+    }
+
+    #[test]
+    fn test_validate_directory_accepts_normal_paths() {
+        assert!(validate_directory(Path::new("/home/user/photos")).is_ok());
+        assert!(validate_directory(Path::new("/mnt/photos")).is_ok());
+        assert!(validate_directory(Path::new("/data/sync")).is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,7 +168,7 @@ pub struct Config {
     pub folder_structure: String,
     pub albums: Vec<String>,
     pub exclude_albums: Vec<String>,
-    pub filename_exclude: Vec<String>,
+    pub filename_exclude: Vec<glob::Pattern>,
     pub library: LibrarySelection,
     pub temp_suffix: String,
 
@@ -525,19 +525,21 @@ impl Config {
         } else {
             sync.exclude_albums
         };
-        let filename_exclude = if sync.filename_exclude.is_empty() {
+        let filename_exclude_strs = if sync.filename_exclude.is_empty() {
             toml_filters
                 .and_then(|f| f.filename_exclude.clone())
                 .unwrap_or_default()
         } else {
             sync.filename_exclude
         };
-        // Validate glob patterns early
-        for pattern in &filename_exclude {
-            glob::Pattern::new(pattern).map_err(|e| {
-                anyhow::anyhow!("invalid --filename-exclude pattern '{pattern}': {e}")
-            })?;
-        }
+        // Compile glob patterns once during build
+        let filename_exclude: Vec<glob::Pattern> = filename_exclude_strs
+            .iter()
+            .map(|p| {
+                glob::Pattern::new(p)
+                    .map_err(|e| anyhow::anyhow!("invalid --filename-exclude pattern '{p}': {e}"))
+            })
+            .collect::<anyhow::Result<_>>()?;
         let recent = sync.recent.or_else(|| toml_filters.and_then(|f| f.recent));
         if let Some(0) = recent {
             anyhow::bail!("recent must be >= 1 (got 0)");
@@ -756,7 +758,12 @@ impl Config {
                 filename_exclude: if self.filename_exclude.is_empty() {
                     None
                 } else {
-                    Some(self.filename_exclude.clone())
+                    Some(
+                        self.filename_exclude
+                            .iter()
+                            .map(|p| p.as_str().to_string())
+                            .collect(),
+                    )
                 },
                 skip_videos: if self.skip_videos { Some(true) } else { None },
                 skip_photos: if self.skip_photos { Some(true) } else { None },
@@ -3200,7 +3207,8 @@ mod tests {
             Some(toml),
         )
         .unwrap();
-        assert_eq!(cfg.filename_exclude, vec!["*.AAE", "*.TMP"]);
+        let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
+        assert_eq!(patterns, vec!["*.AAE", "*.TMP"]);
     }
 
     #[test]
@@ -3225,5 +3233,70 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.exclude_albums, vec!["Hidden", "Trash"]);
+    }
+
+    #[test]
+    fn test_contradictory_date_filter_succeeds() {
+        // before >= after is a warning, not an error -- Config::build should succeed
+        let mut sync = default_sync();
+        sync.skip_created_before = Some("2025-06-01".to_string());
+        sync.skip_created_after = Some("2025-01-01".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None);
+        assert!(
+            cfg.is_ok(),
+            "Contradictory date filters should warn, not error"
+        );
+        let cfg = cfg.unwrap();
+        assert!(cfg.skip_created_before >= cfg.skip_created_after);
+    }
+
+    #[test]
+    fn test_exclude_album_cli_overrides_toml() {
+        let mut sync = default_sync();
+        sync.exclude_albums = vec!["CLI_Album".to_string()];
+        let toml_str = "[filters]\nexclude_albums = [\"TOML_Album\"]\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(&default_globals(), default_password(), sync, Some(toml)).unwrap();
+        assert_eq!(cfg.exclude_albums, vec!["CLI_Album"]);
+    }
+
+    #[test]
+    fn test_exclude_album_falls_back_to_toml() {
+        let toml_str = "[filters]\nexclude_albums = [\"TOML_Album\"]\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.exclude_albums, vec!["TOML_Album"]);
+    }
+
+    #[test]
+    fn test_filename_exclude_cli_overrides_toml() {
+        let mut sync = default_sync();
+        sync.filename_exclude = vec!["*.AAE".to_string()];
+        let toml_str = "[filters]\nfilename_exclude = [\"*.TMP\"]\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(&default_globals(), default_password(), sync, Some(toml)).unwrap();
+        let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
+        assert_eq!(patterns, vec!["*.AAE"]);
+    }
+
+    #[test]
+    fn test_filename_exclude_falls_back_to_toml() {
+        let toml_str = "[filters]\nfilename_exclude = [\"*.TMP\"]\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        let patterns: Vec<&str> = cfg.filename_exclude.iter().map(|p| p.as_str()).collect();
+        assert_eq!(patterns, vec!["*.TMP"]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::password::SecretString;
 use crate::types::{
-    Domain, FileMatchPolicy, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
+    Domain, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize, LogLevel,
     RawTreatmentPolicy, VersionSize,
 };
 use chrono::{DateTime, Local, NaiveDate, NaiveDateTime};
@@ -63,6 +63,8 @@ pub(crate) struct TomlRetry {
 pub(crate) struct TomlFilters {
     pub library: Option<String>,
     pub albums: Option<Vec<String>>,
+    pub exclude_albums: Option<Vec<String>>,
+    pub filename_exclude: Option<Vec<String>>,
     pub skip_videos: Option<bool>,
     pub skip_photos: Option<bool>,
     pub skip_live_photos: Option<bool>,
@@ -76,6 +78,7 @@ pub(crate) struct TomlFilters {
 pub(crate) struct TomlPhotos {
     pub size: Option<VersionSize>,
     pub live_photo_size: Option<LivePhotoSize>,
+    pub live_photo_mode: Option<LivePhotoMode>,
     pub live_photo_mov_filename_policy: Option<LivePhotoMovFilenamePolicy>,
     pub align_raw: Option<RawTreatmentPolicy>,
     pub file_match_policy: Option<FileMatchPolicy>,
@@ -164,6 +167,8 @@ pub struct Config {
     pub cookie_directory: PathBuf,
     pub folder_structure: String,
     pub albums: Vec<String>,
+    pub exclude_albums: Vec<String>,
+    pub filename_exclude: Vec<String>,
     pub library: LibrarySelection,
     pub temp_suffix: String,
 
@@ -190,6 +195,7 @@ pub struct Config {
     pub size: VersionSize,
     pub live_photo_size: LivePhotoSize,
     pub domain: Domain,
+    pub live_photo_mode: LivePhotoMode,
     pub live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy,
     pub align_raw: RawTreatmentPolicy,
     pub file_match_policy: FileMatchPolicy,
@@ -197,7 +203,6 @@ pub struct Config {
     // All booleans grouped together
     pub skip_videos: bool,
     pub skip_photos: bool,
-    pub skip_live_photos: bool,
     pub force_size: bool,
     pub set_exif_datetime: bool,
     pub dry_run: bool,
@@ -454,28 +459,6 @@ impl Config {
             toml_dl.and_then(|d| d.folder_structure.clone()),
             "%Y/%m/%d".to_string(),
         );
-        // Validate folder_structure doesn't contain unrecognized % tokens.
-        // expand_date_format only handles %Y, %m, %d, %H, %M, %S — unknown
-        // tokens like %q are silently preserved as literal "%q" in paths.
-        if !folder_structure.eq_ignore_ascii_case("none") {
-            let format_str = folder_structure
-                .strip_prefix("{:")
-                .and_then(|s| s.strip_suffix('}'))
-                .unwrap_or(&folder_structure);
-            let remaining = format_str
-                .replace("%Y", "")
-                .replace("%m", "")
-                .replace("%d", "")
-                .replace("%H", "")
-                .replace("%M", "")
-                .replace("%S", "");
-            anyhow::ensure!(
-                !remaining.contains('%'),
-                "folder_structure contains unrecognized format token: \
-                 '{folder_structure}'. Supported tokens: %Y, %m, %d, %H, %M, %S"
-            );
-        }
-
         let threads_num = resolve(sync.threads_num, toml_dl.and_then(|d| d.threads_num), 10);
         anyhow::ensure!(
             threads_num >= 1,
@@ -522,10 +505,39 @@ impl Config {
         };
         let skip_videos = resolve_flag(sync.skip_videos, toml_filters.and_then(|f| f.skip_videos));
         let skip_photos = resolve_flag(sync.skip_photos, toml_filters.and_then(|f| f.skip_photos));
-        let skip_live_photos = resolve_flag(
-            sync.skip_live_photos,
-            toml_filters.and_then(|f| f.skip_live_photos),
-        );
+        // Resolve live photo mode: --live-photo-mode > --skip-live-photos > TOML photos > TOML filters compat
+        let live_photo_mode = if let Some(mode) = sync.live_photo_mode {
+            mode
+        } else if sync.skip_live_photos == Some(true) {
+            crate::cli::deprecation_warning("--skip-live-photos", "--live-photo-mode skip");
+            LivePhotoMode::Skip
+        } else if let Some(mode) = toml_photos.and_then(|p| p.live_photo_mode) {
+            mode
+        } else if toml_filters.and_then(|f| f.skip_live_photos) == Some(true) {
+            LivePhotoMode::Skip
+        } else {
+            LivePhotoMode::Both
+        };
+        let exclude_albums = if sync.exclude_albums.is_empty() {
+            toml_filters
+                .and_then(|f| f.exclude_albums.clone())
+                .unwrap_or_default()
+        } else {
+            sync.exclude_albums
+        };
+        let filename_exclude = if sync.filename_exclude.is_empty() {
+            toml_filters
+                .and_then(|f| f.filename_exclude.clone())
+                .unwrap_or_default()
+        } else {
+            sync.filename_exclude
+        };
+        // Validate glob patterns early
+        for pattern in &filename_exclude {
+            glob::Pattern::new(pattern).map_err(|e| {
+                anyhow::anyhow!("invalid --filename-exclude pattern '{pattern}': {e}")
+            })?;
+        }
         let recent = sync.recent.or_else(|| toml_filters.and_then(|f| f.recent));
         if let Some(0) = recent {
             anyhow::bail!("recent must be >= 1 (got 0)");
@@ -611,10 +623,10 @@ impl Config {
             .or_else(|| toml_notif.and_then(|n| n.script.clone()))
             .map(|s| expand_tilde(&s));
 
-        if skip_videos && skip_photos && skip_live_photos {
+        if skip_videos && skip_photos && live_photo_mode == LivePhotoMode::Skip {
             tracing::warn!(
                 "All media types are being skipped (--skip-videos, --skip-photos, \
-                 --skip-live-photos) — nothing will be downloaded"
+                 --live-photo-mode skip) -- nothing will be downloaded"
             );
         }
 
@@ -627,6 +639,8 @@ impl Config {
             cookie_directory,
             folder_structure,
             albums,
+            exclude_albums,
+            filename_exclude,
             library,
             temp_suffix,
             skip_created_before,
@@ -641,12 +655,12 @@ impl Config {
             size,
             live_photo_size,
             domain,
+            live_photo_mode,
             live_photo_mov_filename_policy,
             align_raw,
             file_match_policy,
             skip_videos,
             skip_photos,
-            skip_live_photos,
             force_size,
             set_exif_datetime,
             dry_run: sync.dry_run,
@@ -724,16 +738,22 @@ impl Config {
                 } else {
                     Some(self.albums.clone())
                 },
+                exclude_albums: if self.exclude_albums.is_empty() {
+                    None
+                } else {
+                    Some(self.exclude_albums.clone())
+                },
+                filename_exclude: if self.filename_exclude.is_empty() {
+                    None
+                } else {
+                    Some(self.filename_exclude.clone())
+                },
                 skip_videos: if self.skip_videos { Some(true) } else { None },
                 skip_photos: if self.skip_photos { Some(true) } else { None },
-                skip_live_photos: if self.skip_live_photos {
-                    Some(true)
-                } else {
-                    None
-                },
-                recent: None,              // per-run
+                skip_live_photos: None, // deprecated, use live_photo_mode in [photos]
+                recent: None,           // per-run
                 skip_created_before: None, // per-run
-                skip_created_after: None,  // per-run
+                skip_created_after: None, // per-run
             }),
             photos: Some(TomlPhotos {
                 size: if self.size == VersionSize::Original {
@@ -745,6 +765,11 @@ impl Config {
                     None
                 } else {
                     Some(self.live_photo_size)
+                },
+                live_photo_mode: if self.live_photo_mode == LivePhotoMode::Both {
+                    None
+                } else {
+                    Some(self.live_photo_mode)
                 },
                 live_photo_mov_filename_policy: if self.live_photo_mov_filename_policy
                     == LivePhotoMovFilenamePolicy::Suffix
@@ -1911,7 +1936,7 @@ mod tests {
         assert!(cfg.albums.is_empty());
         assert!(!cfg.skip_videos);
         assert!(!cfg.skip_photos);
-        assert!(!cfg.skip_live_photos);
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Both);
         assert!(cfg.recent.is_none());
         assert!(cfg.skip_created_before.is_none());
         assert!(cfg.skip_created_after.is_none());
@@ -2361,7 +2386,7 @@ mod tests {
         assert!(cfg.no_progress_bar);
         assert!(cfg.skip_videos);
         assert!(cfg.skip_photos);
-        assert!(cfg.skip_live_photos);
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Skip);
         assert!(cfg.force_size);
         assert!(cfg.keep_unicode_in_filenames);
         assert!(cfg.notify_systemd);
@@ -2383,7 +2408,7 @@ mod tests {
         assert!(cfg.no_progress_bar);
         assert!(cfg.skip_videos);
         assert!(cfg.skip_photos);
-        assert!(cfg.skip_live_photos);
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::Skip);
         assert!(cfg.force_size);
         assert!(cfg.keep_unicode_in_filenames);
         assert!(cfg.notify_systemd);
@@ -2820,14 +2845,12 @@ mod tests {
     }
 
     #[test]
-    fn test_folder_structure_invalid_token_rejected() {
+    fn test_folder_structure_strftime_tokens_accepted() {
+        // Full strftime support: %B (month name), %X (locale time), etc. are valid
         let mut sync = default_sync();
-        sync.folder_structure = Some("%Y/%X/%d".to_string());
-        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
-        assert!(
-            err.to_string().contains("unrecognized format token"),
-            "error should mention unrecognized token: {err}"
-        );
+        sync.folder_structure = Some("%Y/%B/%d".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.folder_structure, "%Y/%B/%d");
     }
 
     #[test]
@@ -3120,5 +3143,69 @@ mod tests {
             parsed.auth.as_ref().unwrap().password_file.as_deref(),
             Some("/run/secrets/pw")
         );
+    }
+
+    // ── Filter + LivePhotoMode config resolution ──────────────────
+
+    #[test]
+    fn test_live_photo_mode_cli_overrides_toml() {
+        let mut sync = default_sync();
+        sync.live_photo_mode = Some(LivePhotoMode::ImageOnly);
+        let toml_str = "[photos]\nlive_photo_mode = \"skip\"\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(&default_globals(), default_password(), sync, Some(toml)).unwrap();
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::ImageOnly);
+    }
+
+    #[test]
+    fn test_live_photo_mode_from_toml() {
+        let toml_str = "[photos]\nlive_photo_mode = \"video-only\"\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.live_photo_mode, LivePhotoMode::VideoOnly);
+    }
+
+    #[test]
+    fn test_filename_exclude_from_toml() {
+        let toml_str = "[filters]\nfilename_exclude = [\"*.AAE\", \"*.THM\"]\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.filename_exclude, vec!["*.AAE", "*.THM"]);
+    }
+
+    #[test]
+    fn test_filename_exclude_invalid_glob_rejected() {
+        let mut sync = default_sync();
+        sync.filename_exclude = vec!["[invalid".to_string()];
+        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("invalid --filename-exclude pattern"));
+    }
+
+    #[test]
+    fn test_exclude_albums_from_toml() {
+        let toml_str = "[filters]\nexclude_albums = [\"Hidden\", \"Trash\"]\n";
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.exclude_albums, vec!["Hidden", "Trash"]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -243,6 +243,7 @@ fn validate_directory(path: &Path) -> anyhow::Result<()> {
     ];
     let s = path.to_string_lossy();
     let trimmed = s.trim_end_matches('/');
+    // trimmed.is_empty() catches "/" (trimmed to "")
     if trimmed.is_empty() || DENIED.contains(&trimmed) {
         anyhow::bail!(
             "Refusing to use system directory '{}' as download directory",

--- a/src/config.rs
+++ b/src/config.rs
@@ -561,10 +561,9 @@ impl Config {
         if let (Some(before), Some(after)) = (&skip_created_before, &skip_created_after) {
             if before >= after {
                 tracing::warn!(
-                    "skip-created-before ({}) >= skip-created-after ({}) -- \
-                     no assets can match this date range",
-                    before.format("%Y-%m-%d"),
-                    after.format("%Y-%m-%d"),
+                    before = %before.format("%Y-%m-%d"),
+                    after = %after.format("%Y-%m-%d"),
+                    "skip-created-before >= skip-created-after, no assets can match",
                 );
             }
         }
@@ -933,7 +932,9 @@ pub(crate) fn persist_first_run_config(
 pub(crate) fn parse_date_or_interval(s: &str) -> anyhow::Result<DateTime<Local>> {
     if let Some(days_str) = s.strip_suffix('d') {
         if let Ok(days) = days_str.parse::<u64>() {
-            return Ok(Local::now() - chrono::Duration::days(days as i64));
+            let days =
+                i64::try_from(days).map_err(|_| anyhow::anyhow!("interval '{s}' is too large"))?;
+            return Ok(Local::now() - chrono::Duration::days(days));
         }
     }
     if let Ok(date) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -558,6 +558,17 @@ impl Config {
             .map(parse_date_or_interval)
             .transpose()?;
 
+        if let (Some(before), Some(after)) = (&skip_created_before, &skip_created_after) {
+            if before >= after {
+                tracing::warn!(
+                    "skip-created-before ({}) >= skip-created-after ({}) -- \
+                     no assets can match this date range",
+                    before.format("%Y-%m-%d"),
+                    after.format("%Y-%m-%d"),
+                );
+            }
+        }
+
         // Photos
         let size = resolve(
             sync.size,

--- a/src/config.rs
+++ b/src/config.rs
@@ -921,8 +921,8 @@ pub(crate) fn persist_first_run_config(
 /// - ISO datetime: `"2025-01-02T14:30:00"` (local time)
 pub(crate) fn parse_date_or_interval(s: &str) -> anyhow::Result<DateTime<Local>> {
     if let Some(days_str) = s.strip_suffix('d') {
-        if let Ok(days) = days_str.parse::<i64>() {
-            return Ok(Local::now() - chrono::Duration::days(days));
+        if let Ok(days) = days_str.parse::<u64>() {
+            return Ok(Local::now() - chrono::Duration::days(days as i64));
         }
     }
     if let Ok(date) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
@@ -1003,6 +1003,12 @@ mod tests {
     fn test_parse_invalid_date() {
         assert!(parse_date_or_interval("not-a-date").is_err());
         assert!(parse_date_or_interval("").is_err());
+    }
+
+    #[test]
+    fn test_parse_negative_interval_rejected() {
+        assert!(parse_date_or_interval("-5d").is_err());
+        assert!(parse_date_or_interval("-1d").is_err());
     }
 
     // ── TOML parsing tests ──────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -2964,6 +2964,139 @@ mod tests {
         assert!(filters.skip_created_after.is_none());
     }
 
+    #[test]
+    fn test_to_toml_roundtrip_exclude_albums() {
+        let mut sync = default_sync();
+        sync.exclude_albums = vec!["Hidden".to_string(), "Trash".to_string()];
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        let toml = cfg.to_toml();
+        let filters = toml.filters.as_ref().unwrap();
+        assert_eq!(
+            filters.exclude_albums.as_deref(),
+            Some(&["Hidden".to_string(), "Trash".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn test_to_toml_roundtrip_filename_exclude() {
+        let mut sync = default_sync();
+        sync.filename_exclude = vec!["*.AAE".to_string(), "Screenshot*".to_string()];
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        let toml = cfg.to_toml();
+        let filters = toml.filters.as_ref().unwrap();
+        assert_eq!(
+            filters.filename_exclude.as_deref(),
+            Some(&["*.AAE".to_string(), "Screenshot*".to_string()][..])
+        );
+        // Round-trip: serialize then deserialize
+        let serialized = ::toml::to_string_pretty(&toml).unwrap();
+        let parsed: TomlConfig = ::toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            parsed.filters.as_ref().unwrap().filename_exclude.as_deref(),
+            Some(&["*.AAE".to_string(), "Screenshot*".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn test_to_toml_roundtrip_live_photo_mode() {
+        let mut sync = default_sync();
+        sync.live_photo_mode = Some(crate::types::LivePhotoMode::ImageOnly);
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        let toml = cfg.to_toml();
+        assert_eq!(
+            toml.photos.as_ref().unwrap().live_photo_mode,
+            Some(crate::types::LivePhotoMode::ImageOnly)
+        );
+        // Round-trip
+        let serialized = ::toml::to_string_pretty(&toml).unwrap();
+        let parsed: TomlConfig = ::toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            parsed.photos.as_ref().unwrap().live_photo_mode,
+            Some(crate::types::LivePhotoMode::ImageOnly)
+        );
+    }
+
+    #[test]
+    fn test_to_toml_empty_exclude_albums_omitted() {
+        let cfg =
+            Config::build(&default_globals(), default_password(), default_sync(), None).unwrap();
+        let toml = cfg.to_toml();
+        assert!(toml.filters.as_ref().unwrap().exclude_albums.is_none());
+    }
+
+    #[test]
+    fn test_to_toml_default_live_photo_mode_omitted() {
+        let cfg =
+            Config::build(&default_globals(), default_password(), default_sync(), None).unwrap();
+        let toml = cfg.to_toml();
+        assert!(toml.photos.as_ref().unwrap().live_photo_mode.is_none());
+    }
+
+    // ── TOML-only skip_live_photos legacy path ──────────────────────
+
+    #[test]
+    fn test_toml_skip_live_photos_legacy_maps_to_skip_mode() {
+        let toml_str = r#"
+            [auth]
+            username = "u@example.com"
+
+            [filters]
+            skip_live_photos = true
+        "#;
+        let toml: TomlConfig = ::toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.live_photo_mode, crate::types::LivePhotoMode::Skip);
+    }
+
+    #[test]
+    fn test_toml_skip_live_photos_false_stays_both() {
+        let toml_str = r#"
+            [auth]
+            username = "u@example.com"
+
+            [filters]
+            skip_live_photos = false
+        "#;
+        let toml: TomlConfig = ::toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.live_photo_mode, crate::types::LivePhotoMode::Both);
+    }
+
+    #[test]
+    fn test_toml_photos_live_photo_mode_overrides_filters_skip_live_photos() {
+        let toml_str = r#"
+            [auth]
+            username = "u@example.com"
+
+            [filters]
+            skip_live_photos = true
+
+            [photos]
+            live_photo_mode = "image-only"
+        "#;
+        let toml: TomlConfig = ::toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.live_photo_mode, crate::types::LivePhotoMode::ImageOnly);
+    }
+
     // ── resolve_data_dir() tests ────────────────────────────────────
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3173,7 +3173,7 @@ mod tests {
 
     #[test]
     fn test_filename_exclude_from_toml() {
-        let toml_str = "[filters]\nfilename_exclude = [\"*.AAE\", \"*.THM\"]\n";
+        let toml_str = "[filters]\nfilename_exclude = [\"*.AAE\", \"*.TMP\"]\n";
         let toml: TomlConfig = toml::from_str(toml_str).unwrap();
         let cfg = Config::build(
             &default_globals(),
@@ -3182,7 +3182,7 @@ mod tests {
             Some(toml),
         )
         .unwrap();
-        assert_eq!(cfg.filename_exclude, vec!["*.AAE", "*.THM"]);
+        assert_eq!(cfg.filename_exclude, vec!["*.AAE", "*.TMP"]);
     }
 
     #[test]

--- a/src/download/exif.rs
+++ b/src/download/exif.rs
@@ -62,8 +62,15 @@ pub(crate) fn set_photo_exif(path: &Path, datetime_str: &str) -> Result<()> {
         .write_to_vec(&mut buf, FileExtension::JPEG)
         .with_context(|| format!("Writing EXIF metadata for {}", path.display()))?;
 
-    std::fs::write(path, &buf)
-        .with_context(|| format!("Writing EXIF result to {}", path.display()))?;
+    // Write to a sibling temp file and atomically rename to avoid leaving a
+    // truncated file if the process is killed mid-write.
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".exif-tmp");
+    let tmp_path = path.with_file_name(&tmp_name);
+    std::fs::write(&tmp_path, &buf)
+        .with_context(|| format!("Writing EXIF temp file {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("Renaming {} -> {}", tmp_path.display(), path.display()))?;
 
     tracing::debug!(
         datetime = %datetime_str,
@@ -218,6 +225,35 @@ mod tests {
 
         let result = get_photo_exif(&path).unwrap();
         assert_eq!(result, Some("2024-12-25 12:00:00".to_string()));
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_exif_tmp_file_not_left_behind() {
+        let dir = test_tmp_dir("exif_atomic");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("atomic_test.jpg");
+        let _ = fs::remove_file(&path);
+
+        // Create a minimal valid JPEG
+        fs::write(&path, minimal_jpeg()).unwrap();
+
+        set_photo_exif(&path, "2025:01:01 00:00:00").unwrap();
+
+        // The .exif-tmp file must not exist after a successful call.
+        let mut tmp_name = path.file_name().unwrap().to_os_string();
+        tmp_name.push(".exif-tmp");
+        let tmp_path = path.with_file_name(&tmp_name);
+        assert!(
+            !tmp_path.exists(),
+            ".exif-tmp should be cleaned up after successful write"
+        );
+
+        // The original file should still exist and have valid EXIF.
+        assert!(path.exists());
+        let result = get_photo_exif(&path).unwrap();
+        assert_eq!(result, Some("2025-01-01 00:00:00".to_string()));
 
         fs::remove_file(&path).ok();
     }

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -152,7 +152,24 @@ async fn attempt_download<C: DownloadClient>(
     let path_str = download_path.display().to_string();
 
     let resume_offset = match fs::metadata(part_path).await {
-        Ok(meta) if meta.len() > 0 => meta.len(),
+        Ok(meta) if meta.len() > 0 => {
+            // Discard stale .part files from crashed runs to avoid resuming
+            // from potentially corrupt bytes.
+            let stale = meta.modified().ok().is_some_and(|mtime| {
+                mtime.elapsed().unwrap_or(std::time::Duration::ZERO)
+                    > std::time::Duration::from_secs(24 * 3600)
+            });
+            if stale {
+                tracing::warn!(
+                    path = %part_path.display(),
+                    size = meta.len(),
+                    "Stale .part file (>24h old), restarting download"
+                );
+                0
+            } else {
+                meta.len()
+            }
+        }
         _ => 0,
     };
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2168,19 +2168,19 @@ where
                     } else {
                         for task in tasks {
                             // Skip assets that have exceeded the retry limit.
-                            if config.max_download_attempts > 0 {
-                                if let Some(&attempts) =
-                                    download_ctx.attempt_counts.get(task.asset_id.as_ref())
+                            if let Some(&attempts) =
+                                download_ctx.attempt_counts.get(task.asset_id.as_ref())
+                            {
+                                if config.max_download_attempts > 0
+                                    && attempts >= config.max_download_attempts
                                 {
-                                    if attempts >= config.max_download_attempts {
-                                        tracing::warn!(
-                                            asset_id = %task.asset_id,
-                                            attempts,
-                                            max = config.max_download_attempts,
-                                            "Skipping asset: exceeded max download attempts"
-                                        );
-                                        continue;
-                                    }
+                                    tracing::warn!(
+                                        asset_id = %task.asset_id,
+                                        attempts,
+                                        max = config.max_download_attempts,
+                                        "Skipping asset: exceeded max download attempts"
+                                    );
+                                    continue;
                                 }
                             }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -131,7 +131,7 @@ pub enum DownloadOutcome {
 }
 
 /// How the sync should enumerate photos from iCloud.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SyncMode {
     /// Full enumeration via records/query (existing behavior).
     /// On completion, captures the syncToken for future incremental syncs.
@@ -197,7 +197,7 @@ pub(crate) fn hash_download_config(config: &DownloadConfig) -> String {
     hasher.update([u8::from(config.force_size)]);
     hasher.update([u8::from(config.skip_videos)]);
     hasher.update([u8::from(config.skip_photos)]);
-    hasher.update(format!("{:?}", config.live_photo_mode).as_bytes());
+    hasher.update([config.live_photo_mode as u8]);
     // filename_exclude patterns affect which assets are eligible
     let mut sorted_excludes: Vec<&str> =
         config.filename_exclude.iter().map(|p| p.as_str()).collect();
@@ -262,7 +262,7 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // Enumeration-filter fields: changing these affects WHICH assets are
     // fetched from iCloud, so sync tokens must be invalidated to avoid
     // missing assets that are newly eligible under the changed filters.
-    hasher.update(format!("{:?}", config.live_photo_mode).as_bytes());
+    hasher.update([config.live_photo_mode as u8]);
     for album in &config.albums {
         hasher.update(album.as_bytes());
         hasher.update(b"\0");
@@ -335,12 +335,16 @@ pub(crate) struct DownloadConfig {
 
 impl DownloadConfig {
     /// Clone this config with a different `album_name`, for per-album processing
-    /// when `{album}` is in `folder_structure`.
+    /// when `{album}` is in `folder_structure`. Pre-expands the `{album}` token
+    /// in `folder_structure` so `local_download_dir` avoids per-asset
+    /// sanitize/escape/replace allocations.
     fn with_album_name(&self, name: Arc<str>) -> Self {
+        let album_ref = Some(name.as_ref()).filter(|n: &&str| !n.is_empty());
+        let folder_structure = paths::expand_album_token(&self.folder_structure, album_ref);
         Self {
             album_name: Some(name),
             directory: self.directory.clone(),
-            folder_structure: self.folder_structure.clone(),
+            folder_structure,
             filename_exclude: self.filename_exclude.clone(),
             temp_suffix: self.temp_suffix.clone(),
             state_db: self.state_db.clone(),
@@ -1431,6 +1435,11 @@ async fn download_photos_full_with_token(
         };
         let mut token_receivers = Vec::with_capacity(albums.len());
 
+        // When {album} is in folder_structure, albums are processed sequentially
+        // so each gets its own per-album path expansion. Cross-album download
+        // concurrency is intentionally sacrificed for correct path placement.
+        // Assets appearing in multiple albums are downloaded once per album,
+        // each to its respective album directory.
         for (album, &count) in albums.iter().zip(&album_counts) {
             if shutdown_token.is_cancelled() {
                 break;
@@ -1651,6 +1660,9 @@ async fn download_photos_incremental(
     let mut skipped_by_state = 0usize;
     let mut album_configs: FxHashMap<Arc<str>, Arc<DownloadConfig>> = FxHashMap::default();
 
+    // In {album} mode, assets in multiple albums are processed once per album,
+    // each downloading to the album-specific directory. Configs are cached per
+    // album name to avoid redundant allocations.
     for (asset, album_name) in &downloadable_assets {
         let effective_config: &Arc<DownloadConfig> = if uses_album_token {
             album_configs
@@ -1948,7 +1960,9 @@ where
                     _ => {}
                 }
             }
-            let _ = db.set_metadata("config_hash", &config_hash).await;
+            if let Err(e) = db.set_metadata("config_hash", &config_hash).await {
+                tracing::warn!(error = %e, "Failed to persist config_hash");
+            }
         }
         trust = trust && !download_ctx.downloaded_ids.is_empty();
 
@@ -3761,6 +3775,42 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_skip_candidates_skip_mode() {
+        let asset = test_live_photo_asset();
+        let mut config = test_config();
+        config.live_photo_mode = LivePhotoMode::Skip;
+        let candidates = extract_skip_candidates(&asset, &config);
+        assert!(
+            candidates.is_empty(),
+            "Skip mode should exclude live photos entirely"
+        );
+    }
+
+    #[test]
+    fn test_extract_skip_candidates_skip_mode_non_live_passes() {
+        let asset = TestPhotoAsset::new("TEST_1").build();
+        let mut config = test_config();
+        config.live_photo_mode = LivePhotoMode::Skip;
+        let candidates = extract_skip_candidates(&asset, &config);
+        assert_eq!(
+            candidates.len(),
+            1,
+            "Skip mode should not affect non-live photos"
+        );
+    }
+
+    #[test]
+    fn test_extract_skip_candidates_video_only_mode() {
+        let asset = test_live_photo_asset();
+        let mut config = test_config();
+        config.live_photo_mode = LivePhotoMode::VideoOnly;
+        let candidates = extract_skip_candidates(&asset, &config);
+        // Should have only the MOV companion, no primary image
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].0, VersionSizeKey::LiveOriginal);
+    }
+
+    #[test]
     fn test_extract_skip_candidates_date_before_filter() {
         let asset = TestPhotoAsset::new("TEST_1").build(); // assetDate = 1736899200000 = 2025-01-15
         let mut config = test_config();
@@ -5539,6 +5589,26 @@ mod tests {
         let a = build_config_with(tmp.path(), "/photos", |_| {});
         let b = build_config_with(tmp.path(), "/photos", |s| {
             s.albums = vec!["Favorites".to_string()];
+        });
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn test_compute_config_hash_different_exclude_albums() {
+        let tmp = TempDir::new().unwrap();
+        let a = build_config_with(tmp.path(), "/photos", |_| {});
+        let b = build_config_with(tmp.path(), "/photos", |s| {
+            s.exclude_albums = vec!["Hidden".to_string()];
+        });
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn test_compute_config_hash_different_live_photo_mode() {
+        let tmp = TempDir::new().unwrap();
+        let a = build_config_with(tmp.path(), "/photos", |_| {});
+        let b = build_config_with(tmp.path(), "/photos", |s| {
+            s.live_photo_mode = Some(LivePhotoMode::Skip);
         });
         assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
     }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -35,9 +35,18 @@ use crate::icloud::photos::{
 };
 use crate::retry::RetryConfig;
 use crate::state::{AssetRecord, MediaType, StateDb, SyncRunStats, VersionSizeKey};
-use crate::types::{FileMatchPolicy, LivePhotoMovFilenamePolicy, RawTreatmentPolicy};
+use crate::types::{
+    FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, RawTreatmentPolicy,
+};
 
 use error::DownloadError;
+
+/// Case-insensitive glob matching options for filename exclusion patterns.
+const GLOB_CASE_INSENSITIVE: glob::MatchOptions = glob::MatchOptions {
+    case_sensitive: false,
+    require_literal_separator: false,
+    require_literal_leading_dot: false,
+};
 
 /// Determine the media type for an asset based on version size and item type.
 pub fn determine_media_type(
@@ -58,18 +67,8 @@ pub fn determine_media_type(
         _ => {
             if asset.item_type() == Some(AssetItemType::Movie) {
                 MediaType::Video
-            } else if asset.item_type() == Some(AssetItemType::Image) {
-                // Could be live photo image or regular photo
-                // Check if asset has live photo versions
-                if asset.contains_version(AssetVersionSize::LiveOriginal)
-                    || asset.contains_version(AssetVersionSize::LiveMedium)
-                    || asset.contains_version(AssetVersionSize::LiveThumb)
-                    || asset.contains_version(AssetVersionSize::LiveAdjusted)
-                {
-                    MediaType::LivePhotoImage
-                } else {
-                    MediaType::Photo
-                }
+            } else if asset.is_live_photo() {
+                MediaType::LivePhotoImage
             } else {
                 MediaType::Photo
             }
@@ -198,7 +197,15 @@ pub(crate) fn hash_download_config(config: &DownloadConfig) -> String {
     hasher.update([u8::from(config.force_size)]);
     hasher.update([u8::from(config.skip_videos)]);
     hasher.update([u8::from(config.skip_photos)]);
-    hasher.update([u8::from(config.skip_live_photos)]);
+    hasher.update(format!("{:?}", config.live_photo_mode).as_bytes());
+    // filename_exclude patterns affect which assets are eligible
+    let mut sorted_excludes: Vec<&str> =
+        config.filename_exclude.iter().map(|p| p.as_str()).collect();
+    sorted_excludes.sort_unstable();
+    for pattern in &sorted_excludes {
+        hasher.update(pattern.as_bytes());
+        hasher.update(b"\0");
+    }
     let hash = hasher.finalize();
     let mut hex = String::with_capacity(16);
     // First 8 bytes is plenty for collision avoidance in this context
@@ -215,7 +222,7 @@ pub(crate) fn hash_download_config(config: &DownloadConfig) -> String {
 ///
 /// This hash is a SUPERSET of [`hash_download_config`]: it includes all
 /// the fields that affect download paths (shared with hash_download_config)
-/// plus enumeration-filter fields (albums, library, skip_live_photos) that
+/// plus enumeration-filter fields (albums, library, live_photo_mode) that
 /// affect WHICH assets are eligible. Changing these filters must invalidate
 /// sync tokens so the next run does a full enumeration.
 pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
@@ -255,9 +262,24 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // Enumeration-filter fields: changing these affects WHICH assets are
     // fetched from iCloud, so sync tokens must be invalidated to avoid
     // missing assets that are newly eligible under the changed filters.
-    hasher.update([u8::from(config.skip_live_photos)]);
+    hasher.update(format!("{:?}", config.live_photo_mode).as_bytes());
     for album in &config.albums {
         hasher.update(album.as_bytes());
+        hasher.update(b"\0");
+    }
+    let mut sorted_excludes: Vec<&str> = config.exclude_albums.iter().map(|s| s.as_str()).collect();
+    sorted_excludes.sort_unstable();
+    for name in &sorted_excludes {
+        hasher.update(b"exclude:");
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+    }
+    let mut sorted_fn_excludes: Vec<&str> =
+        config.filename_exclude.iter().map(|s| s.as_str()).collect();
+    sorted_fn_excludes.sort_unstable();
+    for pattern in &sorted_fn_excludes {
+        hasher.update(b"fnexclude:");
+        hasher.update(pattern.as_bytes());
         hasher.update(b"\0");
     }
     hasher.update(format!("{:?}", config.library).as_bytes());
@@ -284,7 +306,7 @@ pub(crate) struct DownloadConfig {
     pub(crate) concurrent_downloads: usize,
     pub(crate) recent: Option<u32>,
     pub(crate) retry: RetryConfig,
-    pub(crate) skip_live_photos: bool,
+    pub(crate) live_photo_mode: LivePhotoMode,
     pub(crate) live_photo_size: AssetVersionSize,
     pub(crate) live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy,
     pub(crate) align_raw: RawTreatmentPolicy,
@@ -293,6 +315,8 @@ pub(crate) struct DownloadConfig {
     pub(crate) file_match_policy: FileMatchPolicy,
     pub(crate) force_size: bool,
     pub(crate) keep_unicode_in_filenames: bool,
+    /// Compiled glob patterns for filename exclusion.
+    pub(crate) filename_exclude: Vec<glob::Pattern>,
     /// Temp file suffix for partial downloads (e.g. `.kei-tmp`).
     pub(crate) temp_suffix: String,
     /// State database for tracking download progress.
@@ -302,6 +326,9 @@ pub(crate) struct DownloadConfig {
     pub(crate) retry_only: bool,
     /// Sync mode: full enumeration or incremental delta via syncToken.
     pub(crate) sync_mode: SyncMode,
+    /// Album name for `{album}` token in folder_structure. Set per-album when
+    /// processing albums individually.
+    pub(crate) album_name: Option<Arc<str>>,
 }
 
 impl std::fmt::Debug for DownloadConfig {
@@ -319,7 +346,7 @@ impl std::fmt::Debug for DownloadConfig {
             .field("concurrent_downloads", &self.concurrent_downloads)
             .field("recent", &self.recent)
             .field("retry", &self.retry)
-            .field("skip_live_photos", &self.skip_live_photos)
+            .field("live_photo_mode", &self.live_photo_mode)
             .field("live_photo_size", &self.live_photo_size)
             .field(
                 "live_photo_mov_filename_policy",
@@ -331,10 +358,12 @@ impl std::fmt::Debug for DownloadConfig {
             .field("file_match_policy", &self.file_match_policy)
             .field("force_size", &self.force_size)
             .field("keep_unicode_in_filenames", &self.keep_unicode_in_filenames)
+            .field("filename_exclude", &self.filename_exclude)
             .field("temp_suffix", &self.temp_suffix)
             .field("state_db", &self.state_db.is_some())
             .field("retry_only", &self.retry_only)
             .field("sync_mode", &self.sync_mode)
+            .field("album_name", &self.album_name)
             .finish()
     }
 }
@@ -579,11 +608,16 @@ fn extract_skip_candidates<'a>(
     asset: &'a crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) -> SmallVec<[(VersionSizeKey, &'a str); 2]> {
-    // Content type filters — same as filter_asset_to_tasks
+    // Content type filters -- same as filter_asset_to_tasks
     if config.skip_videos && asset.item_type() == Some(AssetItemType::Movie) {
         return SmallVec::new();
     }
     if config.skip_photos && asset.item_type() == Some(AssetItemType::Image) {
+        return SmallVec::new();
+    }
+
+    let is_live_photo = asset.is_live_photo();
+    if config.live_photo_mode == LivePhotoMode::Skip && is_live_photo {
         return SmallVec::new();
     }
 
@@ -604,21 +638,29 @@ fn extract_skip_candidates<'a>(
     let mut result = SmallVec::new();
 
     // Primary version (with fallback to Original, same logic as filter_asset_to_tasks)
+    // VideoOnly: skip primary image for live photos.
+    let skip_primary = config.live_photo_mode == LivePhotoMode::VideoOnly && is_live_photo;
     let get_version = |key: &AssetVersionSize| -> Option<&AssetVersion> {
         versions.iter().find(|(k, _)| k == key).map(|(_, v)| v)
     };
-    let primary = version_with_fallback(
-        &get_version,
-        config.size,
-        AssetVersionSize::Original,
-        config.force_size,
-    );
-    if let Some((v, effective_size)) = primary {
-        result.push((VersionSizeKey::from(effective_size), v.checksum.as_ref()));
+    if !skip_primary {
+        let primary = version_with_fallback(
+            &get_version,
+            config.size,
+            AssetVersionSize::Original,
+            config.force_size,
+        );
+        if let Some((v, effective_size)) = primary {
+            result.push((VersionSizeKey::from(effective_size), v.checksum.as_ref()));
+        }
     }
 
     // Live photo companion (with fallback to LiveOriginal, mirrors primary logic)
-    if !config.skip_live_photos && asset.item_type() == Some(AssetItemType::Image) {
+    if matches!(
+        config.live_photo_mode,
+        LivePhotoMode::Both | LivePhotoMode::VideoOnly
+    ) && asset.item_type() == Some(AssetItemType::Image)
+    {
         let live = version_with_fallback(
             &get_version,
             config.live_photo_size,
@@ -663,8 +705,12 @@ async fn pre_ensure_asset_dir(
     config: &DownloadConfig,
 ) {
     let created_local: DateTime<Local> = asset.created().with_timezone(&Local);
-    let parent =
-        paths::local_download_dir(&config.directory, &config.folder_structure, &created_local);
+    let parent = paths::local_download_dir(
+        &config.directory,
+        &config.folder_structure,
+        &created_local,
+        config.album_name.as_deref(),
+    );
     dir_cache.ensure_dir_async(&parent).await;
 }
 
@@ -687,6 +733,13 @@ fn filter_asset_to_tasks(
     }
     if config.skip_photos && asset.item_type() == Some(AssetItemType::Image) {
         tracing::debug!(asset_id = %asset.id(), "Skipping photo (skip_photos enabled)");
+        return SmallVec::new();
+    }
+
+    // LivePhotoMode::Skip: skip live photo assets entirely (both image and MOV)
+    let is_live_photo = asset.is_live_photo();
+    if config.live_photo_mode == LivePhotoMode::Skip && is_live_photo {
+        tracing::debug!(asset_id = %asset.id(), "Skipping live photo (live_photo_mode=skip)");
         return SmallVec::new();
     }
 
@@ -722,6 +775,17 @@ fn filter_asset_to_tasks(
         &fallback_filename
     };
 
+    // Filename exclusion: match raw filename against glob patterns before any
+    // cleaning or unicode stripping, so patterns match the original iCloud name.
+    if config
+        .filename_exclude
+        .iter()
+        .any(|p| p.matches_with(raw_filename, GLOB_CASE_INSENSITIVE))
+    {
+        tracing::debug!(asset_id = %asset.id(), filename = raw_filename, "Skipping (filename_exclude match)");
+        return SmallVec::new();
+    }
+
     // Strip non-ASCII characters unless --keep-unicode-in-filenames is set.
     // Matches Python's default behavior of calling remove_unicode_chars() on filenames.
     let base_filename = if config.keep_unicode_in_filenames {
@@ -755,7 +819,10 @@ fn filter_asset_to_tasks(
         Some((v, s)) => (Some(v), s),
         None => (None, config.size),
     };
-    if let Some(version) = version {
+    // VideoOnly mode: skip the primary image for live photos, only emit MOV.
+    let skip_primary = config.live_photo_mode == LivePhotoMode::VideoOnly && is_live_photo;
+
+    if let Some(version) = version.filter(|_| !skip_primary) {
         // Map the file extension based on the version's UTI asset_type
         let mapped_filename = paths::map_filename_extension(&base_filename, &version.asset_type);
 
@@ -779,6 +846,7 @@ fn filter_asset_to_tasks(
             &config.folder_structure,
             &created_local,
             &filename,
+            config.album_name.as_deref(),
         );
         // Determine the final download path, applying size-based deduplication if needed.
         // Check both on-disk files AND in-flight downloads (claimed_paths) to handle
@@ -813,6 +881,7 @@ fn filter_asset_to_tasks(
                             &config.folder_structure,
                             &created_local,
                             &dedup_filename,
+                            config.album_name.as_deref(),
                         );
                         // Use normalize() for lookup to avoid PathBuf clone
                         let dedup_key = NormalizedPath::normalize(&dedup_path);
@@ -864,6 +933,7 @@ fn filter_asset_to_tasks(
                             &config.folder_structure,
                             &created_local,
                             &dedup_filename,
+                            config.album_name.as_deref(),
                         );
                         // Use normalize() for lookup to avoid PathBuf clone
                         let dedup_key = NormalizedPath::normalize(&dedup_path);
@@ -911,10 +981,14 @@ fn filter_asset_to_tasks(
         }
     }
 
-    // Live photo MOV companion — only for images.
-    // Falls back from LiveAdjusted → LiveOriginal when adjusted isn't available
+    // Live photo MOV companion -- only for images.
+    // Falls back from LiveAdjusted -> LiveOriginal when adjusted isn't available
     // (mirrors the primary version fallback logic), unless --force-size is set.
-    if !config.skip_live_photos && asset.item_type() == Some(AssetItemType::Image) {
+    if matches!(
+        config.live_photo_mode,
+        LivePhotoMode::Both | LivePhotoMode::VideoOnly
+    ) && asset.item_type() == Some(AssetItemType::Image)
+    {
         let (live_version_opt, effective_live_size) = match version_with_fallback(
             &get_version,
             config.live_photo_size,
@@ -946,6 +1020,7 @@ fn filter_asset_to_tasks(
                 &config.folder_structure,
                 &created_local,
                 &mov_filename,
+                config.album_name.as_deref(),
             );
             // If the path already exists (on disk or claimed), it may be a different
             // file (e.g. a regular video) that collides with the live photo companion
@@ -967,6 +1042,7 @@ fn filter_asset_to_tasks(
                         &config.folder_structure,
                         &created_local,
                         &dedup_filename,
+                        config.album_name.as_deref(),
                     );
                     let dedup_key = NormalizedPath::normalize(&dedup_path);
                     if dir_cache.exists(&dedup_path)
@@ -994,6 +1070,7 @@ fn filter_asset_to_tasks(
                         &config.folder_structure,
                         &created_local,
                         &dedup_filename,
+                        config.album_name.as_deref(),
                     );
                     let dedup_key = NormalizedPath::normalize(&dedup_path);
                     if dir_cache.exists(&dedup_path)
@@ -2682,7 +2759,7 @@ mod tests {
             concurrent_downloads: 1,
             recent: None,
             retry: RetryConfig::default(),
-            skip_live_photos: false,
+            live_photo_mode: LivePhotoMode::Both,
             live_photo_size: AssetVersionSize::LiveOriginal,
             live_photo_mov_filename_policy: crate::types::LivePhotoMovFilenamePolicy::Suffix,
             align_raw: RawTreatmentPolicy::Unchanged,
@@ -2691,10 +2768,12 @@ mod tests {
             file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
             force_size: false,
             keep_unicode_in_filenames: false,
+            filename_exclude: Vec::new(),
             temp_suffix: ".kei-tmp".to_string(),
             state_db: None,
             retry_only: false,
             sync_mode: SyncMode::Full,
+            album_name: None,
         }
     }
 
@@ -2882,10 +2961,10 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_skips_live_photo_when_configured() {
+    fn test_filter_skips_live_photo_mov_when_image_only() {
         let asset = test_live_photo_asset();
         let mut config = test_config();
-        config.skip_live_photos = true;
+        config.live_photo_mode = LivePhotoMode::ImageOnly;
         let tasks = filter_asset_fresh(&asset, &config);
         assert_eq!(tasks.len(), 1);
         assert_eq!(&*tasks[0].url, "https://example.com/heic_orig");
@@ -3576,10 +3655,10 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_skip_candidates_skip_live_photos() {
+    fn test_extract_skip_candidates_image_only_mode() {
         let asset = test_live_photo_asset();
         let mut config = test_config();
-        config.skip_live_photos = true;
+        config.live_photo_mode = LivePhotoMode::ImageOnly;
         let candidates = extract_skip_candidates(&asset, &config);
         // Should still have the primary HEIC version, just not the MOV companion
         assert_eq!(candidates.len(), 1);
@@ -4393,14 +4472,14 @@ mod tests {
     // ── compute_config_hash equivalence ────────────────────────────────
 
     /// `compute_config_hash` includes enumeration-filter fields (albums,
-    /// library, skip_live_photos) that `hash_download_config` doesn't.
+    /// library, live_photo_mode) that `hash_download_config` doesn't.
     /// Verify it produces a valid hex hash and is deterministic.
     #[test]
     fn test_compute_config_hash_matches_hash_download_config() {
         use crate::config::Config;
         use crate::types::{
-            Domain, FileMatchPolicy, LivePhotoMovFilenamePolicy, LivePhotoSize, RawTreatmentPolicy,
-            VersionSize,
+            Domain, FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, LivePhotoSize,
+            RawTreatmentPolicy, VersionSize,
         };
         use secrecy::SecretString;
 
@@ -4414,6 +4493,8 @@ mod tests {
             cookie_directory: std::path::PathBuf::from("/tmp"),
             folder_structure: dl_config.folder_structure.clone(),
             albums: vec![],
+            exclude_albums: vec![],
+            filename_exclude: vec![],
             library: crate::config::LibrarySelection::Single("PrimarySync".into()),
             temp_suffix: dl_config.temp_suffix.clone(),
             skip_created_before: None,
@@ -4428,12 +4509,12 @@ mod tests {
             size: VersionSize::Original,
             live_photo_size: LivePhotoSize::Original,
             domain: Domain::Com,
+            live_photo_mode: LivePhotoMode::Both,
             live_photo_mov_filename_policy: LivePhotoMovFilenamePolicy::Suffix,
             align_raw: RawTreatmentPolicy::Unchanged,
             file_match_policy: FileMatchPolicy::NameSizeDedupWithSuffix,
             skip_videos: false,
             skip_photos: false,
-            skip_live_photos: false,
             force_size: false,
             set_exif_datetime: false,
             dry_run: false,
@@ -4445,7 +4526,7 @@ mod tests {
             save_password: false,
         };
 
-        // compute_config_hash is a superset (includes albums, library, skip_live_photos)
+        // compute_config_hash is a superset (includes albums, library, live_photo_mode)
         // so it won't match hash_download_config. Verify it's deterministic and valid hex.
         let hash1 = compute_config_hash(&app_config);
         let hash2 = compute_config_hash(&app_config);
@@ -4943,6 +5024,7 @@ mod tests {
             &config.folder_structure,
             &tasks[0].created_local,
             "photo.JPG",
+            config.album_name.as_deref(),
         );
         fs::create_dir_all(original_path.parent().unwrap()).unwrap();
         fs::write(&original_path, vec![0u8; 1000]).unwrap();
@@ -5464,6 +5546,87 @@ mod tests {
         assert!(
             filter_asset_fresh(&asset, &config).is_empty(),
             "force_size=true with missing Medium version should not fall back to Original"
+        );
+    }
+
+    // ── LivePhotoMode + filename_exclude filter tests ─────────────
+
+    #[test]
+    fn test_filter_skip_mode_skips_live_photo_entirely() {
+        let asset = test_live_photo_asset();
+        let mut config = test_config();
+        config.live_photo_mode = LivePhotoMode::Skip;
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert!(
+            tasks.is_empty(),
+            "Skip mode should produce no tasks for live photos"
+        );
+    }
+
+    #[test]
+    fn test_filter_video_only_mode_skips_primary_keeps_mov() {
+        let asset = test_live_photo_asset();
+        let mut config = test_config();
+        config.live_photo_mode = LivePhotoMode::VideoOnly;
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert_eq!(tasks.len(), 1);
+        // The task should be the MOV companion
+        assert!(tasks[0].download_path.to_str().unwrap().contains(".MOV"));
+    }
+
+    #[test]
+    fn test_filter_filename_exclude_matches() {
+        let asset = TestPhotoAsset::new("EXCL_1")
+            .filename("IMG_0001.AAE")
+            .build();
+        let mut config = test_config();
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert!(tasks.is_empty(), "*.AAE pattern should exclude AAE files");
+    }
+
+    #[test]
+    fn test_filter_filename_exclude_case_insensitive() {
+        let asset = TestPhotoAsset::new("EXCL_2").filename("Photo.aae").build();
+        let mut config = test_config();
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert!(
+            tasks.is_empty(),
+            "Pattern matching should be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_filter_filename_exclude_no_match_passes() {
+        let asset = TestPhotoAsset::new("EXCL_3")
+            .filename("IMG_0001.JPG")
+            .build();
+        let mut config = test_config();
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert!(!tasks.is_empty(), "Non-matching files should pass through");
+    }
+
+    #[test]
+    fn test_hash_changes_on_live_photo_mode() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.live_photo_mode = LivePhotoMode::Skip;
+        assert_ne!(
+            hash_download_config(&config1),
+            hash_download_config(&config2)
+        );
+    }
+
+    #[test]
+    fn test_hash_changes_on_filename_exclude() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        assert_ne!(
+            hash_download_config(&config1),
+            hash_download_config(&config2)
         );
     }
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -331,6 +331,8 @@ pub(crate) struct DownloadConfig {
     pub(crate) album_name: Option<Arc<str>>,
     /// Asset IDs to exclude (from `--exclude-album` without `--album`).
     pub(crate) exclude_asset_ids: Arc<FxHashSet<String>>,
+    /// Maximum download attempts per asset before giving up (0 = unlimited).
+    pub(crate) max_download_attempts: u32,
 }
 
 impl DownloadConfig {
@@ -389,6 +391,7 @@ impl std::fmt::Debug for DownloadConfig {
             .field("sync_mode", &self.sync_mode)
             .field("album_name", &self.album_name)
             .field("exclude_asset_ids_count", &self.exclude_asset_ids.len())
+            .field("max_download_attempts", &self.max_download_attempts)
             .finish()
     }
 }
@@ -437,6 +440,9 @@ struct DownloadContext {
     /// All asset IDs known to the state DB (any status). Used in retry-only mode
     /// to skip new assets that were never synced.
     known_ids: FxHashSet<Box<str>>,
+    /// Per-asset maximum download attempt count (from failed assets).
+    /// Used to skip assets that have exceeded `max_download_attempts`.
+    attempt_counts: FxHashMap<Box<str>, u32>,
 }
 
 impl DownloadContext {
@@ -484,10 +490,22 @@ impl DownloadContext {
             FxHashSet::default()
         };
 
+        let attempt_counts: FxHashMap<Box<str>, u32> = db
+            .get_attempt_counts()
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "Failed to load attempt counts from state DB");
+                Default::default()
+            })
+            .into_iter()
+            .map(|(id, count)| (id.into_boxed_str(), count))
+            .collect();
+
         Self {
             downloaded_ids,
             downloaded_checksums,
             known_ids,
+            attempt_counts,
         }
     }
 
@@ -2149,6 +2167,23 @@ where
                         producer_pb.inc(1);
                     } else {
                         for task in tasks {
+                            // Skip assets that have exceeded the retry limit.
+                            if config.max_download_attempts > 0 {
+                                if let Some(&attempts) =
+                                    download_ctx.attempt_counts.get(task.asset_id.as_ref())
+                                {
+                                    if attempts >= config.max_download_attempts {
+                                        tracing::warn!(
+                                            asset_id = %task.asset_id,
+                                            attempts,
+                                            max = config.max_download_attempts,
+                                            "Skipping asset: exceeded max download attempts"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+
                             if config.retry_only
                                 && !download_ctx.known_ids.contains(task.asset_id.as_ref())
                             {
@@ -2941,6 +2976,7 @@ mod tests {
             temp_suffix: ".kei-tmp".to_string(),
             state_db: None,
             retry_only: false,
+            max_download_attempts: 10,
             sync_mode: SyncMode::Full,
             album_name: None,
             exclude_asset_ids: Arc::new(FxHashSet::default()),
@@ -5353,6 +5389,9 @@ mod tests {
             &self,
         ) -> Result<HashMap<(String, String), String>, StateError> {
             unimplemented!()
+        }
+        async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+            Ok(HashMap::new())
         }
         async fn get_metadata(&self, _: &str) -> Result<Option<String>, StateError> {
             unimplemented!()

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -935,7 +935,12 @@ fn filter_asset_to_tasks(
                         if dir_cache.exists(&dedup_path)
                             || claimed_paths.contains_key(dedup_key.as_ref())
                         {
-                            None // deduped version already downloaded or claimed
+                            tracing::info!(
+                                asset_id = asset.id(),
+                                path = %dedup_path.display(),
+                                "Skipping asset: dedup path already exists"
+                            );
+                            None
                         } else {
                             tracing::debug!(
                                 path = %download_path.display(),
@@ -951,6 +956,11 @@ fn filter_asset_to_tasks(
                 FileMatchPolicy::NameId7 => {
                     // name-id7 policy adds asset ID to ALL filenames, not just collisions.
                     // If the file exists, it's already downloaded, skip.
+                    tracing::info!(
+                        asset_id = asset.id(),
+                        path = %download_path.display(),
+                        "Skipping asset: file exists (name-id7)"
+                    );
                     None
                 }
             }
@@ -987,7 +997,12 @@ fn filter_asset_to_tasks(
                         if dir_cache.exists(&dedup_path)
                             || claimed_paths.contains_key(dedup_key.as_ref())
                         {
-                            None // deduped version already downloaded or claimed
+                            tracing::info!(
+                                asset_id = asset.id(),
+                                path = %dedup_path.display(),
+                                "Skipping asset: dedup path already claimed in-flight"
+                            );
+                            None
                         } else {
                             tracing::debug!(
                                 path = %download_path.display(),
@@ -1000,7 +1015,14 @@ fn filter_asset_to_tasks(
                         }
                     }
                 }
-                FileMatchPolicy::NameId7 => None,
+                FileMatchPolicy::NameId7 => {
+                    tracing::info!(
+                        asset_id = asset.id(),
+                        path = %download_path.display(),
+                        "Skipping asset: path claimed in-flight (name-id7)"
+                    );
+                    None
+                }
             }
         } else {
             Some(download_path.clone())
@@ -1080,6 +1102,11 @@ fn filter_asset_to_tasks(
             let final_mov_path = if let Some(on_disk_size) = dir_cache.file_size(&mov_path) {
                 if on_disk_size == live_version.size {
                     // Same size — likely already downloaded, skip.
+                    tracing::info!(
+                        asset_id = asset.id(),
+                        path = %mov_path.display(),
+                        "Skipping live photo MOV: already exists with same size"
+                    );
                     None
                 } else {
                     // Collision with a different file — deduplicate.
@@ -1095,7 +1122,12 @@ fn filter_asset_to_tasks(
                     if dir_cache.exists(&dedup_path)
                         || claimed_paths.contains_key(dedup_key.as_ref())
                     {
-                        None // deduped version already downloaded or claimed
+                        tracing::info!(
+                            asset_id = asset.id(),
+                            path = %dedup_path.display(),
+                            "Skipping live photo MOV: dedup path already exists"
+                        );
+                        None
                     } else {
                         tracing::debug!(
                             path = %mov_path.display(),
@@ -1108,7 +1140,12 @@ fn filter_asset_to_tasks(
             } else if let Some(&claimed_size) = claimed_paths.get(mov_key.as_ref()) {
                 // Path is claimed by an in-flight download
                 if claimed_size == live_version.size {
-                    None // Same size, likely duplicate
+                    tracing::info!(
+                        asset_id = asset.id(),
+                        path = %mov_path.display(),
+                        "Skipping live photo MOV: in-flight with same size"
+                    );
+                    None
                 } else {
                     // Collision with in-flight download — deduplicate.
                     let dedup_filename = paths::insert_suffix(&mov_filename, asset.id());
@@ -1123,6 +1160,11 @@ fn filter_asset_to_tasks(
                     if dir_cache.exists(&dedup_path)
                         || claimed_paths.contains_key(dedup_key.as_ref())
                     {
+                        tracing::info!(
+                            asset_id = asset.id(),
+                            path = %dedup_path.display(),
+                            "Skipping live photo MOV: dedup path already claimed in-flight"
+                        );
                         None
                     } else {
                         tracing::debug!(
@@ -1815,17 +1857,19 @@ async fn download_photos_incremental(
         });
     }
 
-    let outcome =
-        if failed > 0 || pass_result.exif_failures > 0 || pass_result.state_write_failures > 0 {
-            for task in &pass_result.failed {
-                tracing::error!(path = %task.download_path.display(), "Download failed");
-            }
-            DownloadOutcome::PartialFailure {
-                failed_count: failed + pass_result.exif_failures + pass_result.state_write_failures,
-            }
-        } else {
-            DownloadOutcome::Success
-        };
+    let outcome = if failed > 0
+        || pass_result.exif_failures > 0
+        || pass_result.state_write_failures > 0
+    {
+        for task in &pass_result.failed {
+            tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), "Download failed");
+        }
+        DownloadOutcome::PartialFailure {
+            failed_count: failed + pass_result.exif_failures + pass_result.state_write_failures,
+        }
+    } else {
+        DownloadOutcome::Success
+    };
 
     Ok(SyncResult {
         outcome,
@@ -2108,6 +2152,10 @@ where
                             if config.retry_only
                                 && !download_ctx.known_ids.contains(task.asset_id.as_ref())
                             {
+                                tracing::debug!(
+                                    asset_id = %task.asset_id,
+                                    "Skipping new asset in retry-only mode"
+                                );
                                 continue;
                             }
 
@@ -2305,12 +2353,12 @@ where
                         }
                     } else {
                         pb.suspend(|| {
-                            tracing::error!(path = %task.download_path.display(), error = %e, "Download failed");
+                            tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), error = %e, "Download failed");
                         });
                     }
                 } else {
                     pb.suspend(|| {
-                        tracing::error!(path = %task.download_path.display(), error = %e, "Download failed");
+                        tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), error = %e, "Download failed");
                     });
                 }
                 if let Some(db) = &state_db {
@@ -2528,7 +2576,7 @@ async fn build_download_outcome(
     let total_failures = failed + state_write_failures + exif_failures;
     if total_failures > 0 {
         for task in &remaining_failed {
-            tracing::error!(path = %task.download_path.display(), "Download failed");
+            tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), "Download failed");
         }
         return Ok(DownloadOutcome::PartialFailure {
             failed_count: total_failures,
@@ -2641,7 +2689,7 @@ async fn run_download_pass(config: PassConfig<'_>, tasks: Vec<DownloadTask>) -> 
                     }
                 } else {
                     pb.suspend(|| {
-                        tracing::error!(path = %task.download_path.display(), error = %e, "Download failed");
+                        tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), error = %e, "Download failed");
                     });
                 }
                 if let Some(db) = &state_db {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -664,6 +664,19 @@ fn extract_skip_candidates<'a>(
         }
     }
 
+    // Filename exclusion -- mirrors filter_asset_to_tasks
+    if !config.filename_exclude.is_empty() {
+        if let Some(filename) = asset.filename() {
+            if config
+                .filename_exclude
+                .iter()
+                .any(|p| p.matches_with(filename, GLOB_CASE_INSENSITIVE))
+            {
+                return SmallVec::new();
+            }
+        }
+    }
+
     let versions = asset.versions();
     let mut result = SmallVec::new();
 
@@ -5836,6 +5849,132 @@ mod tests {
         assert_ne!(
             hash_download_config(&config1),
             hash_download_config(&config2)
+        );
+    }
+
+    // ── with_album_name tests ─────────────────────────────────────
+
+    #[test]
+    fn test_with_album_name_expands_album_token() {
+        let mut config = test_config();
+        config.folder_structure = "{album}/%Y/%m/%d".to_string();
+        let derived = config.with_album_name(Arc::from("Vacation"));
+        assert_eq!(derived.folder_structure, "Vacation/%Y/%m/%d");
+    }
+
+    #[test]
+    fn test_with_album_name_sets_album_name_field() {
+        let config = test_config();
+        assert!(config.album_name.is_none());
+        let derived = config.with_album_name(Arc::from("Favorites"));
+        assert_eq!(derived.album_name.as_deref(), Some("Favorites"));
+    }
+
+    #[test]
+    fn test_with_album_name_preserves_all_fields() {
+        let mut config = test_config();
+        config.folder_structure = "{album}/%Y".to_string();
+        config.skip_videos = true;
+        config.skip_photos = true;
+        config.live_photo_mode = LivePhotoMode::ImageOnly;
+        config.force_size = true;
+        config.keep_unicode_in_filenames = true;
+        config.dry_run = true;
+        config.set_exif_datetime = true;
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        config.temp_suffix = ".custom-tmp".to_string();
+        let derived = config.with_album_name(Arc::from("Test"));
+        assert!(derived.skip_videos);
+        assert!(derived.skip_photos);
+        assert_eq!(derived.live_photo_mode, LivePhotoMode::ImageOnly);
+        assert!(derived.force_size);
+        assert!(derived.keep_unicode_in_filenames);
+        assert!(derived.dry_run);
+        assert!(derived.set_exif_datetime);
+        assert_eq!(derived.filename_exclude.len(), 1);
+        assert_eq!(derived.temp_suffix, ".custom-tmp");
+        assert_eq!(derived.directory, config.directory);
+    }
+
+    #[test]
+    fn test_with_album_name_empty_name_leaves_token_stripped() {
+        let mut config = test_config();
+        config.folder_structure = "{album}/%Y/%m/%d".to_string();
+        let derived = config.with_album_name(Arc::from(""));
+        // Empty album name should strip the {album}/ prefix
+        assert!(!derived.folder_structure.contains("{album}"));
+        assert!(derived.album_name.as_deref() == Some(""));
+    }
+
+    #[test]
+    fn test_with_album_name_no_token_in_structure() {
+        let config = test_config(); // folder_structure = "%Y/%m/%d"
+        let derived = config.with_album_name(Arc::from("MyAlbum"));
+        // No {album} token, so structure should be unchanged
+        assert_eq!(derived.folder_structure, "%Y/%m/%d");
+        assert_eq!(derived.album_name.as_deref(), Some("MyAlbum"));
+    }
+
+    #[test]
+    fn test_with_album_name_sanitizes_special_chars() {
+        let mut config = test_config();
+        config.folder_structure = "{album}/%Y".to_string();
+        let derived = config.with_album_name(Arc::from("My/Album"));
+        // The expand_album_token sanitizes path separators
+        assert!(
+            !derived.folder_structure.contains('/')
+                || !derived.folder_structure.starts_with("My/Album")
+        );
+    }
+
+    // ── extract_skip_candidates: filename_exclude ─────────────────
+
+    #[test]
+    fn test_extract_skip_candidates_filename_exclude_matches() {
+        let asset = TestPhotoAsset::new("TEST_1").filename("photo.AAE").build();
+        let mut config = test_config();
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        assert!(
+            extract_skip_candidates(&asset, &config).is_empty(),
+            "filename_exclude should filter in extract_skip_candidates"
+        );
+    }
+
+    #[test]
+    fn test_extract_skip_candidates_filename_exclude_no_match_passes() {
+        let asset = TestPhotoAsset::new("TEST_1").build(); // filename = "test_photo.jpg"
+        let mut config = test_config();
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        assert!(
+            !extract_skip_candidates(&asset, &config).is_empty(),
+            "non-matching filename should pass through"
+        );
+    }
+
+    #[test]
+    fn test_extract_skip_candidates_filename_exclude_case_insensitive() {
+        let asset = TestPhotoAsset::new("TEST_1").filename("photo.aae").build();
+        let mut config = test_config();
+        config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
+        assert!(
+            extract_skip_candidates(&asset, &config).is_empty(),
+            "filename_exclude should be case-insensitive"
+        );
+    }
+
+    // ── compute_config_hash: filename_exclude ─────────────────────
+
+    #[test]
+    fn test_compute_config_hash_different_filename_exclude() {
+        let tmp = TempDir::new().unwrap();
+        let a = build_config_with(tmp.path(), "/photos", |_| {});
+        let b = build_config_with(tmp.path(), "/photos", |s| {
+            s.filename_exclude = vec!["*.AAE".to_string()];
+        });
+        assert_ne!(
+            compute_config_hash(&a),
+            compute_config_hash(&b),
+            "changing filename_exclude should change the config hash"
         );
     }
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -329,6 +329,26 @@ pub(crate) struct DownloadConfig {
     /// Album name for `{album}` token in folder_structure. Set per-album when
     /// processing albums individually.
     pub(crate) album_name: Option<Arc<str>>,
+    /// Asset IDs to exclude (from `--exclude-album` without `--album`).
+    pub(crate) exclude_asset_ids: Arc<FxHashSet<String>>,
+}
+
+impl DownloadConfig {
+    /// Clone this config with a different `album_name`, for per-album processing
+    /// when `{album}` is in `folder_structure`.
+    fn with_album_name(&self, name: Arc<str>) -> Self {
+        Self {
+            album_name: Some(name),
+            directory: self.directory.clone(),
+            folder_structure: self.folder_structure.clone(),
+            filename_exclude: self.filename_exclude.clone(),
+            temp_suffix: self.temp_suffix.clone(),
+            state_db: self.state_db.clone(),
+            sync_mode: self.sync_mode.clone(),
+            exclude_asset_ids: Arc::clone(&self.exclude_asset_ids),
+            ..*self
+        }
+    }
 }
 
 impl std::fmt::Debug for DownloadConfig {
@@ -364,6 +384,7 @@ impl std::fmt::Debug for DownloadConfig {
             .field("retry_only", &self.retry_only)
             .field("sync_mode", &self.sync_mode)
             .field("album_name", &self.album_name)
+            .field("exclude_asset_ids_count", &self.exclude_asset_ids.len())
             .finish()
     }
 }
@@ -608,6 +629,11 @@ fn extract_skip_candidates<'a>(
     asset: &'a crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
 ) -> SmallVec<[(VersionSizeKey, &'a str); 2]> {
+    // Excluded album assets -- same as filter_asset_to_tasks
+    if config.exclude_asset_ids.contains(asset.id()) {
+        return SmallVec::new();
+    }
+
     // Content type filters -- same as filter_asset_to_tasks
     if config.skip_videos && asset.item_type() == Some(AssetItemType::Movie) {
         return SmallVec::new();
@@ -727,6 +753,10 @@ fn filter_asset_to_tasks(
     claimed_paths: &mut FxHashMap<NormalizedPath, u64>,
     dir_cache: &mut paths::DirCache,
 ) -> SmallVec<[DownloadTask; 2]> {
+    if config.exclude_asset_ids.contains(asset.id()) {
+        tracing::debug!(asset_id = %asset.id(), "Skipping (excluded album asset)");
+        return SmallVec::new();
+    }
     if config.skip_videos && asset.item_type() == Some(AssetItemType::Movie) {
         tracing::debug!(asset_id = %asset.id(), "Skipping video (skip_videos enabled)");
         return SmallVec::new();
@@ -1405,35 +1435,7 @@ async fn download_photos_full_with_token(
             if shutdown_token.is_cancelled() {
                 break;
             }
-            let album_config = Arc::new(DownloadConfig {
-                album_name: Some(album.name.clone()),
-                directory: config.directory.clone(),
-                folder_structure: config.folder_structure.clone(),
-                size: config.size,
-                skip_videos: config.skip_videos,
-                skip_photos: config.skip_photos,
-                skip_created_before: config.skip_created_before,
-                skip_created_after: config.skip_created_after,
-                set_exif_datetime: config.set_exif_datetime,
-                dry_run: config.dry_run,
-                concurrent_downloads: config.concurrent_downloads,
-                recent: config.recent,
-                retry: config.retry,
-                live_photo_mode: config.live_photo_mode,
-                live_photo_size: config.live_photo_size,
-                live_photo_mov_filename_policy: config.live_photo_mov_filename_policy,
-                align_raw: config.align_raw,
-                no_progress_bar: config.no_progress_bar,
-                only_print_filenames: config.only_print_filenames,
-                file_match_policy: config.file_match_policy,
-                force_size: config.force_size,
-                keep_unicode_in_filenames: config.keep_unicode_in_filenames,
-                filename_exclude: config.filename_exclude.clone(),
-                temp_suffix: config.temp_suffix.clone(),
-                state_db: config.state_db.clone(),
-                retry_only: config.retry_only,
-                sync_mode: config.sync_mode.clone(),
-            });
+            let album_config = Arc::new(config.with_album_name(album.name.clone()));
 
             let (stream, token_rx) = album.photo_stream_with_token(
                 config.recent,
@@ -1446,7 +1448,7 @@ async fn download_photos_full_with_token(
                 download_client,
                 stream,
                 &album_config,
-                count,
+                total,
                 shutdown_token.clone(),
             )
             .await?;
@@ -1547,9 +1549,12 @@ async fn download_photos_incremental(
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
+    let uses_album_token = config.folder_structure.contains("{album}");
 
-    // Collect change events from all albums, counting and filtering in a single pass
-    let mut downloadable_assets: Vec<PhotoAsset> = Vec::new();
+    // Collect change events from all albums, counting and filtering in a single pass.
+    // Each asset is paired with its source album name so that {album} token
+    // expansion works correctly in the incremental path.
+    let mut downloadable_assets: Vec<(PhotoAsset, Arc<str>)> = Vec::new();
     let mut sync_token: Option<String> = None;
     let mut created_count = 0u64;
     let mut soft_deleted_count = 0u64;
@@ -1571,7 +1576,7 @@ async fn download_photos_incremental(
                 ChangeReason::Created => {
                     created_count += 1;
                     if let Some(asset) = event.asset {
-                        downloadable_assets.push(asset);
+                        downloadable_assets.push((asset, Arc::clone(&album.name)));
                     }
                 }
                 ChangeReason::SoftDeleted => {
@@ -1637,16 +1642,27 @@ async fn download_photos_incremental(
         DownloadContext::default()
     };
 
-    // Convert assets to download tasks, using state DB fast-skip where possible
+    // Convert assets to download tasks, using state DB fast-skip where possible.
+    // When {album} is in folder_structure, create per-album configs so the album
+    // name is threaded into path expansion (mirrors full sync behaviour).
     let mut tasks: Vec<DownloadTask> = Vec::new();
     let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
     let mut dir_cache = paths::DirCache::new();
     let mut skipped_by_state = 0usize;
+    let mut album_configs: FxHashMap<Arc<str>, Arc<DownloadConfig>> = FxHashMap::default();
 
-    for asset in &downloadable_assets {
+    for (asset, album_name) in &downloadable_assets {
+        let effective_config: &Arc<DownloadConfig> = if uses_album_token {
+            album_configs
+                .entry(Arc::clone(album_name))
+                .or_insert_with(|| Arc::new(config.with_album_name(Arc::clone(album_name))))
+        } else {
+            config
+        };
+
         // Fast-skip: if state DB confirms all versions are already downloaded
         // with matching checksums, skip the filesystem check entirely.
-        let candidates = extract_skip_candidates(asset, config);
+        let candidates = extract_skip_candidates(asset, effective_config);
         if !candidates.is_empty()
             && candidates.iter().all(|&(vs, cs)| {
                 matches!(
@@ -1659,8 +1675,9 @@ async fn download_photos_incremental(
             continue;
         }
 
-        pre_ensure_asset_dir(&mut dir_cache, asset, config).await;
-        let asset_tasks = filter_asset_to_tasks(asset, config, &mut claimed_paths, &mut dir_cache);
+        pre_ensure_asset_dir(&mut dir_cache, asset, effective_config).await;
+        let asset_tasks =
+            filter_asset_to_tasks(asset, effective_config, &mut claimed_paths, &mut dir_cache);
 
         // Upsert state records so mark_downloaded/mark_failed can find them.
         // Without this, the UPDATE in mark_downloaded matches 0 rows and the
@@ -2851,6 +2868,7 @@ mod tests {
             retry_only: false,
             sync_mode: SyncMode::Full,
             album_name: None,
+            exclude_asset_ids: Arc::new(FxHashSet::default()),
         }
     }
 
@@ -5683,6 +5701,50 @@ mod tests {
         config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
         let tasks = filter_asset_fresh(&asset, &config);
         assert!(!tasks.is_empty(), "Non-matching files should pass through");
+    }
+
+    // ── exclude_asset_ids filter tests ─────────────────────────────
+
+    #[test]
+    fn test_filter_exclude_asset_ids_blocks_matching() {
+        let asset = TestPhotoAsset::new("EXCLUDED_1")
+            .filename("IMG_0001.JPG")
+            .build();
+        let mut config = test_config();
+        let mut ids = FxHashSet::default();
+        ids.insert("EXCLUDED_1".to_string());
+        config.exclude_asset_ids = Arc::new(ids);
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert!(tasks.is_empty(), "Asset in exclude set should be filtered");
+    }
+
+    #[test]
+    fn test_filter_exclude_asset_ids_passes_non_matching() {
+        let asset = TestPhotoAsset::new("KEEP_1")
+            .filename("IMG_0002.JPG")
+            .build();
+        let mut config = test_config();
+        let mut ids = FxHashSet::default();
+        ids.insert("OTHER_ID".to_string());
+        config.exclude_asset_ids = Arc::new(ids);
+        let tasks = filter_asset_fresh(&asset, &config);
+        assert!(!tasks.is_empty(), "Asset not in exclude set should pass");
+    }
+
+    #[test]
+    fn test_skip_candidates_exclude_asset_ids() {
+        let asset = TestPhotoAsset::new("SKIP_EXCL_1")
+            .filename("IMG_0001.JPG")
+            .build();
+        let mut config = test_config();
+        let mut ids = FxHashSet::default();
+        ids.insert("SKIP_EXCL_1".to_string());
+        config.exclude_asset_ids = Arc::new(ids);
+        let candidates = extract_skip_candidates(&asset, &config);
+        assert!(
+            candidates.is_empty(),
+            "extract_skip_candidates should return empty for excluded assets"
+        );
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1374,6 +1374,7 @@ async fn download_photos_full_with_token(
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
+    let uses_album_token = config.folder_structure.contains("{album}");
 
     // Build token-aware streams for each album
     let mut album_counts: Vec<u64> = Vec::with_capacity(albums.len());
@@ -1385,33 +1386,109 @@ async fn download_photos_full_with_token(
         total = total.min(u64::from(recent));
     }
 
-    // Create photo_stream_with_token for each album and collect token receivers
-    let mut token_receivers = Vec::with_capacity(albums.len());
-    let streams: Vec<_> = albums
-        .iter()
-        .zip(&album_counts)
-        .map(|(album, &count)| {
+    // When {album} is in folder_structure, process each album separately so that
+    // the album name can be threaded into path expansion. Otherwise, merge all
+    // album streams for maximum download concurrency across albums.
+    let (streaming_result, token_receivers) = if uses_album_token {
+        let mut combined_result = StreamingResult {
+            downloaded: 0,
+            exif_failures: 0,
+            failed: Vec::new(),
+            auth_errors: 0,
+            state_write_failures: 0,
+            enumeration_errors: 0,
+            assets_seen: 0,
+        };
+        let mut token_receivers = Vec::with_capacity(albums.len());
+
+        for (album, &count) in albums.iter().zip(&album_counts) {
+            if shutdown_token.is_cancelled() {
+                break;
+            }
+            let album_config = Arc::new(DownloadConfig {
+                album_name: Some(album.name.clone()),
+                directory: config.directory.clone(),
+                folder_structure: config.folder_structure.clone(),
+                size: config.size,
+                skip_videos: config.skip_videos,
+                skip_photos: config.skip_photos,
+                skip_created_before: config.skip_created_before,
+                skip_created_after: config.skip_created_after,
+                set_exif_datetime: config.set_exif_datetime,
+                dry_run: config.dry_run,
+                concurrent_downloads: config.concurrent_downloads,
+                recent: config.recent,
+                retry: config.retry,
+                live_photo_mode: config.live_photo_mode,
+                live_photo_size: config.live_photo_size,
+                live_photo_mov_filename_policy: config.live_photo_mov_filename_policy,
+                align_raw: config.align_raw,
+                no_progress_bar: config.no_progress_bar,
+                only_print_filenames: config.only_print_filenames,
+                file_match_policy: config.file_match_policy,
+                force_size: config.force_size,
+                keep_unicode_in_filenames: config.keep_unicode_in_filenames,
+                filename_exclude: config.filename_exclude.clone(),
+                temp_suffix: config.temp_suffix.clone(),
+                state_db: config.state_db.clone(),
+                retry_only: config.retry_only,
+                sync_mode: config.sync_mode.clone(),
+            });
+
             let (stream, token_rx) = album.photo_stream_with_token(
                 config.recent,
                 Some(count),
                 config.concurrent_downloads,
             );
             token_receivers.push(token_rx);
-            stream
-        })
-        .collect();
 
-    let combined = stream::select_all(streams);
+            let result = stream_and_download_from_stream(
+                download_client,
+                stream,
+                &album_config,
+                count,
+                shutdown_token.clone(),
+            )
+            .await?;
 
-    // Run the streaming download pipeline with the combined stream
-    let streaming_result = stream_and_download_from_stream(
-        download_client,
-        combined,
-        config,
-        total,
-        shutdown_token.clone(),
-    )
-    .await?;
+            combined_result.downloaded += result.downloaded;
+            combined_result.exif_failures += result.exif_failures;
+            combined_result.failed.extend(result.failed);
+            combined_result.auth_errors += result.auth_errors;
+            combined_result.state_write_failures += result.state_write_failures;
+            combined_result.enumeration_errors += result.enumeration_errors;
+            combined_result.assets_seen += result.assets_seen;
+        }
+
+        (combined_result, token_receivers)
+    } else {
+        let mut token_receivers = Vec::with_capacity(albums.len());
+        let streams: Vec<_> = albums
+            .iter()
+            .zip(&album_counts)
+            .map(|(album, &count)| {
+                let (stream, token_rx) = album.photo_stream_with_token(
+                    config.recent,
+                    Some(count),
+                    config.concurrent_downloads,
+                );
+                token_receivers.push(token_rx);
+                stream
+            })
+            .collect();
+
+        let combined = stream::select_all(streams);
+        let result = stream_and_download_from_stream(
+            download_client,
+            combined,
+            config,
+            total,
+            shutdown_token.clone(),
+        )
+        .await?;
+
+        (result, token_receivers)
+    };
 
     // Warn if enumeration saw significantly fewer assets than the API reported.
     // This catches silent pagination truncation, dropped pages, or API hiccups

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -6,6 +6,34 @@ use base64::Engine;
 use chrono::{DateTime, Local};
 use rustc_hash::FxHashMap;
 
+/// Strip the legacy Python-style `{:%Y/%m/%d}` wrapper, returning the inner
+/// format string. Returns the input unchanged if the wrapper is absent.
+fn strip_python_wrapper(folder_structure: &str) -> &str {
+    if folder_structure.starts_with("{:") && folder_structure.ends_with('}') {
+        &folder_structure[2..folder_structure.len() - 1]
+    } else {
+        folder_structure
+    }
+}
+
+/// Expand the `{album}` token in a folder structure format string.
+///
+/// Strips the Python-style wrapper, sanitizes the album name as a path
+/// component, escapes `%` for chrono strftime, and replaces `{album}`.
+/// Returns the original `folder_structure` (wrapper-stripped) unchanged if
+/// `{album}` is absent.
+pub(crate) fn expand_album_token(folder_structure: &str, album_name: Option<&str>) -> String {
+    let format_str = strip_python_wrapper(folder_structure);
+    if !format_str.contains("{album}") {
+        return format_str.to_string();
+    }
+    let safe_name = album_name
+        .filter(|n| !n.is_empty())
+        .map(|n| sanitize_path_component(n).replace('%', "%%"))
+        .unwrap_or_default();
+    format_str.replace("{album}", &safe_name)
+}
+
 /// Build the date-based parent directory for a photo asset (without filename).
 ///
 /// `folder_structure` is a strftime format string such as `"%Y/%m/%d"`. The
@@ -22,33 +50,10 @@ pub(crate) fn local_download_dir(
         return directory.to_path_buf();
     }
 
-    // Extract format from Python-style {:%Y/%m/%d} wrapper if present
-    let format_str = if folder_structure.starts_with("{:") && folder_structure.ends_with('}') {
-        &folder_structure[2..folder_structure.len() - 1]
-    } else {
-        folder_structure
-    };
-
-    // Expand {album} token before strftime, sanitizing the album name as a
-    // path component to prevent traversal. Empty/missing album names produce
-    // an empty replacement so the {album} path component is skipped.
-    // Percent signs in album names are escaped to %% so chrono's strftime
-    // treats them as literal '%' rather than format specifiers.
-    let expanded;
-    let strftime_input = if format_str.contains("{album}") {
-        let safe_name = album_name
-            .filter(|n| !n.is_empty())
-            .map(sanitize_path_component)
-            .map(|s| s.replace('%', "%%"))
-            .unwrap_or_default();
-        expanded = format_str.replace("{album}", &safe_name);
-        expanded.as_str()
-    } else {
-        format_str
-    };
+    let expanded = expand_album_token(folder_structure, album_name);
 
     // Use chrono's strftime for full format token support (%Y, %m, %d, %B, etc.)
-    let date_path = created_date.format(strftime_input).to_string();
+    let date_path = created_date.format(&expanded).to_string();
 
     // Split on "/" and join as path components to handle cross-platform paths.
     // Each component is sanitized to prevent path traversal (e.g. "../../etc").

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -3,17 +3,20 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use base64::Engine;
-use chrono::{DateTime, Datelike, Local, Timelike};
+use chrono::{DateTime, Local};
 use rustc_hash::FxHashMap;
 
 /// Build the date-based parent directory for a photo asset (without filename).
 ///
-/// `folder_structure` is a date format string such as `"{:%Y/%m/%d}"`. The
-/// special value `"none"` (case-insensitive) disables date-based folders.
+/// `folder_structure` is a strftime format string such as `"%Y/%m/%d"`. The
+/// legacy Python-style `"{:%Y/%m/%d}"` wrapper is also accepted. The custom
+/// `{album}` token is expanded to the album name before strftime processing.
+/// The special value `"none"` (case-insensitive) disables date-based folders.
 pub(crate) fn local_download_dir(
     directory: &Path,
     folder_structure: &str,
     created_date: &DateTime<Local>,
+    album_name: Option<&str>,
 ) -> PathBuf {
     if folder_structure.eq_ignore_ascii_case("none") {
         return directory.to_path_buf();
@@ -26,12 +29,21 @@ pub(crate) fn local_download_dir(
         folder_structure
     };
 
-    // Build date path in a single allocation by scanning for % tokens
-    // and replacing them inline, avoiding 6 intermediate String allocations.
-    let date_path = expand_date_format(format_str, created_date);
+    // Expand {album} token before strftime, sanitizing the album name as a
+    // path component to prevent traversal.
+    let expanded;
+    let strftime_input = if format_str.contains("{album}") {
+        let safe_name = album_name.map(sanitize_path_component).unwrap_or_default();
+        expanded = format_str.replace("{album}", &safe_name);
+        expanded.as_str()
+    } else {
+        format_str
+    };
+
+    // Use chrono's strftime for full format token support (%Y, %m, %d, %B, etc.)
+    let date_path = created_date.format(strftime_input).to_string();
 
     // Split on "/" and join as path components to handle cross-platform paths.
-    // This converts "{:%Y/%m/%d}" format like "2025/01/15" into proper PathBuf.
     // Each component is sanitized to prevent path traversal (e.g. "../../etc").
     let mut path = directory.to_path_buf();
     for component in date_path.split('/') {
@@ -44,59 +56,19 @@ pub(crate) fn local_download_dir(
 
 /// Build the local download path for a photo asset.
 ///
-/// `folder_structure` is a date format string such as `"{:%Y/%m/%d}"`. The
-/// special value `"none"` (case-insensitive) disables date-based folders.
+/// `folder_structure` is a strftime format string such as `"%Y/%m/%d"`. The
+/// legacy Python-style `"{:%Y/%m/%d}"` wrapper is also accepted. The custom
+/// `{album}` token is expanded to the album name before strftime processing.
+/// The special value `"none"` (case-insensitive) disables date-based folders.
 pub(crate) fn local_download_path(
     directory: &Path,
     folder_structure: &str,
     created_date: &DateTime<Local>,
     filename: &str,
+    album_name: Option<&str>,
 ) -> PathBuf {
-    local_download_dir(directory, folder_structure, created_date).join(clean_filename(filename))
-}
-
-/// Expand date format tokens (%Y, %m, %d, %H, %M, %S) in a single pass.
-///
-/// Avoids the 6 intermediate String allocations from chained `.replace()` calls.
-fn expand_date_format(format_str: &str, date: &DateTime<Local>) -> String {
-    let mut result = String::with_capacity(format_str.len() + 8);
-    let mut chars = format_str.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if c == '%' {
-            match chars.peek() {
-                Some('Y') => {
-                    chars.next();
-                    let _ = write!(result, "{:04}", date.year());
-                }
-                Some('m') => {
-                    chars.next();
-                    let _ = write!(result, "{:02}", date.month());
-                }
-                Some('d') => {
-                    chars.next();
-                    let _ = write!(result, "{:02}", date.day());
-                }
-                Some('H') => {
-                    chars.next();
-                    let _ = write!(result, "{:02}", date.hour());
-                }
-                Some('M') => {
-                    chars.next();
-                    let _ = write!(result, "{:02}", date.minute());
-                }
-                Some('S') => {
-                    chars.next();
-                    let _ = write!(result, "{:02}", date.second());
-                }
-                _ => result.push(c), // Unknown token, keep the %
-            }
-        } else {
-            result.push(c);
-        }
-    }
-
-    result
+    local_download_dir(directory, folder_structure, created_date, album_name)
+        .join(clean_filename(filename))
 }
 
 /// Maximum filename length in bytes for common filesystems (ext4, APFS, NTFS).
@@ -985,7 +957,7 @@ mod tests {
         let date = chrono::Local
             .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
             .unwrap();
-        let result = local_download_path(dir, "none", &date, "IMG_0001.JPG");
+        let result = local_download_path(dir, "none", &date, "IMG_0001.JPG", None);
         assert_eq!(result, PathBuf::from("/photos/IMG_0001.JPG"));
     }
 
@@ -996,11 +968,11 @@ mod tests {
             .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
             .unwrap();
         assert_eq!(
-            local_download_path(dir, "NONE", &date, "photo.jpg"),
+            local_download_path(dir, "NONE", &date, "photo.jpg", None),
             PathBuf::from("/photos/photo.jpg")
         );
         assert_eq!(
-            local_download_path(dir, "None", &date, "photo.jpg"),
+            local_download_path(dir, "None", &date, "photo.jpg", None),
             PathBuf::from("/photos/photo.jpg")
         );
     }
@@ -1011,7 +983,7 @@ mod tests {
         let date = chrono::Local
             .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
             .unwrap();
-        let result = local_download_path(dir, "{:%Y/%m/%d}", &date, "IMG_0001.JPG");
+        let result = local_download_path(dir, "{:%Y/%m/%d}", &date, "IMG_0001.JPG", None);
         assert_eq!(result, PathBuf::from("/photos/2025/06/15/IMG_0001.JPG"));
     }
 
@@ -1020,7 +992,7 @@ mod tests {
         // Format string without {: ... } wrapper
         let dir = Path::new("/photos");
         let date = chrono::Local.with_ymd_and_hms(2025, 1, 5, 9, 5, 3).unwrap();
-        let result = local_download_path(dir, "%Y-%m-%d", &date, "photo.jpg");
+        let result = local_download_path(dir, "%Y-%m-%d", &date, "photo.jpg", None);
         assert_eq!(result, PathBuf::from("/photos/2025-01-05/photo.jpg"));
     }
 
@@ -1030,31 +1002,11 @@ mod tests {
         let date = chrono::Local
             .with_ymd_and_hms(2025, 12, 31, 23, 59, 59)
             .unwrap();
-        let result = local_download_path(dir, "{:%Y/%m/%d/%H-%M-%S}", &date, "photo.jpg");
+        let result = local_download_path(dir, "{:%Y/%m/%d/%H-%M-%S}", &date, "photo.jpg", None);
         assert_eq!(
             result,
             PathBuf::from("/photos/2025/12/31/23-59-59/photo.jpg")
         );
-    }
-
-    #[test]
-    fn test_expand_date_format_unknown_token_preserved() {
-        // Unknown % tokens should keep the % sign
-        let date = chrono::Local
-            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
-            .unwrap();
-        let result = expand_date_format("%Y-%Z-%d", &date);
-        // %Z is unknown, so "%" is kept, then "Z" is processed as literal
-        assert_eq!(result, "2025-%Z-15");
-    }
-
-    #[test]
-    fn test_expand_date_format_trailing_percent() {
-        let date = chrono::Local
-            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
-            .unwrap();
-        let result = expand_date_format("%Y/%m/%d%", &date);
-        assert_eq!(result, "2025/06/15%");
     }
 
     #[test]
@@ -1069,7 +1021,7 @@ mod tests {
         let date = chrono::Local
             .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
             .unwrap();
-        let result = local_download_path(dir, "none", &date, "photo:1.jpg");
+        let result = local_download_path(dir, "none", &date, "photo:1.jpg", None);
         assert_eq!(result, PathBuf::from("/photos/photo_1.jpg"));
     }
 
@@ -1082,15 +1034,15 @@ mod tests {
 
         // ".." components are neutralised — path stays inside directory
         assert_eq!(
-            local_download_path(dir, "../../etc", &date, "passwd"),
+            local_download_path(dir, "../../etc", &date, "passwd", None),
             PathBuf::from("/photos/_/_/etc/passwd")
         );
         assert_eq!(
-            local_download_path(dir, "../../%Y", &date, "photo.jpg"),
+            local_download_path(dir, "../../%Y", &date, "photo.jpg", None),
             PathBuf::from("/photos/_/_/2025/photo.jpg")
         );
         assert_eq!(
-            local_download_path(dir, "{:../../%Y}", &date, "photo.jpg"),
+            local_download_path(dir, "{:../../%Y}", &date, "photo.jpg", None),
             PathBuf::from("/photos/_/_/2025/photo.jpg")
         );
     }
@@ -1217,5 +1169,67 @@ mod tests {
     fn test_clean_filename_tab() {
         // Tab is a control character and gets replaced with '_'
         assert_eq!(clean_filename("photo\tname.jpg"), "photo_name.jpg");
+    }
+
+    #[test]
+    fn test_strftime_month_name_token() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 1, 15, 10, 0, 0)
+            .unwrap();
+        let result = local_download_path(dir, "%Y/%B/%d", &date, "photo.jpg", None);
+        assert_eq!(result, PathBuf::from("/photos/2025/January/15/photo.jpg"));
+    }
+
+    #[test]
+    fn test_album_token_expansion() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        let result = local_download_path(
+            dir,
+            "{album}/%Y/%m/%d",
+            &date,
+            "photo.jpg",
+            Some("Vacation"),
+        );
+        assert_eq!(
+            result,
+            PathBuf::from("/photos/Vacation/2025/06/15/photo.jpg")
+        );
+    }
+
+    #[test]
+    fn test_album_token_none_becomes_empty() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        let result = local_download_path(dir, "{album}/%Y/%m/%d", &date, "photo.jpg", None);
+        // Empty album name means the {album} component is empty, so it's skipped
+        assert_eq!(result, PathBuf::from("/photos/2025/06/15/photo.jpg"));
+    }
+
+    #[test]
+    fn test_album_token_sanitized() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some("../etc"));
+        // Path traversal in album name is neutralized
+        assert!(!result.to_str().unwrap().contains("../"));
+    }
+
+    #[test]
+    fn test_no_album_token_ignores_album_name() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        // Without {album} in format, album_name is ignored
+        let result = local_download_path(dir, "%Y/%m/%d", &date, "photo.jpg", Some("Vacation"));
+        assert_eq!(result, PathBuf::from("/photos/2025/06/15/photo.jpg"));
     }
 }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -30,10 +30,14 @@ pub(crate) fn local_download_dir(
     };
 
     // Expand {album} token before strftime, sanitizing the album name as a
-    // path component to prevent traversal.
+    // path component to prevent traversal. Empty/missing album names produce
+    // an empty replacement so the {album} path component is skipped.
     let expanded;
     let strftime_input = if format_str.contains("{album}") {
-        let safe_name = album_name.map(sanitize_path_component).unwrap_or_default();
+        let safe_name = album_name
+            .filter(|n| !n.is_empty())
+            .map(sanitize_path_component)
+            .unwrap_or_default();
         expanded = format_str.replace("{album}", &safe_name);
         expanded.as_str()
     } else {
@@ -1208,6 +1212,17 @@ mod tests {
             .unwrap();
         let result = local_download_path(dir, "{album}/%Y/%m/%d", &date, "photo.jpg", None);
         // Empty album name means the {album} component is empty, so it's skipped
+        assert_eq!(result, PathBuf::from("/photos/2025/06/15/photo.jpg"));
+    }
+
+    #[test]
+    fn test_album_token_empty_string_skipped() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        // The "All Photos" album has name "" -- should behave like None
+        let result = local_download_path(dir, "{album}/%Y/%m/%d", &date, "photo.jpg", Some(""));
         assert_eq!(result, PathBuf::from("/photos/2025/06/15/photo.jpg"));
     }
 

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -32,11 +32,14 @@ pub(crate) fn local_download_dir(
     // Expand {album} token before strftime, sanitizing the album name as a
     // path component to prevent traversal. Empty/missing album names produce
     // an empty replacement so the {album} path component is skipped.
+    // Percent signs in album names are escaped to %% so chrono's strftime
+    // treats them as literal '%' rather than format specifiers.
     let expanded;
     let strftime_input = if format_str.contains("{album}") {
         let safe_name = album_name
             .filter(|n| !n.is_empty())
             .map(sanitize_path_component)
+            .map(|s| s.replace('%', "%%"))
             .unwrap_or_default();
         expanded = format_str.replace("{album}", &safe_name);
         expanded.as_str()
@@ -1235,6 +1238,38 @@ mod tests {
         let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some("../etc"));
         // Path traversal in album name is neutralized
         assert!(!result.to_str().unwrap().contains("../"));
+    }
+
+    #[test]
+    fn test_album_token_percent_escaped() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        // Album name containing % should not be interpreted as strftime
+        let result =
+            local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some("My %d Album"));
+        let result_str = result.to_str().unwrap();
+        // %d should be literal, not expanded to "15"
+        assert!(
+            result_str.contains("%d"),
+            "percent in album name should be literal, got: {result_str}"
+        );
+        assert!(
+            !result_str.contains("/15/"),
+            "album %d should not expand to day number, got: {result_str}"
+        );
+    }
+
+    #[test]
+    fn test_album_token_trailing_percent_no_panic() {
+        let dir = Path::new("/photos");
+        let date = chrono::Local
+            .with_ymd_and_hms(2025, 6, 15, 14, 30, 0)
+            .unwrap();
+        // Trailing % in album name must not panic
+        let result = local_download_path(dir, "{album}/%Y", &date, "photo.jpg", Some("50% Off"));
+        assert!(result.to_str().unwrap().contains("50% Off"));
     }
 
     #[test]

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -1640,4 +1640,70 @@ mod tests {
         let flushed = buffer.flush();
         assert!(flushed.is_empty());
     }
+
+    #[test]
+    fn test_is_live_photo_true() {
+        let asset = make_asset(
+            json!({
+                "recordName": "LIVE_1",
+                "fields": {
+                    "filenameEnc": {"value": "IMG_0001.HEIC", "type": "STRING"},
+                    "itemType": {"value": "public.heic"},
+                    "resOriginalRes": {"value": {
+                        "size": 2000, "downloadURL": "https://example.com/heic",
+                        "fileChecksum": "heic_ck"
+                    }},
+                    "resOriginalVidComplRes": {"value": {
+                        "size": 3000, "downloadURL": "https://example.com/mov",
+                        "fileChecksum": "mov_ck"
+                    }}
+                }
+            }),
+            json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
+        );
+        assert!(asset.is_live_photo());
+    }
+
+    #[test]
+    fn test_is_live_photo_false_no_companion() {
+        let asset = make_asset(
+            json!({
+                "recordName": "PHOTO_1",
+                "fields": {
+                    "itemType": {"value": "public.jpeg"},
+                    "resOriginalRes": {"value": {
+                        "size": 1000, "downloadURL": "https://example.com/jpg",
+                        "fileChecksum": "jpg_ck"
+                    }}
+                }
+            }),
+            json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
+        );
+        assert!(!asset.is_live_photo());
+    }
+
+    #[test]
+    fn test_is_live_photo_false_for_movie() {
+        let asset = make_asset(
+            json!({
+                "recordName": "VID_1",
+                "fields": {
+                    "itemType": {"value": "com.apple.quicktime-movie"},
+                    "resOriginalRes": {"value": {
+                        "size": 5000, "downloadURL": "https://example.com/mov",
+                        "fileChecksum": "vid_ck"
+                    }},
+                    "resOriginalVidComplRes": {"value": {
+                        "size": 3000, "downloadURL": "https://example.com/mov2",
+                        "fileChecksum": "mov2_ck"
+                    }}
+                }
+            }),
+            json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
+        );
+        assert!(
+            !asset.is_live_photo(),
+            "Movies with video companion are not live photos"
+        );
+    }
 }

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -295,6 +295,15 @@ impl PhotoAsset {
     pub fn contains_version(&self, key: AssetVersionSize) -> bool {
         self.versions.iter().any(|(k, _)| *k == key)
     }
+
+    /// Whether this asset is a live photo (image with a companion video).
+    pub fn is_live_photo(&self) -> bool {
+        self.item_type() == Some(AssetItemType::Image)
+            && (self.contains_version(AssetVersionSize::LiveOriginal)
+                || self.contains_version(AssetVersionSize::LiveMedium)
+                || self.contains_version(AssetVersionSize::LiveThumb)
+                || self.contains_version(AssetVersionSize::LiveAdjusted))
+    }
 }
 
 impl std::fmt::Display for PhotoAsset {

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -175,13 +175,17 @@ fn extract_versions(
             continue;
         };
 
-        let asset_type: Box<str> = fields[type_field]["value"]
-            .as_str()
-            .unwrap_or_else(|| {
-                tracing::warn!("Missing expected field: {type_field}");
-                ""
-            })
-            .into();
+        let asset_type: Box<str> = match fields[type_field]["value"].as_str() {
+            Some(s) if !s.is_empty() => s.into(),
+            _ => {
+                tracing::warn!(
+                    asset = %record_name,
+                    field = %type_field,
+                    "Missing or empty asset type, skipping version"
+                );
+                continue;
+            }
+        };
 
         versions.push((
             *key,
@@ -1653,10 +1657,12 @@ mod tests {
                         "size": 2000, "downloadURL": "https://example.com/heic",
                         "fileChecksum": "heic_ck"
                     }},
+                    "resOriginalFileType": {"value": "public.heic"},
                     "resOriginalVidComplRes": {"value": {
                         "size": 3000, "downloadURL": "https://example.com/mov",
                         "fileChecksum": "mov_ck"
-                    }}
+                    }},
+                    "resOriginalVidComplFileType": {"value": "com.apple.quicktime-movie"}
                 }
             }),
             json!({"fields": {"assetDate": {"value": 1736899200000.0}}}),
@@ -1704,6 +1710,47 @@ mod tests {
         assert!(
             !asset.is_live_photo(),
             "Movies with video companion are not live photos"
+        );
+    }
+
+    #[test]
+    fn test_versions_skips_empty_asset_type() {
+        // When resOriginalFileType is missing, the version should be excluded.
+        let asset = make_asset(
+            json!({"fields": {
+                "itemType": {"value": "public.jpeg"},
+                "resOriginalRes": {"value": {
+                    "size": 5000,
+                    "downloadURL": "https://example.com/orig",
+                    "fileChecksum": "ck_orig"
+                }}
+                // resOriginalFileType intentionally omitted
+            }}),
+            json!({"fields": {}}),
+        );
+        assert!(
+            asset.versions().is_empty(),
+            "Version with missing asset type should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_versions_skips_null_asset_type() {
+        let asset = make_asset(
+            json!({"fields": {
+                "itemType": {"value": "public.jpeg"},
+                "resOriginalRes": {"value": {
+                    "size": 5000,
+                    "downloadURL": "https://example.com/orig",
+                    "fileChecksum": "ck_orig"
+                }},
+                "resOriginalFileType": {"value": null}
+            }}),
+            json!({"fields": {}}),
+        );
+        assert!(
+            asset.versions().is_empty(),
+            "Version with null asset type should be skipped"
         );
     }
 }

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -268,7 +268,7 @@ impl PhotoLibrary {
 #[cfg(test)]
 impl PhotoLibrary {
     /// Test-only constructor that bypasses the indexing check.
-    pub(super) fn new_stub(session: Box<dyn PhotosSession>) -> Self {
+    pub(crate) fn new_stub(session: Box<dyn PhotosSession>) -> Self {
         Self {
             service_endpoint: Arc::from("https://stub.example.com"),
             params: Arc::new(HashMap::new()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1364,6 +1364,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         _ => unreachable!("legacy command variants should be mapped by effective_command()"),
     };
     let is_retry_failed = sync.retry_failed;
+    let max_download_attempts = sync.max_download_attempts.unwrap_or(10);
     let reset_sync_token = sync.reset_sync_token;
     let toml_existed = toml_config.is_some();
     let cli_data_dir = globals
@@ -1683,6 +1684,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             temp_suffix: config.temp_suffix.clone(),
             state_db: state_db.clone(),
             retry_only: is_retry_failed,
+            max_download_attempts,
             sync_mode,
             album_name: None,
             exclude_asset_ids,
@@ -1693,6 +1695,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 
     let is_watch_mode = config.watch_with_interval.is_some();
     let mut reauth_attempts = 0u32;
+    let mut last_cycle_failed_count: usize = 0;
 
     let mut library_states: Vec<LibraryState> = Vec::with_capacity(libraries.len());
     for library in &libraries {
@@ -2012,11 +2015,13 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                         failed_count = cycle_failed_count,
                         "Some downloads failed this cycle, will retry next cycle"
                     );
+                    last_cycle_failed_count = cycle_failed_count;
                 } else {
                     return Err(PartialSyncError(cycle_failed_count).into());
                 }
             } else {
                 reauth_attempts = 0;
+                last_cycle_failed_count = 0;
                 notifier.notify(
                     notifications::Event::SyncComplete,
                     "Sync completed successfully",
@@ -2095,7 +2100,11 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         }
     }
 
-    Ok(())
+    if last_cycle_failed_count > 0 {
+        Err(PartialSyncError(last_cycle_failed_count).into())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1646,13 +1646,6 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         .map(|d| d.with_timezone(&chrono::Utc));
     let retry_config = api_retry_config;
     let live_photo_size = config.live_photo_size.to_asset_version_size();
-    // Compile glob patterns once (already validated in Config::build)
-    let filename_exclude_patterns: Vec<glob::Pattern> = config
-        .filename_exclude
-        .iter()
-        .map(|p| glob::Pattern::new(p).expect("validated in Config::build"))
-        .collect();
-
     let build_download_config = |sync_mode: download::SyncMode,
                                  exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>|
      -> Arc<download::DownloadConfig> {
@@ -1678,7 +1671,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             file_match_policy: config.file_match_policy,
             force_size: config.force_size,
             keep_unicode_in_filenames: config.keep_unicode_in_filenames,
-            filename_exclude: filename_exclude_patterns.clone(),
+            filename_exclude: config.filename_exclude.clone(),
             temp_suffix: config.temp_suffix.clone(),
             state_db: state_db.clone(),
             retry_only: is_retry_failed,
@@ -1826,7 +1819,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                                     _ => {}
                                 }
                             }
-                            let _ = db.set_metadata("enum_config_hash", &config_hash).await;
+                            if let Err(e) = db.set_metadata("enum_config_hash", &config_hash).await
+                            {
+                                tracing::warn!(error = %e, "Failed to persist enum_config_hash");
+                            }
                         }
                     }
                 }
@@ -2052,7 +2048,11 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             .await
             .ok(); // Best-effort pre-check; mid-sync re-auth handles failures
 
-            // Re-resolve albums per-library to discover newly created iCloud albums
+            // Re-resolve albums per-library to discover newly created iCloud albums.
+            // TODO: When --exclude-album is set without --album, this re-fetches the
+            // entire excluded album(s) to collect asset IDs. For large excluded albums
+            // this is expensive -- consider caching exclude_asset_ids across watch
+            // cycles and only refreshing when the album's sync token changes.
             for lib_state in &mut library_states {
                 match resolve_albums(&lib_state.library, &config.albums, &config.exclude_albums)
                     .await
@@ -2375,5 +2375,177 @@ mod tests {
             token_clone.cancel();
         });
         assert_eq!(run_watch_loop(&shutdown_token, Some(3600)).await, 1);
+    }
+
+    // ── resolve_albums tests ──────────────────────────────────────────
+
+    use crate::icloud::photos::PhotoLibrary;
+    use crate::test_helpers::MockPhotosSession;
+
+    /// Build a `PhotoLibrary` stub with a preconfigured mock session.
+    fn stub_library(mock: MockPhotosSession) -> PhotoLibrary {
+        PhotoLibrary::new_stub(Box::new(mock))
+    }
+
+    /// CloudKit folder record for a user album. The albumNameEnc field is
+    /// base64-encoded.
+    fn folder_record(record_name: &str, album_name: &str) -> serde_json::Value {
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(album_name);
+        serde_json::json!({
+            "recordName": record_name,
+            "recordType": "CPLAlbumByPositionLive",
+            "fields": {
+                "albumNameEnc": {"value": encoded},
+                "isDeleted": {"value": false}
+            }
+        })
+    }
+
+    /// A single paired CPLMaster+CPLAsset page for photo streaming.
+    fn asset_page(record_name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "records": [
+                {
+                    "recordName": record_name,
+                    "recordType": "CPLMaster",
+                    "fields": {
+                        "filenameEnc": {"value": "dGVzdC5qcGc=", "type": "STRING"},
+                        "resOriginalRes": {"value": {
+                            "downloadURL": "https://example.com/photo.jpg",
+                            "size": 1024,
+                            "fileChecksum": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                        }},
+                        "resOriginalFileType": {"value": "public.jpeg"},
+                        "itemType": {"value": "public.jpeg"},
+                        "adjustmentRenderType": {"value": 0, "type": "INT64"}
+                    }
+                },
+                {
+                    "recordName": format!("asset-{record_name}"),
+                    "recordType": "CPLAsset",
+                    "fields": {
+                        "masterRef": {
+                            "value": {"recordName": record_name, "zoneID": {"zoneName": "PrimarySync"}},
+                            "type": "REFERENCE"
+                        },
+                        "assetDate": {"value": 1700000000000i64, "type": "TIMESTAMP"},
+                        "addedDate": {"value": 1700000000000i64, "type": "TIMESTAMP"}
+                    }
+                }
+            ]
+        })
+    }
+
+    /// Batch album count response.
+    fn album_count_response(count: u64) -> serde_json::Value {
+        serde_json::json!({
+            "batch": [{"records": [{"fields": {"itemCount": {"value": count}}}]}]
+        })
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_no_album_no_exclude() {
+        let mock = MockPhotosSession::new();
+        let library = stub_library(mock);
+        let (albums, exclude_ids) = resolve_albums(&library, &[], &[]).await.unwrap();
+        assert_eq!(albums.len(), 1, "should return library.all()");
+        assert!(exclude_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_exclude_not_found_warns() {
+        // fetch_folders returns one album "Vacation", but we exclude "Nonexistent"
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": []})); // fetch_folders: no user albums
+        let library = stub_library(mock);
+
+        let (albums, exclude_ids) = resolve_albums(&library, &[], &["Nonexistent".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(albums.len(), 1, "should return library.all()");
+        assert!(exclude_ids.is_empty(), "non-existent album produces no IDs");
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_explicit_album_found() {
+        // fetch_folders returns "Vacation" album
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": [
+            folder_record("FOLDER_1", "Vacation")
+        ]}));
+        let library = stub_library(mock);
+
+        let (albums, exclude_ids) = resolve_albums(&library, &["Vacation".to_string()], &[])
+            .await
+            .unwrap();
+        assert_eq!(albums.len(), 1);
+        assert!(exclude_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_explicit_album_not_found_errors() {
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": []})); // no user albums
+        let library = stub_library(mock);
+
+        let result = resolve_albums(&library, &["DoesNotExist".to_string()], &[]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_explicit_album_with_exclusion() {
+        // Two albums: Vacation and Hidden. Exclude Hidden.
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": [
+            folder_record("FOLDER_1", "Vacation"),
+            folder_record("FOLDER_2", "Hidden")
+        ]}));
+        let library = stub_library(mock);
+
+        let (albums, exclude_ids) = resolve_albums(
+            &library,
+            &["Vacation".to_string(), "Hidden".to_string()],
+            &["Hidden".to_string()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            albums.len(),
+            1,
+            "Hidden should be excluded from matched albums"
+        );
+        assert!(
+            exclude_ids.is_empty(),
+            "explicit album path doesn't populate exclude IDs"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_exclude_without_album_collects_ids() {
+        // The mock session needs to handle:
+        // 1. fetch_folders (original session) → returns album "Hidden"
+        // 2. album.len() (cloned session) → returns count
+        // 3. photo_stream fetcher (re-cloned session) → returns one asset page
+        // 4. photo_stream fetcher 2nd call → returns empty (end of stream)
+        let mock = MockPhotosSession::new()
+            // 1. fetch_folders
+            .ok(serde_json::json!({"records": [
+                folder_record("FOLDER_1", "Hidden")
+            ]}))
+            // Remaining responses are cloned into the album's session:
+            // 2. album.len() batch query
+            .ok(album_count_response(1))
+            // 3. photo_stream fetcher: first page with one asset
+            .ok(asset_page("MASTER_1"))
+            // 4. photo_stream fetcher: empty page (end)
+            .ok(serde_json::json!({"records": []}));
+        let library = stub_library(mock);
+
+        let (albums, exclude_ids) = resolve_albums(&library, &[], &["Hidden".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(albums.len(), 1, "should return library.all()");
+        assert!(
+            exclude_ids.contains("MASTER_1"),
+            "should contain the excluded asset ID"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1627,12 +1627,21 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     // Handle --reset-sync-token (hidden compat flag): clear stored tokens before the sync loop
     if reset_sync_token {
         if let Some(ref db) = state_db {
-            db.set_metadata("db_sync_token", "").await.ok();
+            let mut cleared_ok = true;
+            if let Err(e) = db.set_metadata("db_sync_token", "").await {
+                tracing::warn!(error = %e, "Failed to clear db_sync_token");
+                cleared_ok = false;
+            }
             for library in &libraries {
                 let key = format!("sync_token:{}", library.zone_name());
-                db.set_metadata(&key, "").await.ok();
+                if let Err(e) = db.set_metadata(&key, "").await {
+                    tracing::warn!(error = %e, key = %key, "Failed to clear sync token");
+                    cleared_ok = false;
+                }
             }
-            tracing::info!("Cleared stored sync tokens");
+            if cleared_ok {
+                tracing::info!("Cleared stored sync tokens");
+            }
         }
     }
 
@@ -1703,6 +1712,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     sd_notifier.notify_ready();
 
     let mut health = health::HealthStatus::new();
+    let mut consecutive_album_refresh_failures: u32 = 0;
 
     loop {
         if shutdown_token.is_cancelled() {
@@ -2060,13 +2070,24 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                     Ok((refreshed, exclude_ids)) => {
                         lib_state.albums = refreshed;
                         lib_state.exclude_asset_ids = Arc::new(exclude_ids);
+                        consecutive_album_refresh_failures = 0;
                     }
                     Err(e) => {
-                        tracing::warn!(
-                            zone = %lib_state.zone_name,
-                            error = %e,
-                            "Failed to refresh albums, reusing previous set"
-                        );
+                        consecutive_album_refresh_failures += 1;
+                        if consecutive_album_refresh_failures >= 3 {
+                            tracing::error!(
+                                zone = %lib_state.zone_name,
+                                error = %e,
+                                consecutive_failures = consecutive_album_refresh_failures,
+                                "Repeated album refresh failures, reusing previous set"
+                            );
+                        } else {
+                            tracing::warn!(
+                                zone = %lib_state.zone_name,
+                                error = %e,
+                                "Failed to refresh albums, reusing previous set"
+                            );
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1435,6 +1435,36 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         );
     }
 
+    // Validate download directory is writable before spending time on authentication.
+    tokio::fs::create_dir_all(&config.directory)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to create download directory {}",
+                config.directory.display()
+            )
+        })?;
+    let probe = config.directory.join(".kei_probe");
+    tokio::fs::write(&probe, b"").await.with_context(|| {
+        format!(
+            "Download directory {} is not writable",
+            config.directory.display()
+        )
+    })?;
+    let _ = tokio::fs::remove_file(&probe).await;
+
+    // Abort if available disk space is too low.
+    if let Some(avail) = available_disk_space(&config.directory) {
+        const MIN_FREE_BYTES: u64 = 1_073_741_824; // 1 GiB
+        if avail < MIN_FREE_BYTES {
+            let avail_mb = avail / (1024 * 1024);
+            anyhow::bail!(
+                "Insufficient disk space: only {avail_mb} MiB available in {} (minimum 1 GiB)",
+                config.directory.display()
+            );
+        }
+    }
+
     let cred_store = credential::CredentialStore::new(&config.username, &config.cookie_directory);
     let source = password::build_password_source(
         config.password.as_ref(),
@@ -1552,37 +1582,6 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         zones = %libraries.iter().map(|l| l.zone_name().to_string()).collect::<Vec<_>>().join(", "),
         "Resolved libraries"
     );
-
-    // Validate download directory is writable before spending time on enumeration
-    tokio::fs::create_dir_all(&config.directory)
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to create download directory {}",
-                config.directory.display()
-            )
-        })?;
-    let probe = config.directory.join(".kei_probe");
-    tokio::fs::write(&probe, b"").await.with_context(|| {
-        format!(
-            "Download directory {} is not writable",
-            config.directory.display()
-        )
-    })?;
-    let _ = tokio::fs::remove_file(&probe).await;
-
-    // Warn if available disk space is low
-    if let Some(avail) = available_disk_space(&config.directory) {
-        const MIN_FREE_BYTES: u64 = 1_073_741_824; // 1 GiB
-        if avail < MIN_FREE_BYTES {
-            let avail_mb = avail / (1024 * 1024);
-            tracing::warn!(
-                available_mb = avail_mb,
-                path = %config.directory.display(),
-                "Low disk space — downloads may fail with disk errors"
-            );
-        }
-    }
 
     // Initialize state database.
     // Skip for --dry-run so a preview doesn't create the DB or poison

--- a/src/main.rs
+++ b/src/main.rs
@@ -966,6 +966,7 @@ async fn run_import_existing(
                 &folder_structure,
                 &created_local,
                 &filename,
+                None, // import-existing doesn't have album context
             );
 
             if expected_path.exists() {
@@ -1048,22 +1049,39 @@ async fn run_import_existing(
 async fn resolve_albums(
     library: &icloud::photos::PhotoLibrary,
     album_names: &[String],
+    exclude_albums: &[String],
 ) -> anyhow::Result<Vec<icloud::photos::PhotoAlbum>> {
+    if album_names.is_empty() && exclude_albums.is_empty() {
+        return Ok(vec![library.all()]);
+    }
+
     if album_names.is_empty() {
-        Ok(vec![library.all()])
-    } else {
+        // No --album but --exclude-album is set: fetch all albums and filter.
         let mut album_map = library.albums().await?;
-        let mut matched = Vec::new();
-        for name in album_names {
-            if let Some(album) = album_map.remove(name.as_str()) {
-                matched.push(album);
-            } else {
-                let available: Vec<&String> = album_map.keys().collect();
-                anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+        for name in exclude_albums {
+            if album_map.remove(name.as_str()).is_none() {
+                tracing::warn!(album = name, "Excluded album not found, ignoring");
             }
         }
-        Ok(matched)
+        return Ok(album_map.into_values().collect());
     }
+
+    // Explicit --album list: resolve and exclude.
+    let mut album_map = library.albums().await?;
+    let mut matched = Vec::new();
+    for name in album_names {
+        if exclude_albums.iter().any(|e| e == name) {
+            tracing::info!(album = name, "Album excluded by --exclude-album");
+            continue;
+        }
+        if let Some(album) = album_map.remove(name.as_str()) {
+            matched.push(album);
+        } else {
+            let available: Vec<&String> = album_map.keys().collect();
+            anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+        }
+    }
+    Ok(matched)
 }
 
 /// RAII guard that writes the current PID to a file on creation and removes
@@ -1600,6 +1618,12 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         .map(|d| d.with_timezone(&chrono::Utc));
     let retry_config = api_retry_config;
     let live_photo_size = config.live_photo_size.to_asset_version_size();
+    // Compile glob patterns once (already validated in Config::build)
+    let filename_exclude_patterns: Vec<glob::Pattern> = config
+        .filename_exclude
+        .iter()
+        .map(|p| glob::Pattern::new(p).expect("validated in Config::build"))
+        .collect();
 
     let build_download_config = |sync_mode: download::SyncMode| -> Arc<download::DownloadConfig> {
         Arc::new(download::DownloadConfig {
@@ -1615,7 +1639,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             concurrent_downloads: config.threads_num as usize,
             recent: config.recent,
             retry: retry_config,
-            skip_live_photos: config.skip_live_photos,
+            live_photo_mode: config.live_photo_mode,
             live_photo_size,
             live_photo_mov_filename_policy: config.live_photo_mov_filename_policy,
             align_raw: config.align_raw,
@@ -1624,10 +1648,12 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             file_match_policy: config.file_match_policy,
             force_size: config.force_size,
             keep_unicode_in_filenames: config.keep_unicode_in_filenames,
+            filename_exclude: filename_exclude_patterns.clone(),
             temp_suffix: config.temp_suffix.clone(),
             state_db: state_db.clone(),
             retry_only: is_retry_failed,
             sync_mode,
+            album_name: None,
         })
     };
 
@@ -1640,7 +1666,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     for library in &libraries {
         let zone_name = library.zone_name().to_string();
         let sync_token_key = format!("sync_token:{zone_name}");
-        let albums = resolve_albums(library, &config.albums).await?;
+        let albums = resolve_albums(library, &config.albums, &config.exclude_albums).await?;
         library_states.push(LibraryState {
             library: library.clone(),
             zone_name,
@@ -1994,7 +2020,9 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 
             // Re-resolve albums per-library to discover newly created iCloud albums
             for lib_state in &mut library_states {
-                match resolve_albums(&lib_state.library, &config.albums).await {
+                match resolve_albums(&lib_state.library, &config.albums, &config.exclude_albums)
+                    .await
+                {
                     Ok(refreshed) => lib_state.albums = refreshed,
                     Err(e) => {
                         tracing::warn!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1695,7 +1695,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 
     let is_watch_mode = config.watch_with_interval.is_some();
     let mut reauth_attempts = 0u32;
-    let mut last_cycle_failed_count: usize = 0;
+    let mut last_cycle_failed_count = 0usize;
 
     let mut library_states: Vec<LibraryState> = Vec::with_capacity(libraries.len());
     for library in &libraries {
@@ -1714,7 +1714,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     sd_notifier.notify_ready();
 
     let mut health = health::HealthStatus::new();
-    let mut consecutive_album_refresh_failures: u32 = 0;
+    let mut consecutive_album_refresh_failures = 0u32;
 
     loop {
         if shutdown_token.is_cancelled() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2548,4 +2548,24 @@ mod tests {
             "should contain the excluded asset ID"
         );
     }
+
+    #[tokio::test]
+    async fn resolve_albums_same_album_in_both_yields_empty() {
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": [
+            folder_record("FOLDER_1", "Vacation")
+        ]}));
+        let library = stub_library(mock);
+
+        let (albums, _) = resolve_albums(
+            &library,
+            &["Vacation".to_string()],
+            &["Vacation".to_string()],
+        )
+        .await
+        .unwrap();
+        assert!(
+            albums.is_empty(),
+            "album present in both --album and --exclude-album should yield zero albums"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1041,29 +1041,54 @@ async fn run_import_existing(
     Ok(())
 }
 
-/// Resolve which albums to download from.
+/// Resolve which albums to download from, plus any asset IDs to exclude.
 ///
 /// When no `--album` names are specified, returns `library.all()` (a cheap
 /// in-memory construction, no API call). When names are given, calls
 /// `library.albums().await` to discover user-created albums from iCloud.
+///
+/// The returned `FxHashSet<String>` contains asset IDs from excluded albums
+/// that should be filtered out at download time. This is only populated when
+/// `--exclude-album` is set without `--album`, because the all-photos stream
+/// doesn't carry album membership per asset.
 async fn resolve_albums(
     library: &icloud::photos::PhotoLibrary,
     album_names: &[String],
     exclude_albums: &[String],
-) -> anyhow::Result<Vec<icloud::photos::PhotoAlbum>> {
+) -> anyhow::Result<(
+    Vec<icloud::photos::PhotoAlbum>,
+    rustc_hash::FxHashSet<String>,
+)> {
+    use futures_util::StreamExt;
+
+    let empty_ids = rustc_hash::FxHashSet::default();
+
     if album_names.is_empty() && exclude_albums.is_empty() {
-        return Ok(vec![library.all()]);
+        return Ok((vec![library.all()], empty_ids));
     }
 
     if album_names.is_empty() {
-        // No --album but --exclude-album is set: fetch all albums and filter.
-        let mut album_map = library.albums().await?;
+        // No --album but --exclude-album is set: use library.all() as the
+        // base (all photos) and pre-collect asset IDs from excluded albums
+        // so they can be filtered at download time. This avoids silently
+        // dropping photos that aren't in any named album.
+        let album_map = library.albums().await?;
+        let mut exclude_ids = rustc_hash::FxHashSet::default();
         for name in exclude_albums {
-            if album_map.remove(name.as_str()).is_none() {
+            if let Some(album) = album_map.get(name.as_str()) {
+                let count = album.len().await.unwrap_or(0);
+                tracing::info!(album = name, count, "Pre-fetching excluded album asset IDs");
+                let (stream, _token_rx) = album.photo_stream_with_token(None, Some(count), 1);
+                tokio::pin!(stream);
+                while let Some(Ok(asset)) = stream.next().await {
+                    exclude_ids.insert(asset.id().to_string());
+                }
+            } else {
                 tracing::warn!(album = name, "Excluded album not found, ignoring");
             }
         }
-        return Ok(album_map.into_values().collect());
+        tracing::info!(count = exclude_ids.len(), "Collected excluded asset IDs");
+        return Ok((vec![library.all()], exclude_ids));
     }
 
     // Explicit --album list: resolve and exclude.
@@ -1081,7 +1106,7 @@ async fn resolve_albums(
             anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
         }
     }
-    Ok(matched)
+    Ok((matched, empty_ids))
 }
 
 /// RAII guard that writes the current PID to a file on creation and removes
@@ -1112,6 +1137,9 @@ struct LibraryState {
     zone_name: String,
     sync_token_key: String,
     albums: Vec<icloud::photos::PhotoAlbum>,
+    /// Asset IDs from excluded albums, used to filter out assets when
+    /// `--exclude-album` is set without explicit `--album`.
+    exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>,
 }
 
 fn main() -> ExitCode {
@@ -1625,7 +1653,9 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         .map(|p| glob::Pattern::new(p).expect("validated in Config::build"))
         .collect();
 
-    let build_download_config = |sync_mode: download::SyncMode| -> Arc<download::DownloadConfig> {
+    let build_download_config = |sync_mode: download::SyncMode,
+                                 exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>|
+     -> Arc<download::DownloadConfig> {
         Arc::new(download::DownloadConfig {
             directory: config.directory.clone(),
             folder_structure: config.folder_structure.clone(),
@@ -1654,6 +1684,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             retry_only: is_retry_failed,
             sync_mode,
             album_name: None,
+            exclude_asset_ids,
         })
     };
 
@@ -1666,12 +1697,14 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     for library in &libraries {
         let zone_name = library.zone_name().to_string();
         let sync_token_key = format!("sync_token:{zone_name}");
-        let albums = resolve_albums(library, &config.albums, &config.exclude_albums).await?;
+        let (albums, exclude_ids) =
+            resolve_albums(library, &config.albums, &config.exclude_albums).await?;
         library_states.push(LibraryState {
             library: library.clone(),
             zone_name,
             sync_token_key,
             albums,
+            exclude_asset_ids: Arc::new(exclude_ids),
         });
     }
     sd_notifier.notify_ready();
@@ -1837,7 +1870,8 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 };
                 tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
 
-                let download_config = build_download_config(sync_mode);
+                let download_config =
+                    build_download_config(sync_mode, Arc::clone(&lib_state.exclude_asset_ids));
                 let download_client = shared_session.read().await.download_client();
                 let sync_result = download::download_photos_with_sync(
                     &download_client,
@@ -2023,7 +2057,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 match resolve_albums(&lib_state.library, &config.albums, &config.exclude_albums)
                     .await
                 {
-                    Ok(refreshed) => lib_state.albums = refreshed,
+                    Ok((refreshed, exclude_ids)) => {
+                        lib_state.albums = refreshed;
+                        lib_state.exclude_asset_ids = Arc::new(exclude_ids);
+                    }
                     Err(e) => {
                         tracing::warn!(
                             zone = %lib_state.zone_name,

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -1810,10 +1810,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_attempt_counts() {
-        let dir = test_dir();
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        // Create two assets
         for id in ["A", "B"] {
             let record = TestAssetRecord::new(id)
                 .checksum(&format!("ck_{id}"))
@@ -1823,19 +1821,14 @@ mod tests {
             db.upsert_seen(&record).await.unwrap();
         }
 
-        // Fail asset A three times
         db.mark_failed("A", "original", "error 1").await.unwrap();
         db.mark_failed("A", "original", "error 2").await.unwrap();
         db.mark_failed("A", "original", "error 3").await.unwrap();
-
-        // Fail asset B once
         db.mark_failed("B", "original", "error 1").await.unwrap();
 
         let counts = db.get_attempt_counts().await.unwrap();
-        assert_eq!(counts.get("A"), Some(&3), "A should have 3 attempts");
-        assert_eq!(counts.get("B"), Some(&1), "B should have 1 attempt");
-
-        drop(dir);
+        assert_eq!(counts.get("A"), Some(&3));
+        assert_eq!(counts.get("B"), Some(&1));
     }
 
     #[tokio::test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -111,6 +111,11 @@ pub trait StateDb: Send + Sync {
         &self,
     ) -> Result<HashMap<(String, String), String>, StateError>;
 
+    /// Get per-asset maximum download attempt counts for failed assets.
+    ///
+    /// Returns a map of asset_id -> max(download_attempts).
+    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError>;
+
     /// Get a metadata value by key.
     async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError>;
 
@@ -603,6 +608,32 @@ impl StateDb for SqliteStateDb {
             .map_err(|e| StateError::query(&e))?;
 
         Ok(checksums)
+    }
+
+    async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| StateError::Query(e.to_string()))?;
+
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT id, MAX(download_attempts) FROM assets \
+                 WHERE download_attempts > 0 GROUP BY id",
+            )
+            .map_err(|e| StateError::query(&e))?;
+
+        let counts = stmt
+            .query_map([], |row| {
+                let id: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok((id, u32::try_from(count).unwrap_or(u32::MAX)))
+            })
+            .map_err(|e| StateError::query(&e))?
+            .collect::<Result<HashMap<_, _>, _>>()
+            .map_err(|e| StateError::query(&e))?;
+
+        Ok(counts)
     }
 
     async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
@@ -1775,5 +1806,42 @@ mod tests {
 
         let result = SqliteStateDb::open(&path).await;
         assert!(result.is_err(), "opening a truncated DB should fail");
+    }
+
+    #[tokio::test]
+    async fn test_get_attempt_counts() {
+        let dir = test_dir();
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // Create two assets
+        for id in ["A", "B"] {
+            let record = TestAssetRecord::new(id)
+                .checksum(&format!("ck_{id}"))
+                .filename(&format!("{id}.jpg"))
+                .size(1000)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+        }
+
+        // Fail asset A three times
+        db.mark_failed("A", "original", "error 1").await.unwrap();
+        db.mark_failed("A", "original", "error 2").await.unwrap();
+        db.mark_failed("A", "original", "error 3").await.unwrap();
+
+        // Fail asset B once
+        db.mark_failed("B", "original", "error 1").await.unwrap();
+
+        let counts = db.get_attempt_counts().await.unwrap();
+        assert_eq!(counts.get("A"), Some(&3), "A should have 3 attempts");
+        assert_eq!(counts.get("B"), Some(&1), "B should have 1 attempt");
+
+        drop(dir);
+    }
+
+    #[tokio::test]
+    async fn test_get_attempt_counts_empty() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let counts = db.get_attempt_counts().await.unwrap();
+        assert!(counts.is_empty());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,6 +74,23 @@ pub enum LivePhotoMovFilenamePolicy {
     Original,
 }
 
+/// Controls which components of live photos are downloaded.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LivePhotoMode {
+    /// Download both the still image and the MOV video
+    #[default]
+    Both,
+    /// Download only the still image, skip the MOV
+    #[value(name = "image-only")]
+    ImageOnly,
+    /// Download only the MOV video, skip the still image
+    #[value(name = "video-only")]
+    VideoOnly,
+    /// Skip live photos entirely (both image and MOV)
+    Skip,
+}
+
 impl LivePhotoSize {
     pub fn to_asset_version_size(self) -> crate::icloud::photos::AssetVersionSize {
         use crate::icloud::photos::AssetVersionSize;
@@ -199,6 +216,21 @@ mod tests {
             let json = serde_json::to_string(&variant).unwrap();
             assert_eq!(json, expected);
             let parsed: RawTreatmentPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn live_photo_mode_serde_round_trip() {
+        for (variant, expected) in [
+            (LivePhotoMode::Both, "\"both\""),
+            (LivePhotoMode::ImageOnly, "\"image-only\""),
+            (LivePhotoMode::VideoOnly, "\"video-only\""),
+            (LivePhotoMode::Skip, "\"skip\""),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected);
+            let parsed: LivePhotoMode = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed, variant);
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,6 +76,7 @@ pub enum LivePhotoMovFilenamePolicy {
 
 /// Controls which components of live photos are downloaded.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize)]
+#[repr(u8)]
 #[serde(rename_all = "kebab-case")]
 pub enum LivePhotoMode {
     /// Download both the still image and the MOV video

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2185,6 +2185,7 @@ fn log_level_default_info() {
 #[test]
 fn log_level_debug() {
     let dir = tempfile::tempdir().unwrap();
+    let dl_dir = dir.path().join("photos");
     let out = clean_cmd()
         .args([
             "--log-level",
@@ -2193,7 +2194,7 @@ fn log_level_debug() {
             "--username",
             "x@x.com",
             "--directory",
-            "/photos",
+            dl_dir.to_str().unwrap(),
             "--data-dir",
             dir.path().to_str().unwrap(),
         ])

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -1148,12 +1148,14 @@ fn config_multiple_password_sources_in_toml() {
 }
 
 #[test]
-fn config_invalid_folder_structure_token() {
+fn config_strftime_folder_structure_accepted() {
+    // Full strftime support: %B (month name), %q, etc. are no longer rejected.
+    // The process may fail auth, but it should NOT fail config validation.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
         &config_path,
-        "[auth]\nusername = \"x@x.com\"\n\n[download]\ndirectory = \"/photos\"\nfolder_structure = \"%Y/%q\"\n",
+        "[auth]\nusername = \"x@x.com\"\n\n[download]\ndirectory = \"/photos\"\nfolder_structure = \"%Y/%B/%d\"\n",
     )
     .unwrap();
 
@@ -1166,8 +1168,9 @@ fn config_invalid_folder_structure_token() {
             dir.path().to_str().unwrap(),
         ])
         .assert()
-        .code(1)
-        .stderr(predicate::str::contains("unrecognized format token"));
+        // Should get past config validation (no "unrecognized format token" error).
+        // Fails on auth, not on config.
+        .stderr(predicate::str::contains("unrecognized format token").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **`--live-photo-mode`** (`both`/`image-only`/`video-only`/`skip`) replaces `--skip-live-photos` boolean. Old flag kept as hidden compat alias with deprecation warning. Closes #95.
- **`--filename-exclude`** for glob-based filename filtering (e.g. `*.AAE`, `Screenshot*`). Case-insensitive matching against original iCloud filenames. Closes #96.
- **`--exclude-album`** to exclude specific albums from sync. When no `--album` is set, fetches all albums and removes excluded ones. Closes #88.
- **Full strftime** in `--folder-structure` via chrono -- enables `%B` (month name), `%A` (weekday), and all other strftime tokens. Closes #141.
- **`{album}` token** in `--folder-structure` for album-based directory organization (e.g. `{album}/%Y/%m/%d`). Closes #80.

All flags support TOML config (`[filters]`/`[photos]` sections) and `KEI_*` env vars. Config hashes updated to invalidate sync tokens when new filter fields change.

## Test plan

- [x] `cargo fmt -- --check && cargo clippy && cargo test` -- 1234 tests pass, zero warnings
- [x] CLI parsing tests for all new flags and enum variants
- [x] Config resolution tests (CLI > TOML precedence, invalid glob rejection)
- [x] Download filter tests for LivePhotoMode (Skip, VideoOnly, ImageOnly, Both)
- [x] Filename exclusion tests (match, case-insensitive, no-match passthrough)
- [x] Path expansion tests for strftime (%B) and {album} token
- [x] Config hash sensitivity tests for new fields
- [x] Serde round-trip test for LivePhotoMode enum
- [x] Backward compat: `--skip-live-photos` still parses, `{:%Y/%m/%d}` wrapper still works
- [x] Manual: `--exclude-album Hidden` excludes album, `--exclude-album icloudpd-test` on `--album icloudpd-test` produces 0 files
- [x] Manual: `--filename-exclude "*.MOV"` correctly filters MOV files from dry-run output
- [x] Manual: `--folder-structure '{album}/%Y/%B'` produces `icloudpd-test/2026/February/...` paths
- [x] Manual: `--folder-structure '%Y/%B/%d'` produces `2025/April/13/...` paths (full strftime)
- [x] Manual: `--live-photo-mode` all 4 variants with real Live Photos album (both=10, image-only=5, skip=0, video-only=5)
- [x] Manual: `--skip-live-photos` prints deprecation warning
- [x] Docker: container starts, parses new TOML config fields, binary runs (auth required for full sync)