### PR TITLE
Fix library selection, deprecated messages, and misplaced flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -236,6 +236,10 @@ pub struct ImportArgs {
     #[command(flatten)]
     pub password: PasswordArgs,
 
+    /// Library to import (default: PrimarySync, use "all" for all libraries)
+    #[arg(long, env = "KEI_LIBRARY")]
+    pub library: Option<String>,
+
     /// Local directory containing existing downloads
     #[arg(short = 'd', long, env = "KEI_DIRECTORY", value_parser = non_empty_string)]
     pub directory: Option<String>,
@@ -362,6 +366,10 @@ pub enum Command {
     List {
         #[command(flatten)]
         password: PasswordArgs,
+
+        /// Library to list albums from (default: PrimarySync, use "all" for all)
+        #[arg(long, env = "KEI_LIBRARY")]
+        library: Option<String>,
 
         #[command(subcommand)]
         what: ListCommand,
@@ -645,6 +653,7 @@ impl Cli {
                     deprecation_warning("--list-albums", "kei list albums");
                     return Command::List {
                         password: self.password.clone(),
+                        library: self.sync.library.clone(),
                         what: ListCommand::Albums,
                     };
                 }
@@ -652,6 +661,7 @@ impl Cli {
                     deprecation_warning("--list-libraries", "kei list libraries");
                     return Command::List {
                         password: self.password.clone(),
+                        library: self.sync.library.clone(),
                         what: ListCommand::Libraries,
                     };
                 }
@@ -731,6 +741,7 @@ impl Cli {
                 deprecation_warning("--list-albums", "kei list albums");
                 Command::List {
                     password: password.clone(),
+                    library: sync.library.clone(),
                     what: ListCommand::Albums,
                 }
             }
@@ -741,6 +752,7 @@ impl Cli {
                 deprecation_warning("--list-libraries", "kei list libraries");
                 Command::List {
                     password: password.clone(),
+                    library: sync.library.clone(),
                     what: ListCommand::Libraries,
                 }
             }
@@ -1817,6 +1829,37 @@ mod tests {
         } else {
             panic!("Expected ImportExisting command");
         }
+    }
+
+    #[test]
+    fn test_import_existing_library_flag() {
+        let cli = Cli::try_parse_from([
+            "kei",
+            "import-existing",
+            "--library",
+            "SharedSync-ABCD1234",
+            "--directory",
+            "/photos",
+        ])
+        .unwrap();
+        if let Some(Command::ImportExisting(args)) = cli.command {
+            assert_eq!(args.library.as_deref(), Some("SharedSync-ABCD1234"));
+        } else {
+            panic!("Expected ImportExisting command");
+        }
+    }
+
+    #[test]
+    fn test_list_albums_library_flag() {
+        let cli = Cli::try_parse_from(["kei", "list", "--library", "all", "albums"]).unwrap();
+        assert!(matches!(
+            cli.effective_command(),
+            Command::List {
+                library: Some(ref l),
+                what: ListCommand::Albums,
+                ..
+            } if l == "all"
+        ));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,11 +51,6 @@ pub struct PasswordArgs {
     /// Example: --password-command "op read 'op://vault/icloud/password'"
     #[arg(long, env = "KEI_PASSWORD_COMMAND", conflicts_with_all = ["password", "password_file"])]
     pub password_command: Option<String>,
-
-    /// After successful auth, persist the password to the credential store
-    /// (OS keyring or encrypted file).
-    #[arg(long)]
-    pub save_password: bool,
 }
 
 /// Arguments for the sync command (also used as default when no subcommand).
@@ -195,6 +190,11 @@ pub struct SyncArgs {
     /// Called with `KEI_EVENT`, `KEI_MESSAGE`, `KEI_ICLOUD_USERNAME` env vars.
     #[arg(long, env = "KEI_NOTIFICATION_SCRIPT")]
     pub notification_script: Option<String>,
+
+    /// After successful auth, persist the password to the credential store
+    /// (OS keyring or encrypted file).
+    #[arg(long)]
+    pub save_password: bool,
 
     /// Re-sync only previously failed assets
     #[arg(long, conflicts_with_all = ["dry_run", "watch_with_interval"])]
@@ -620,7 +620,6 @@ impl PasswordArgs {
         if self.password_command.is_none() {
             self.password_command.clone_from(&fallback.password_command);
         }
-        self.save_password = self.save_password || fallback.save_password;
     }
 }
 
@@ -1309,7 +1308,7 @@ mod tests {
         let mut args = base_args();
         args.push("--save-password");
         let cli = parse(&args);
-        assert!(cli.password.save_password);
+        assert!(cli.sync.save_password);
     }
 
     // ── Sync args ─────────────────────────────────────────────────

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -604,6 +604,7 @@ impl SyncArgs {
             self.notification_script
                 .clone_from(&fallback.notification_script);
         }
+        self.save_password = self.save_password || fallback.save_password;
         self.retry_failed = self.retry_failed || fallback.retry_failed;
     }
 }
@@ -1309,6 +1310,16 @@ mod tests {
         args.push("--save-password");
         let cli = parse(&args);
         assert!(cli.sync.save_password);
+    }
+
+    #[test]
+    fn test_save_password_merges_into_subcommand() {
+        let cli = parse(&["kei", "--username", "u@e.com", "--save-password", "sync"]);
+        if let Command::Sync { sync, .. } = cli.effective_command() {
+            assert!(sync.save_password);
+        } else {
+            panic!("expected Sync command");
+        }
     }
 
     // ── Sync args ─────────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,21 @@ pub enum LibrarySelection {
     All,
 }
 
