### PR TITLE
Release session lock during watch idle sleep

### DIFF
--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -21,6 +21,9 @@ pub enum AuthError {
     #[error("Two-factor authentication is required (no code provided)")]
     TwoFactorRequired,
 
+    #[error("Session lock held by another instance: {0}")]
+    LockContention(String),
+
     #[error(transparent)]
     Http(Box<reqwest::Error>),
 
@@ -57,6 +60,11 @@ impl AuthError {
         matches!(self, Self::TwoFactorRequired)
     }
 
+    /// Check if this error indicates lock contention with another kei instance.
+    pub fn is_lock_contention(&self) -> bool {
+        matches!(self, Self::LockContention(_))
+    }
+
     /// Build a `ServiceError` with an enriched message for well-known Apple error codes.
     pub(crate) fn service_error(code: &str, raw_message: &str) -> Self {
         let upper = code.to_ascii_uppercase();
@@ -91,6 +99,7 @@ mod tests {
         assert!(!AuthError::FailedLogin("test".into()).is_two_factor_required());
         assert!(!AuthError::TwoFactorFailed("test".into()).is_two_factor_required());
         assert!(!AuthError::InvalidToken("test".into()).is_two_factor_required());
+        assert!(!AuthError::LockContention("test".into()).is_two_factor_required());
         assert!(!AuthError::ApiError {
             code: 401,
             message: "test".into()
@@ -101,6 +110,23 @@ mod tests {
             message: "test".into()
         }
         .is_two_factor_required());
+    }
+
+    #[test]
+    fn lock_contention_is_detected() {
+        assert!(AuthError::LockContention("test".into()).is_lock_contention());
+    }
+
+    #[test]
+    fn other_variants_are_not_lock_contention() {
+        assert!(!AuthError::FailedLogin("test".into()).is_lock_contention());
+        assert!(!AuthError::TwoFactorRequired.is_lock_contention());
+    }
+
+    #[test]
+    fn lock_contention_display() {
+        let err = AuthError::LockContention("lock path".into());
+        assert!(err.to_string().contains("lock path"));
     }
 
     #[test]

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -188,12 +188,13 @@ impl Session {
                     .try_lock_exclusive()
                     .with_context(|| format!("Failed to acquire lock: {}", lock_path.display()))?;
                 if !acquired {
-                    anyhow::bail!(
+                    return Err(crate::auth::error::AuthError::LockContention(format!(
                         "Another kei instance is running for this account (lock: {}). \
                          If running in Docker, check for orphaned containers with \
                          `docker ps` and stop them with `docker stop <name>`.",
                         lock_path.display()
-                    );
+                    ))
+                    .into());
                 }
                 Ok::<std::fs::File, anyhow::Error>(file)
             }
@@ -330,6 +331,24 @@ impl Session {
     /// This allows a new Session to acquire the lock (e.g. during re-authentication).
     pub fn release_lock(&self) -> Result<()> {
         FileExt::unlock(&self.lock_file).context("Failed to release session lock file")
+    }
+
+    /// Re-acquire the exclusive file lock after a prior `release_lock()`.
+    ///
+    /// Returns `Err(AuthError::LockContention)` if another process acquired
+    /// the lock in the interim (e.g. a concurrent `get-code` or `submit-code`).
+    pub fn reacquire_lock(&self) -> Result<()> {
+        let acquired = self
+            .lock_file
+            .try_lock_exclusive()
+            .context("Failed to re-acquire session lock")?;
+        if !acquired {
+            return Err(crate::auth::error::AuthError::LockContention(
+                "Another kei instance acquired the lock while it was released".into(),
+            )
+            .into());
+        }
+        Ok(())
     }
 
     pub fn client_id(&self) -> Option<&String> {
@@ -557,9 +576,9 @@ mod tests {
         match result {
             Ok(_) => panic!("Second session should have failed"),
             Err(e) => assert!(
-                e.to_string().contains("Another kei instance"),
-                "Unexpected error: {}",
-                e
+                e.downcast_ref::<crate::auth::error::AuthError>()
+                    .is_some_and(crate::auth::error::AuthError::is_lock_contention),
+                "Expected LockContention, got: {e}",
             ),
         }
     }
@@ -586,6 +605,54 @@ mod tests {
         let _s2 = Session::new(&dir, "user@test.com", "https://example.com", None)
             .await
             .expect("Lock should be released after drop");
+    }
+
+    #[tokio::test]
+    async fn test_release_and_reacquire_lock() {
+        let (_td, dir) = test_dir("lock_reacquire");
+        let s1 = Session::new(&dir, "user@test.com", "https://example.com", None)
+            .await
+            .unwrap();
+
+        // Release the lock — another session should now succeed
+        s1.release_lock().unwrap();
+        let s2 = Session::new(&dir, "user@test.com", "https://example.com", None)
+            .await
+            .expect("Should acquire lock after release");
+        drop(s2);
+
+        // Re-acquire the lock on the original session
+        s1.reacquire_lock()
+            .expect("Should re-acquire after other session dropped");
+
+        // Now a new session should be blocked again
+        let result = Session::new(&dir, "user@test.com", "https://example.com", None).await;
+        match result {
+            Ok(_) => panic!("Lock should be held after reacquire"),
+            Err(e) => assert!(
+                e.downcast_ref::<crate::auth::error::AuthError>()
+                    .is_some_and(crate::auth::error::AuthError::is_lock_contention),
+                "Expected LockContention, got: {e}",
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reacquire_fails_while_held() {
+        let (_td, dir) = test_dir("lock_reacquire_contention");
+        let s1 = Session::new(&dir, "user@test.com", "https://example.com", None)
+            .await
+            .unwrap();
+        s1.release_lock().unwrap();
+
+        // Another session holds the lock
+        let _s2 = Session::new(&dir, "user@test.com", "https://example.com", None)
+            .await
+            .unwrap();
+
+        // Reacquire should fail because s2 holds the lock
+        let result = s1.reacquire_lock();
+        assert!(result.is_err(), "Should fail to reacquire while held");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,6 +413,51 @@ async fn wait_for_2fa_submit(cookie_dir: &Path, username: &str) {
     }
 }
 
+/// Wait for a 2FA code submission, then retry authentication with back-off.
+///
+/// Polls `wait_for_2fa_submit` in a loop. After each mtime change, retries
+/// the provided `auth_fn` up to 3 times with 5-second back-off to handle
+/// lock contention (submit-code may still be running when mtime changes).
+/// False wakeups from get-code's SRP writes (which change the mtime before
+/// the session is trusted) are handled by looping back to wait.
+async fn wait_and_retry_2fa<T, F, Fut>(
+    cookie_dir: &Path,
+    username: &str,
+    auth_fn: F,
+) -> anyhow::Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    loop {
+        wait_for_2fa_submit(cookie_dir, username).await;
+
+        for attempt in 0..3 {
+            if attempt > 0 {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            }
+            match (auth_fn)().await {
+                Ok(result) => return Ok(result),
+                Err(e)
+                    if e.downcast_ref::<auth::error::AuthError>()
+                        .is_some_and(auth::error::AuthError::is_two_factor_required) =>
+                {
+                    tracing::info!("Session not yet trusted, continuing to wait...");
+                    break; // Back to outer loop (wait_for_2fa_submit)
+                }
+                Err(e)
+                    if e.downcast_ref::<auth::error::AuthError>()
+                        .is_some_and(auth::error::AuthError::is_lock_contention) =>
+                {
+                    tracing::debug!("Lock held by another process, retrying...");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        tracing::debug!("Lock still held after retries, resuming wait...");
+    }
+}
+
 /// Get the database path for a given auth config, merging with TOML defaults.
 ///
 /// Returns an error if the resolved username is empty, since an empty username
@@ -710,26 +755,30 @@ async fn run_login(
 
     match subcommand {
         Some(cli::LoginCommand::GetCode) => {
-            auth::send_2fa_push(
-                &cookie_directory,
-                &username,
-                &password_provider,
-                domain.as_str(),
-            )
+            retry_on_lock_contention(|| {
+                auth::send_2fa_push(
+                    &cookie_directory,
+                    &username,
+                    &password_provider,
+                    domain.as_str(),
+                )
+            })
             .await?;
             println!("2FA code requested. Check your trusted devices, then run:");
             println!("  kei login submit-code <CODE>");
         }
         Some(cli::LoginCommand::SubmitCode { code }) => {
-            let result = auth::authenticate(
-                &cookie_directory,
-                &username,
-                &password_provider,
-                domain.as_str(),
-                None,
-                None,
-                Some(&code),
-            )
+            let result = retry_on_lock_contention(|| {
+                auth::authenticate(
+                    &cookie_directory,
+                    &username,
+                    &password_provider,
+                    domain.as_str(),
+                    None,
+                    None,
+                    Some(&code),
+                )
+            })
             .await?;
             if result.requires_2fa {
                 println!("2FA code accepted. Session is now authenticated.");
@@ -739,20 +788,57 @@ async fn run_login(
         }
         None => {
             // Bare "kei login" = auth-only
-            auth::authenticate(
-                &cookie_directory,
-                &username,
-                &password_provider,
-                domain.as_str(),
-                None,
-                None,
-                None,
-            )
+            retry_on_lock_contention(|| {
+                auth::authenticate(
+                    &cookie_directory,
+                    &username,
+                    &password_provider,
+                    domain.as_str(),
+                    None,
+                    None,
+                    None,
+                )
+            })
             .await?;
             tracing::info!("Authentication completed successfully");
         }
     }
     Ok(())
+}
+
+/// Retry an auth operation on lock contention, with a brief wait.
+///
+/// Short-lived commands like `login get-code` and `login submit-code` may
+/// collide with a `sync` process that is mid-auth (SRP takes a few seconds).
+/// Instead of failing immediately, wait for the lock to be released.
+async fn retry_on_lock_contention<T, F, Fut>(auth_fn: F) -> anyhow::Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    const MAX_ATTEMPTS: u32 = 6;
+    const DELAY_SECS: u64 = 3;
+
+    let mut last_err = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match (auth_fn)().await {
+            Ok(result) => return Ok(result),
+            Err(e)
+                if e.downcast_ref::<auth::error::AuthError>()
+                    .is_some_and(auth::error::AuthError::is_lock_contention) =>
+            {
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_attempts = MAX_ATTEMPTS,
+                    "Another kei process is holding the session lock, retrying..."
+                );
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_secs(DELAY_SECS)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.expect("MAX_ATTEMPTS must be >= 1"))
 }
 
 /// Run the list command: list albums or libraries.
@@ -772,15 +858,17 @@ async fn run_list(
     let password_provider =
         make_provider_from_auth(pw, password, &username, &cookie_directory, toml);
 
-    let auth_result = auth::authenticate(
-        &cookie_directory,
-        &username,
-        &password_provider,
-        domain.as_str(),
-        None,
-        None,
-        None,
-    )
+    let auth_result = retry_on_lock_contention(|| {
+        auth::authenticate(
+            &cookie_directory,
+            &username,
+            &password_provider,
+            domain.as_str(),
+            None,
+            None,
+            None,
+        )
+    })
     .await?;
 
     let api_retry_config = retry::RetryConfig::default();
@@ -1567,47 +1655,18 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
             tracing::warn!(message = %msg, "2FA required");
             notifier.notify(notifications::Event::TwoFaRequired, &msg, &config.username);
 
-            // Wait for submit-code to update the session file, then retry
-            // auth. Loop because get-code also writes to the session file
-            // (during SRP), which changes the mtime and wakes us up before
-            // the session is actually trusted.
-            'wait_2fa: loop {
-                wait_for_2fa_submit(&config.cookie_directory, &config.username).await;
-
-                // Retry auth with back-off for lock contention — submit-code
-                // may still be running when we detect the mtime change.
-                for attempt in 0..3 {
-                    if attempt > 0 {
-                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    }
-                    match auth::authenticate(
-                        &config.cookie_directory,
-                        &config.username,
-                        &password_provider,
-                        config.domain.as_str(),
-                        None,
-                        None,
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(result) => break 'wait_2fa result,
-                        Err(e)
-                            if e.downcast_ref::<auth::error::AuthError>()
-                                .is_some_and(auth::error::AuthError::is_two_factor_required) =>
-                        {
-                            tracing::info!("Session not yet trusted, continuing to wait...");
-                            continue 'wait_2fa;
-                        }
-                        Err(e) if e.to_string().contains("Another kei instance") => {
-                            tracing::debug!("Lock held by another process, retrying...");
-                        }
-                        Err(e) => return Err(e),
-                    }
-                }
-                // Exhausted lock retries — back to waiting for next file change
-                tracing::debug!("Lock still held after retries, resuming wait...");
-            }
+            wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
+                auth::authenticate(
+                    &config.cookie_directory,
+                    &config.username,
+                    &password_provider,
+                    config.domain.as_str(),
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .await?
         }
         Err(e) => return Err(e),
     };
@@ -2056,7 +2115,17 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                         if !is_watch_mode {
                             return Err(e);
                         }
-                        wait_for_2fa_submit(&config.cookie_directory, &config.username).await;
+
+                        wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
+                            attempt_reauth(
+                                &shared_session,
+                                &config.cookie_directory,
+                                &config.username,
+                                config.domain.as_str(),
+                                &password_provider,
+                            )
+                        })
+                        .await?;
                         continue;
                     }
                     Err(e) => {
@@ -2105,6 +2174,16 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 tracing::info!("Shutdown requested, exiting...");
                 break;
             }
+
+            // Release the file lock during idle sleep so that docker exec
+            // commands (login get-code, login submit-code) can acquire it.
+            {
+                let session = shared_session.read().await;
+                if let Err(e) = session.release_lock() {
+                    tracing::warn!(error = %e, "Failed to release lock before idle sleep");
+                }
+            }
+
             sd_notifier.notify_status(&format!("Waiting {interval} seconds..."));
             tracing::info!(interval_secs = interval, "Waiting before next cycle");
             tokio::select! {
@@ -2115,8 +2194,11 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 }
             }
 
-            // Validate session before next cycle; re-authenticate if expired
-            attempt_reauth(
+            // Validate session before next cycle; re-authenticate if expired.
+            // If the session is still valid, attempt_reauth returns without
+            // re-locking, so we re-acquire the lock ourselves. If the session
+            // is invalid, attempt_reauth creates a new Session with its own lock.
+            match attempt_reauth(
                 &shared_session,
                 &config.cookie_directory,
                 &config.username,
@@ -2124,7 +2206,26 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
                 &password_provider,
             )
             .await
-            .ok(); // Best-effort pre-check; mid-sync re-auth handles failures
+            {
+                Ok(()) => {
+                    // Re-acquire the lock. If attempt_reauth performed a full
+                    // re-auth, the new Session already holds its own lock, so
+                    // LockContention here is expected and harmless.
+                    let session = shared_session.read().await;
+                    if let Err(e) = session.reacquire_lock() {
+                        if e.downcast_ref::<auth::error::AuthError>()
+                            .is_some_and(auth::error::AuthError::is_lock_contention)
+                        {
+                            tracing::debug!("Lock held by new session after reauth");
+                        } else {
+                            tracing::warn!(error = %e, "Failed to reacquire lock after idle");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Pre-cycle reauth failed, will retry mid-sync");
+                }
+            }
 
             // Re-resolve albums per-library to discover newly created iCloud albums.
             // TODO: When --exclude-album is set without --album, this re-fetches the


### PR DESCRIPTION
## Summary

Fixes #191 -- the exclusive file lock was held continuously during watch mode, including the idle sleep between sync cycles. This prevented `docker exec` commands (`login get-code`, `login submit-code`) from acquiring the lock to perform 2FA authentication.

- Release the file lock before the idle sleep window, reacquire after `attempt_reauth`
- Add `Session::reacquire_lock()` for re-locking after a prior `release_lock()`
- Add `AuthError::LockContention` typed variant, replacing fragile string matching on error messages
- Extract `wait_and_retry_2fa()` to deduplicate the 2FA retry loop used by both initial-auth and watch-mode mid-cycle paths
- Add `retry_on_lock_contention()` so `login get-code`, `login submit-code`, `login`, and `list` wait briefly instead of failing immediately when another process is mid-auth

## Test plan

- [x] Verify `cargo fmt -- --check && cargo clippy && cargo test` passes (1302 tests, 0 failures)
- [x] Docker: start container with `watch_with_interval`, wait for idle sleep, run `docker exec kei kei login get-code` -- should acquire the lock
- [x] Docker: start container, immediately run `docker exec kei kei login get-code` during initial SRP -- should see "Another kei process is holding the session lock, retrying..." and succeed after sync finishes auth
- [x] Verify watch mode resumes correctly after idle lock release/reacquire cycle