+/// Resolve library selection from CLI flag > TOML config > default (`PrimarySync`).
+pub(crate) fn resolve_library_selection(
+    cli_library: Option<String>,
+    toml_filters: Option<&TomlFilters>,
+) -> LibrarySelection {
+    let library_str = cli_library
+        .or_else(|| toml_filters.and_then(|f| f.library.clone()))
+        .unwrap_or_else(|| "PrimarySync".to_string());
+    if library_str.eq_ignore_ascii_case("all") {
+        LibrarySelection::All
+    } else {
+        LibrarySelection::Single(library_str)
+    }
+}
+
 impl std::fmt::Display for LibrarySelection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -507,16 +522,7 @@ impl Config {
         }
 
         // Filters
-        let library_str = resolve(
-            sync.library,
-            toml_filters.and_then(|f| f.library.clone()),
-            "PrimarySync".to_string(),
-        );
-        let library = if library_str.eq_ignore_ascii_case("all") {
-            LibrarySelection::All
-        } else {
-            LibrarySelection::Single(library_str)
-        };
+        let library = resolve_library_selection(sync.library, toml_filters);
         let albums = if sync.albums.is_empty() {
             toml_filters
                 .and_then(|f| f.albums.clone())
@@ -3479,5 +3485,72 @@ mod tests {
         assert!(validate_directory(Path::new("/home/user/photos")).is_ok());
         assert!(validate_directory(Path::new("/mnt/photos")).is_ok());
         assert!(validate_directory(Path::new("/data/sync")).is_ok());
+    }
+
+    // ── resolve_library_selection ──────────────────────────────────
+
+    #[test]
+    fn resolve_library_defaults_to_primary_sync() {
+        let result = resolve_library_selection(None, None);
+        assert_eq!(result, LibrarySelection::Single("PrimarySync".to_string()));
+    }
+
+    #[test]
+    fn resolve_library_cli_overrides_toml() {
+        let toml_filters = TomlFilters {
+            library: Some("SharedSync-FROM-TOML".to_string()),
+            albums: None,
+            exclude_albums: None,
+            filename_exclude: None,
+            skip_videos: None,
+            skip_photos: None,
+            skip_live_photos: None,
+            recent: None,
+            skip_created_before: None,
+            skip_created_after: None,
+        };
+        let result =
+            resolve_library_selection(Some("SharedSync-FROM-CLI".to_string()), Some(&toml_filters));
+        assert_eq!(
+            result,
+            LibrarySelection::Single("SharedSync-FROM-CLI".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_library_falls_back_to_toml() {
+        let toml_filters = TomlFilters {
+            library: Some("SharedSync-ABCD".to_string()),
+            albums: None,
+            exclude_albums: None,
+            filename_exclude: None,
+            skip_videos: None,
+            skip_photos: None,
+            skip_live_photos: None,
+            recent: None,
+            skip_created_before: None,
+            skip_created_after: None,
+        };
+        let result = resolve_library_selection(None, Some(&toml_filters));
+        assert_eq!(
+            result,
+            LibrarySelection::Single("SharedSync-ABCD".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_library_all_case_insensitive() {
+        assert_eq!(
+            resolve_library_selection(Some("ALL".to_string()), None),
+            LibrarySelection::All
+        );
+        assert_eq!(
+            resolve_library_selection(Some("All".to_string()), None),
+            LibrarySelection::All
+        );
+        assert_eq!(
+            resolve_library_selection(Some("all".to_string()), None),
+            LibrarySelection::All
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -424,7 +424,7 @@ impl Config {
             resolve_auth(globals, &pw, toml.as_ref());
         let password_file = resolve_password_file(&pw, toml_auth);
         let password_command = resolve_password_command(&pw, toml_auth);
-        let save_password = pw.save_password;
+        let save_password = sync.save_password;
 
         // Reject explicitly provided empty username/password (CLI value_parser
         // catches the CLI case; this catches empty strings from TOML).

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,7 @@ pub(crate) struct TomlRetry {
     pub delay: Option<u64>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TomlFilters {
     pub library: Option<String>,
@@ -3499,15 +3499,7 @@ mod tests {
     fn resolve_library_cli_overrides_toml() {
         let toml_filters = TomlFilters {
             library: Some("SharedSync-FROM-TOML".to_string()),
-            albums: None,
-            exclude_albums: None,
-            filename_exclude: None,
-            skip_videos: None,
-            skip_photos: None,
-            skip_live_photos: None,
-            recent: None,
-            skip_created_before: None,
-            skip_created_after: None,
+            ..Default::default()
         };
         let result =
             resolve_library_selection(Some("SharedSync-FROM-CLI".to_string()), Some(&toml_filters));
@@ -3521,15 +3513,7 @@ mod tests {
     fn resolve_library_falls_back_to_toml() {
         let toml_filters = TomlFilters {
             library: Some("SharedSync-ABCD".to_string()),
-            albums: None,
-            exclude_albums: None,
-            filename_exclude: None,
-            skip_videos: None,
-            skip_photos: None,
-            skip_live_photos: None,
-            recent: None,
-            skip_created_before: None,
-            skip_created_after: None,
+            ..Default::default()
         };
         let result = resolve_library_selection(None, Some(&toml_filters));
         assert_eq!(

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -98,11 +98,6 @@ impl PhotosService {
         format!("{service_root}/database/1/com.apple.photos.cloud/production/{library_type}")
     }
 
-    /// Return the "All Photos" album from the primary library.
-    pub fn all(&self) -> PhotoAlbum {
-        self.primary_library.all()
-    }
-
     /// Look up a library by zone name.
     ///
     /// Checks the primary library first ("`PrimarySync`"), then searches private

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -116,7 +116,9 @@ impl PhotosService {
         if let Some(lib) = self.shared_libraries.as_ref().and_then(|m| m.get(name)) {
             return Ok(lib);
         }
-        anyhow::bail!("Unknown library: '{name}'. Use --list-libraries to see available libraries.")
+        anyhow::bail!(
+            "Unknown library: '{name}'. Run `kei list libraries` to see available libraries."
+        )
     }
 
     /// Return all available libraries: primary + private (non-PrimarySync) + shared.

--- a/src/main.rs
+++ b/src/main.rs
@@ -759,6 +759,7 @@ async fn run_login(
 async fn run_list(
     what: cli::ListCommand,
     pw: &cli::PasswordArgs,
+    library: Option<String>,
     globals: &config::GlobalArgs,
     toml: Option<&TomlConfig>,
 ) -> anyhow::Result<()> {
@@ -806,15 +807,13 @@ async fn run_list(
             }
         }
         cli::ListCommand::Albums => {
-            // Resolve library selection from TOML
-            let toml_filters = toml.and_then(|t| t.filters.as_ref());
-            let library_str = toml_filters
-                .and_then(|f| f.library.clone())
-                .unwrap_or_else(|| "PrimarySync".to_string());
-            let libraries = if library_str.eq_ignore_ascii_case("all") {
-                photos_service.all_libraries().await?
-            } else {
-                vec![photos_service.get_library(&library_str).await?.clone()]
+            let selection =
+                config::resolve_library_selection(library, toml.and_then(|t| t.filters.as_ref()));
+            let libraries = match selection {
+                config::LibrarySelection::All => photos_service.all_libraries().await?,
+                config::LibrarySelection::Single(name) => {
+                    vec![photos_service.get_library(&name).await?.clone()]
+                }
             };
             for library in &libraries {
                 println!("Library: {}", library.zone_name());
@@ -939,7 +938,7 @@ async fn run_import_existing(
     )
     .await?;
 
-    let (_shared_session, photos_service) = init_photos_service(
+    let (_shared_session, mut photos_service) = init_photos_service(
         auth_result,
         &username,
         domain.as_str(),
@@ -948,9 +947,21 @@ async fn run_import_existing(
     )
     .await?;
 
-    let all_album = photos_service.all();
-    let stream = all_album.photo_stream(args.recent, None, 1);
-    tokio::pin!(stream);
+    // Resolve library selection (CLI > TOML > default PrimarySync)
+    let toml_filters = toml.and_then(|t| t.filters.as_ref());
+    let selection = config::resolve_library_selection(args.library, toml_filters);
+    let libraries = match selection {
+        config::LibrarySelection::All => {
+            tracing::info!("Importing from all available libraries");
+            photos_service.all_libraries().await?
+        }
+        config::LibrarySelection::Single(name) => {
+            if name != "PrimarySync" {
+                tracing::info!(library = %name, "Importing from non-default library");
+            }
+            vec![photos_service.get_library(&name).await?.clone()]
+        }
+    };
 
     if !args.no_progress_bar {
         println!("Scanning iCloud assets and matching with local files...");
@@ -960,107 +971,118 @@ async fn run_import_existing(
     let mut unmatched = 0u64;
     let mut total = 0u64;
 
-    while let Some(result) = stream.next().await {
-        let asset: icloud::photos::PhotoAsset = match result {
-            Ok(a) => a,
-            Err(e) => {
-                tracing::warn!(error = %e, "Error fetching asset");
+    for library in &libraries {
+        tracing::info!(zone = %library.zone_name(), "Scanning library");
+        let all_album = library.all();
+        let stream = all_album.photo_stream(args.recent, None, 1);
+        tokio::pin!(stream);
+
+        while let Some(result) = stream.next().await {
+            let asset: icloud::photos::PhotoAsset = match result {
+                Ok(a) => a,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Error fetching asset");
+                    continue;
+                }
+            };
+
+            total += 1;
+
+            // Get versions
+            if asset.versions().is_empty() {
+                tracing::debug!(id = %asset.id(), "Skipping asset with no versions");
                 continue;
             }
-        };
 
-        total += 1;
+            // Resolve filename using the same logic as the sync download pipeline:
+            // fingerprint fallback → unicode removal → extension mapping.
+            let raw_filename = if let Some(f) = asset.filename() {
+                f.to_string()
+            } else {
+                let asset_type = asset
+                    .versions()
+                    .first()
+                    .map_or("", |(_, v)| v.asset_type.as_ref());
+                download::paths::generate_fingerprint_filename(asset.id(), asset_type)
+            };
+            let base_filename = if keep_unicode {
+                raw_filename
+            } else {
+                download::paths::remove_unicode_chars(&raw_filename)
+            };
 
-        // Get versions
-        if asset.versions().is_empty() {
-            tracing::debug!(id = %asset.id(), "Skipping asset with no versions");
-            continue;
-        }
+            // Get the created date in local time for path computation
+            let created_local = asset.created().with_timezone(&Local);
 
-        // Resolve filename using the same logic as the sync download pipeline:
-        // fingerprint fallback → unicode removal → extension mapping.
-        let raw_filename = if let Some(f) = asset.filename() {
-            f.to_string()
-        } else {
-            let asset_type = asset
-                .versions()
-                .first()
-                .map_or("", |(_, v)| v.asset_type.as_ref());
-            download::paths::generate_fingerprint_filename(asset.id(), asset_type)
-        };
-        let base_filename = if keep_unicode {
-            raw_filename
-        } else {
-            download::paths::remove_unicode_chars(&raw_filename)
-        };
+            // Check each version (we only check "original" for import since that's
+            // what the normal sync would download)
+            if let Some(version) = asset.get_version(AssetVersionSize::Original) {
+                // Map extension from UTI type, matching sync pipeline
+                let filename =
+                    download::paths::map_filename_extension(&base_filename, &version.asset_type);
+                let expected_path = download::paths::local_download_path(
+                    &directory,
+                    &folder_structure,
+                    &created_local,
+                    &filename,
+                    None, // import-existing doesn't have album context
+                );
 
-        // Get the created date in local time for path computation
-        let created_local = asset.created().with_timezone(&Local);
+                if expected_path.exists() {
+                    // Check size matches
+                    if let Ok(metadata) = std::fs::metadata(&expected_path) {
+                        if metadata.len() == version.size {
+                            // File exists with matching size - mark as downloaded
+                            let version_size = state::VersionSizeKey::Original;
+                            let media_type = download::determine_media_type(version_size, &asset);
+                            let record = state::AssetRecord::new_pending(
+                                asset.id().to_string(),
+                                version_size,
+                                version.checksum.to_string(),
+                                filename.clone(),
+                                asset.created(),
+                                Some(asset.added_date()),
+                                version.size,
+                                media_type,
+                            );
 
-        // Check each version (we only check "original" for import since that's
-        // what the normal sync would download)
-        if let Some(version) = asset.get_version(AssetVersionSize::Original) {
-            // Map extension from UTI type, matching sync pipeline
-            let filename =
-                download::paths::map_filename_extension(&base_filename, &version.asset_type);
-            let expected_path = download::paths::local_download_path(
-                &directory,
-                &folder_structure,
-                &created_local,
-                &filename,
-                None, // import-existing doesn't have album context
-            );
-
-            if expected_path.exists() {
-                // Check size matches
-                if let Ok(metadata) = std::fs::metadata(&expected_path) {
-                    if metadata.len() == version.size {
-                        // File exists with matching size - mark as downloaded
-                        let version_size = state::VersionSizeKey::Original;
-                        let media_type = download::determine_media_type(version_size, &asset);
-                        let record = state::AssetRecord::new_pending(
-                            asset.id().to_string(),
-                            version_size,
-                            version.checksum.to_string(),
-                            filename.clone(),
-                            asset.created(),
-                            Some(asset.added_date()),
-                            version.size,
-                            media_type,
-                        );
-
-                        if let Err(e) = db.upsert_seen(&record).await {
-                            tracing::warn!(asset_id = %asset.id(), error = %e, "Failed to record asset");
-                            continue;
-                        }
-
-                        let local_checksum = match download::file::compute_sha256(&expected_path)
-                            .await
-                        {
-                            Ok(hash) => hash,
-                            Err(e) => {
-                                tracing::warn!(path = %expected_path.display(), error = %e, "Failed to hash file");
+                            if let Err(e) = db.upsert_seen(&record).await {
+                                tracing::warn!(asset_id = %asset.id(), error = %e, "Failed to record asset");
                                 continue;
                             }
-                        };
 
-                        if let Err(e) = db
-                            .mark_downloaded(
-                                asset.id(),
-                                version_size.as_str(),
+                            let local_checksum = match download::file::compute_sha256(
                                 &expected_path,
-                                &local_checksum,
-                                None,
                             )
                             .await
-                        {
-                            tracing::warn!(asset_id = %asset.id(), error = %e, "Failed to mark as downloaded");
-                            continue;
-                        }
+                            {
+                                Ok(hash) => hash,
+                                Err(e) => {
+                                    tracing::warn!(path = %expected_path.display(), error = %e, "Failed to hash file");
+                                    continue;
+                                }
+                            };
 
-                        matched += 1;
-                        if !args.no_progress_bar && matched.is_multiple_of(100) {
-                            println!("  Matched {matched} files so far...");
+                            if let Err(e) = db
+                                .mark_downloaded(
+                                    asset.id(),
+                                    version_size.as_str(),
+                                    &expected_path,
+                                    &local_checksum,
+                                    None,
+                                )
+                                .await
+                            {
+                                tracing::warn!(asset_id = %asset.id(), error = %e, "Failed to mark as downloaded");
+                                continue;
+                            }
+
+                            matched += 1;
+                            if !args.no_progress_bar && matched.is_multiple_of(100) {
+                                println!("  Matched {matched} files so far...");
+                            }
+                        } else {
+                            unmatched += 1;
                         }
                     } else {
                         unmatched += 1;
@@ -1068,8 +1090,6 @@ async fn run_import_existing(
                 } else {
                     unmatched += 1;
                 }
-            } else {
-                unmatched += 1;
             }
         }
     }
@@ -1342,8 +1362,12 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         Command::Password { password, action } => {
             return run_password(action, &globals, &password, toml_config.as_ref()).await;
         }
-        Command::List { password, what } => {
-            return run_list(what, &password, &globals, toml_config.as_ref()).await;
+        Command::List {
+            password,
+            library,
+            what,
+        } => {
+            return run_list(what, &password, library, &globals, toml_config.as_ref()).await;
         }
         Command::Config { action } => match action {
             cli::ConfigAction::Show => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1561,7 +1561,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 .is_some_and(auth::error::AuthError::is_two_factor_required) =>
         {
             let msg = format!(
-                "2FA required for {u}. Run: kei get-code",
+                "2FA required for {u}. Run: kei login get-code",
                 u = config.username
             );
             tracing::warn!(message = %msg, "2FA required");
@@ -2044,7 +2044,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                         reauth_attempts -= 1;
 
                         let msg = format!(
-                            "2FA required for {u}. Run: kei get-code",
+                            "2FA required for {u}. Run: kei login get-code",
                             u = config.username
                         );
                         tracing::warn!(message = %msg, "2FA required");

--- a/src/main.rs
+++ b/src/main.rs
@@ -809,12 +809,7 @@ async fn run_list(
         cli::ListCommand::Albums => {
             let selection =
                 config::resolve_library_selection(library, toml.and_then(|t| t.filters.as_ref()));
-            let libraries = match selection {
-                config::LibrarySelection::All => photos_service.all_libraries().await?,
-                config::LibrarySelection::Single(name) => {
-                    vec![photos_service.get_library(&name).await?.clone()]
-                }
-            };
+            let libraries = resolve_libraries(&selection, &mut photos_service).await?;
             for library in &libraries {
                 println!("Library: {}", library.zone_name());
                 let albums = library.albums().await?;
@@ -950,18 +945,7 @@ async fn run_import_existing(
     // Resolve library selection (CLI > TOML > default PrimarySync)
     let toml_filters = toml.and_then(|t| t.filters.as_ref());
     let selection = config::resolve_library_selection(args.library, toml_filters);
-    let libraries = match selection {
-        config::LibrarySelection::All => {
-            tracing::info!("Importing from all available libraries");
-            photos_service.all_libraries().await?
-        }
-        config::LibrarySelection::Single(name) => {
-            if name != "PrimarySync" {
-                tracing::info!(library = %name, "Importing from non-default library");
-            }
-            vec![photos_service.get_library(&name).await?.clone()]
-        }
-    };
+    let libraries = resolve_libraries(&selection, &mut photos_service).await?;
 
     if !args.no_progress_bar {
         println!("Scanning iCloud assets and matching with local files...");
@@ -1101,6 +1085,25 @@ async fn run_import_existing(
     println!("  Unmatched versions:   {unmatched}");
 
     Ok(())
+}
+
+/// Resolve a [`LibrarySelection`] into concrete [`PhotoLibrary`] instances.
+async fn resolve_libraries(
+    selection: &config::LibrarySelection,
+    photos_service: &mut icloud::photos::PhotosService,
+) -> anyhow::Result<Vec<icloud::photos::PhotoLibrary>> {
+    match selection {
+        config::LibrarySelection::All => {
+            tracing::info!("Using all available libraries");
+            photos_service.all_libraries().await
+        }
+        config::LibrarySelection::Single(name) => {
+            if name != "PrimarySync" {
+                tracing::info!(library = %name, "Using non-default library");
+            }
+            Ok(vec![photos_service.get_library(name).await?.clone()])
+        }
+    }
 }
 
 /// Resolve which albums to download from, plus any asset IDs to exclude.
@@ -1638,18 +1641,7 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     .await?;
 
     // Resolve the selected library/libraries
-    let libraries: Vec<icloud::photos::PhotoLibrary> = match &config.library {
-        config::LibrarySelection::All => {
-            tracing::info!("Using all available libraries");
-            photos_service.all_libraries().await?
-        }
-        config::LibrarySelection::Single(name) => {
-            if name != "PrimarySync" {
-                tracing::info!(library = %name, "Using non-default library");
-            }
-            vec![photos_service.get_library(name).await?.clone()]
-        }
-    };
+    let libraries = resolve_libraries(&config.library, &mut photos_service).await?;
     tracing::info!(
         count = libraries.len(),
         zones = %libraries.iter().map(|l| l.zone_name().to_string()).collect::<Vec<_>>().join(", "),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1087,7 +1087,7 @@ async fn run_import_existing(
     Ok(())
 }
 
-/// Resolve a [`LibrarySelection`] into concrete [`PhotoLibrary`] instances.
+/// Resolve a `LibrarySelection` into concrete `PhotoLibrary` instances.
 async fn resolve_libraries(
     selection: &config::LibrarySelection,
     photos_service: &mut icloud::photos::PhotosService,

--- a/src/password.rs
+++ b/src/password.rs
@@ -53,7 +53,7 @@ impl PasswordSource {
                         "No password configured and stdin is not a terminal. \
                          Set a password with one of:\n  \
                          - ICLOUD_PASSWORD environment variable\n  \
-                         - kei credential set\n  \
+                         - kei password set\n  \
                          - --password-command (external secret manager)\n  \
                          - --password-file or Docker secret\n  \
                          - [auth] password in config.toml"

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -333,7 +333,7 @@ fn ask_what_to_download(answers: &mut SetupAnswers) -> anyhow::Result<()> {
             .filter(|s| !s.is_empty())
             .collect();
         if !answers.albums.is_empty() {
-            println!("  Tip: run `kei sync --list-albums` to see available album names.");
+            println!("  Tip: run `kei list albums` to see available album names.");
         }
     }
 


### PR DESCRIPTION
## Summary

- **import-existing** ignored `--library` / `KEI_LIBRARY` / TOML `[filters] library`, always scanning only PrimarySync. Users with SharedSync libraries couldn't import existing files for those libraries. Now respects library selection and iterates all resolved libraries. Fixes #179.
- **list albums** only read library from TOML, not from a CLI `--library` flag. Now accepts `--library` for consistency.
- Error messages referenced deprecated command names (`kei credential set`, `kei get-code`, `--list-libraries`, `kei sync --list-albums`). Updated to current names. Fixes #178.
- `--save-password` was on `PasswordArgs` (shared by all authenticating commands) but only acted on by sync. Moved to `SyncArgs` so it's only offered where it works.
- Extracted `resolve_libraries()` and `resolve_library_selection()` helpers to DRY up 3-site duplication.
- Removed now-unused `PhotosService::all()`.

## Test plan

- [x] `cargo fmt -- --check && cargo clippy && cargo test` -- 1296 tests pass, zero warnings
- [x] Docker live test: `import-existing` default (PrimarySync only)
- [x] Docker live test: `import-existing --library SharedSync-<zone>`
- [x] Docker live test: `import-existing --library all` (both zones scanned)
- [x] Docker live test: `list --library all albums`