### PR TITLE
Fix 421 recovery and tighten internals

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -68,9 +68,28 @@ pub async fn authenticate(
     code: Option<&str>,
 ) -> Result<AuthResult> {
     let endpoints = Endpoints::for_domain(domain)?;
+    let session = Session::new(cookie_dir, apple_id, endpoints.home, timeout_secs).await?;
+    authenticate_inner(
+        session,
+        &endpoints,
+        apple_id,
+        password_provider,
+        domain,
+        client_id,
+        code,
+    )
+    .await
+}
 
-    let mut session = Session::new(cookie_dir, apple_id, endpoints.home, timeout_secs).await?;
-
+async fn authenticate_inner(
+    mut session: Session,
+    endpoints: &Endpoints,
+    apple_id: &str,
+    password_provider: &dyn Fn() -> Option<SecretString>,
+    domain: &str,
+    client_id: Option<String>,
+    code: Option<&str>,
+) -> Result<AuthResult> {
     // Prefer persisted client_id to maintain session continuity across runs
     let client_id = session
         .client_id()
@@ -83,7 +102,7 @@ pub async fn authenticate(
     let has_session_token = session.session_data.contains_key("session_token");
     if has_session_token {
         tracing::debug!("Checking session token validity");
-        match twofa::validate_token(&mut session, &endpoints).await {
+        match twofa::validate_token(&mut session, endpoints).await {
             Ok(d) => {
                 tracing::debug!("Existing session token is valid");
                 data = Some(d);
@@ -106,7 +125,7 @@ pub async fn authenticate(
     // 2FA push from Apple, invalidating the code the user already has).
     if data.is_none() && code.is_some() && has_session_token {
         tracing::debug!("Session token exists with code provided, trying accountLogin before SRP");
-        match twofa::authenticate_with_token(&mut session, &endpoints).await {
+        match twofa::authenticate_with_token(&mut session, endpoints).await {
             Ok(d) => {
                 tracing::debug!("accountLogin succeeded, skipping SRP");
                 data = Some(d);
@@ -129,7 +148,7 @@ pub async fn authenticate(
 
         srp::authenticate_srp(
             &mut session,
-            &endpoints,
+            endpoints,
             apple_id,
             password.expose_secret(),
             &client_id,
@@ -138,7 +157,7 @@ pub async fn authenticate(
         .await?;
         // `password` (SecretString) dropped here, zeroing memory
 
-        let account_data = twofa::authenticate_with_token(&mut session, &endpoints).await?;
+        let account_data = twofa::authenticate_with_token(&mut session, endpoints).await?;
         data = Some(account_data);
     }
 
@@ -157,7 +176,7 @@ pub async fn authenticate(
         let verified = if let Some(c) = code {
             // Headless: code provided directly (e.g. submit-code subcommand).
             // Do NOT trigger a push — it would invalidate the code being submitted.
-            twofa::submit_2fa_code(&mut session, &endpoints, &client_id, domain, c).await?
+            twofa::submit_2fa_code(&mut session, endpoints, &client_id, domain, c).await?
         } else {
             // Interactive: prompt on stdin (terminal confirmed above).
             // Always trigger an explicit push before prompting. SRP pushes
@@ -165,7 +184,7 @@ pub async fn authenticate(
             // ensures every account gets one. Apple deduplicates, so
             // accounts that already got a code from SRP won't see a second.
             if let Err(e) =
-                twofa::trigger_push_notification(&mut session, &endpoints, &client_id, domain).await
+                twofa::trigger_push_notification(&mut session, endpoints, &client_id, domain).await
             {
                 tracing::warn!(error = %e, "Failed to trigger push notification");
             }
@@ -179,7 +198,7 @@ pub async fn authenticate(
                     // User didn't receive a code - trigger explicit push.
                     if let Err(e) = twofa::trigger_push_notification(
                         &mut session,
-                        &endpoints,
+                        endpoints,
                         &client_id,
                         domain,
                     )
@@ -190,7 +209,7 @@ pub async fn authenticate(
                     tracing::info!("Code requested - check your trusted devices");
                     continue;
                 }
-                if twofa::submit_2fa_code(&mut session, &endpoints, &client_id, domain, &input)
+                if twofa::submit_2fa_code(&mut session, endpoints, &client_id, domain, &input)
                     .await?
                 {
                     verified = true;
@@ -213,9 +232,9 @@ pub async fn authenticate(
             return Err(AuthError::TwoFactorFailed("2FA verification failed".into()).into());
         }
 
-        twofa::trust_session(&mut session, &endpoints, &client_id, domain).await?;
+        twofa::trust_session(&mut session, endpoints, &client_id, domain).await?;
         // Re-authenticate to get fresh account data with 2FA-elevated privileges
-        let account_data = twofa::authenticate_with_token(&mut session, &endpoints).await?;
+        let account_data = twofa::authenticate_with_token(&mut session, endpoints).await?;
 
         tracing::info!("Authentication completed successfully");
         return Ok(AuthResult {

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -1003,4 +1003,42 @@ mod tests {
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "File should be owner-only, got {:o}", mode);
     }
+
+    #[tokio::test]
+    async fn test_reset_http_clients_preserves_cookie_jar() {
+        let (_td, dir) = test_dir("reset_cookies");
+        let mut session = Session::new(&dir, "user@test.com", "https://example.com", None)
+            .await
+            .unwrap();
+
+        // Get a pointer to the cookie jar before reset.
+        let jar_before = Arc::as_ptr(&session.cookie_jar);
+
+        session.reset_http_clients().unwrap();
+
+        // Same Arc, same underlying jar.
+        let jar_after = Arc::as_ptr(&session.cookie_jar);
+        assert_eq!(
+            jar_before, jar_after,
+            "reset_http_clients must reuse the existing cookie jar"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_http_clients_preserves_api_timeout() {
+        let (_td, dir) = test_dir("reset_timeout");
+        let custom_timeout = Some(45);
+        let mut session =
+            Session::new(&dir, "user@test.com", "https://example.com", custom_timeout)
+                .await
+                .unwrap();
+
+        assert_eq!(session.api_timeout, Duration::from_secs(45));
+        session.reset_http_clients().unwrap();
+        assert_eq!(
+            session.api_timeout,
+            Duration::from_secs(45),
+            "reset_http_clients must preserve the configured timeout"
+        );
+    }
 }

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -125,6 +125,42 @@ async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// Build the API and download HTTP clients for a session.
+///
+/// Both share the same cookie jar. The API client uses a total-request timeout;
+/// the download client uses connect + read timeouts without a total cap so
+/// large file transfers aren't killed mid-stream.
+fn build_clients(
+    cookie_jar: &Arc<reqwest::cookie::Jar>,
+    home_endpoint: &str,
+    api_timeout: Duration,
+) -> Result<(Client, Client)> {
+    let mut default_headers = HeaderMap::new();
+    default_headers.insert(ORIGIN, HeaderValue::from_str(home_endpoint)?);
+    default_headers.insert(
+        REFERER,
+        HeaderValue::from_str(&format!("{home_endpoint}/"))?,
+    );
+    default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
+
+    let client = Client::builder()
+        .cookie_provider(cookie_jar.clone())
+        .default_headers(default_headers.clone())
+        .timeout(api_timeout)
+        .build()?;
+
+    let download_client = Client::builder()
+        .cookie_provider(cookie_jar.clone())
+        .default_headers(default_headers)
+        .connect_timeout(Duration::from_secs(30))
+        .read_timeout(Duration::from_secs(120))
+        .pool_max_idle_per_host(20)
+        .pool_idle_timeout(Duration::from_secs(90))
+        .build()?;
+
+    Ok((client, download_client))
+}
+
 /// HTTP session wrapper that persists cookies and session data to disk,
 /// allowing authentication to survive across process restarts.
 pub struct Session {
@@ -138,6 +174,8 @@ pub struct Session {
     cookie_dir: PathBuf,
     sanitized_username: String,
     home_endpoint: String,
+    /// API client timeout (preserved for `reset_http_clients`).
+    api_timeout: Duration,
     /// Exclusive file lock preventing concurrent instances for the same account.
     /// The advisory lock is held for the lifetime of the Session via the open
     /// file descriptor; released automatically when the File is dropped.
@@ -165,7 +203,6 @@ impl Session {
     ) -> Result<Self> {
         let sanitized = sanitize_username(username);
         let cookie_dir = cookie_dir.to_path_buf();
-        let timeout = Duration::from_secs(timeout_secs.unwrap_or(30));
 
         fs::create_dir_all(&cookie_dir).await.with_context(|| {
             format!(
@@ -200,9 +237,29 @@ impl Session {
         })
         .await??;
 
+        Self::build(
+            cookie_dir,
+            &sanitized,
+            home_endpoint,
+            timeout_secs,
+            lock_file,
+        )
+        .await
+    }
+
+    /// Shared constructor body: loads cookies/session from disk, builds HTTP
+    /// clients, and assembles the `Session`. Callers provide the lock file.
+    async fn build(
+        cookie_dir: PathBuf,
+        sanitized: &str,
+        home_endpoint: &str,
+        timeout_secs: Option<u64>,
+        lock_file: std::fs::File,
+    ) -> Result<Self> {
+        let timeout = Duration::from_secs(timeout_secs.unwrap_or(30));
         let cookie_jar = Arc::new(reqwest::cookie::Jar::default());
 
-        let cookiejar_path = cookie_dir.join(&sanitized);
+        let cookiejar_path = cookie_dir.join(sanitized);
         if cookiejar_path.is_file() {
             match fs::read_to_string(&cookiejar_path).await {
                 Ok(contents) => {
@@ -247,33 +304,7 @@ impl Session {
             }
         }
 
-        // Origin/Referer headers are required by Apple's CORS checks
-        let mut default_headers = HeaderMap::new();
-        default_headers.insert(ORIGIN, HeaderValue::from_str(home_endpoint)?);
-        default_headers.insert(
-            REFERER,
-            HeaderValue::from_str(&format!("{home_endpoint}/"))?,
-        );
-        default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
-
-        let client = Client::builder()
-            .cookie_provider(cookie_jar.clone())
-            .default_headers(default_headers.clone())
-            .timeout(timeout)
-            .build()?;
-
-        // Separate client for file downloads: no total timeout so large files
-        // aren't killed mid-transfer. connect_timeout catches unreachable hosts;
-        // read_timeout detects stalled connections (no bytes for 120s).
-        // Pool settings tuned for high-concurrency downloads to Apple's CDN.
-        let download_client = Client::builder()
-            .cookie_provider(cookie_jar.clone())
-            .default_headers(default_headers)
-            .connect_timeout(Duration::from_secs(30))
-            .read_timeout(Duration::from_secs(120))
-            .pool_max_idle_per_host(20)
-            .pool_idle_timeout(Duration::from_secs(90))
-            .build()?;
+        let (client, download_client) = build_clients(&cookie_jar, home_endpoint, timeout)?;
 
         let session_path = cookie_dir.join(format!("{sanitized}.session"));
         let session_data = if session_path.exists() {
@@ -311,8 +342,9 @@ impl Session {
             cookie_jar,
             session_data,
             cookie_dir,
-            sanitized_username: sanitized,
+            sanitized_username: sanitized.to_owned(),
             home_endpoint: home_endpoint.to_string(),
+            api_timeout: timeout,
             lock_file,
         })
     }
@@ -326,35 +358,15 @@ impl Session {
             .join(format!("{}.session", self.sanitized_username))
     }
 
-    /// Clear persisted session/cookie files so the next `Session::new()` gets
-    /// a clean slate. Prevents stale partition routing during 421 recovery.
-    pub async fn clear_persisted_files(&self) -> Result<()> {
-        let session_path = self.session_path();
-        match fs::remove_file(&session_path).await {
-            Ok(()) => {
-                tracing::debug!(path = %session_path.display(), "Cleared session file for clean re-auth");
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                return Err(anyhow::Error::new(e).context(format!(
-                    "Failed to remove session file: {}",
-                    session_path.display()
-                )));
-            }
-        }
-        let cookie_path = self.cookiejar_path();
-        match fs::remove_file(&cookie_path).await {
-            Ok(()) => {
-                tracing::debug!(path = %cookie_path.display(), "Cleared cookie file for clean re-auth");
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                return Err(anyhow::Error::new(e).context(format!(
-                    "Failed to remove cookie file: {}",
-                    cookie_path.display()
-                )));
-            }
-        }
+    /// Replace both HTTP clients with fresh ones, dropping the old connection
+    /// pools. The existing cookie jar and session data are preserved so no
+    /// re-authentication is needed. Used for 421 recovery where the issue is
+    /// stale HTTP/2 connection routing, not invalid auth state.
+    pub fn reset_http_clients(&mut self) -> Result<()> {
+        let (client, download_client) =
+            build_clients(&self.cookie_jar, &self.home_endpoint, self.api_timeout)?;
+        self.client = client;
+        self.download_client = download_client;
         Ok(())
     }
 

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -158,10 +158,20 @@ async fn attempt_download<C: DownloadClient>(
         Ok(meta) if meta.len() > 0 => {
             // Discard stale .part files from crashed runs to avoid resuming
             // from potentially corrupt bytes.
-            let stale = meta.modified().ok().is_some_and(|mtime| {
-                mtime.elapsed().unwrap_or(std::time::Duration::ZERO)
-                    > std::time::Duration::from_secs(STALE_PART_FILE_SECS)
-            });
+            let stale = match meta.modified() {
+                Ok(mtime) => {
+                    mtime.elapsed().unwrap_or(std::time::Duration::ZERO)
+                        > std::time::Duration::from_secs(STALE_PART_FILE_SECS)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %part_path.display(),
+                        error = %e,
+                        "Cannot read .part file mtime, treating as stale"
+                    );
+                    true
+                }
+            };
             if stale {
                 tracing::warn!(
                     path = %part_path.display(),
@@ -326,10 +336,44 @@ async fn attempt_download<C: DownloadClient>(
     }
 
     if !skip_rename {
-        fs::rename(&part_path, download_path).await?;
+        rename_part_to_final(part_path, download_path).await?;
     }
 
     Ok(())
+}
+
+/// Rename a `.part` file to its final destination, handling the case where
+/// a concurrent download already placed the final file. If the destination
+/// exists, the redundant `.part` file is removed instead of overwriting.
+pub(super) async fn rename_part_to_final(
+    part_path: &Path,
+    final_path: &Path,
+) -> anyhow::Result<()> {
+    match fs::rename(part_path, final_path).await {
+        Ok(()) => Ok(()),
+        Err(_) if final_path.is_file() => {
+            // Another task won the race — clean up our .part file.
+            tracing::debug!(
+                path = %final_path.display(),
+                "Destination already exists, removing redundant .part file"
+            );
+            if let Err(rm_err) = fs::remove_file(part_path).await {
+                tracing::warn!(
+                    path = %part_path.display(),
+                    error = %rm_err,
+                    "Failed to remove redundant .part file"
+                );
+            }
+            Ok(())
+        }
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "failed to rename {} to {}",
+                part_path.display(),
+                final_path.display()
+            )
+        }),
+    }
 }
 
 /// Compute the SHA-256 hash of a file, returning a hex-encoded string.

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -91,6 +91,7 @@ pub(super) fn temp_download_path(
 /// place so the caller can modify it before performing the rename.
 /// Retries with exponential backoff on transient failures.
 /// Download options that control post-download behavior and verification.
+#[derive(Debug, Clone, Copy)]
 pub(super) struct DownloadOpts {
     /// Keep the `.part` file instead of renaming to the final path.
     pub skip_rename: bool,

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -1850,4 +1850,45 @@ mod tests {
         assert!(decoded.is_sha1);
         assert_eq!(decoded.hex.len(), 40); // 20 bytes = 40 hex chars
     }
+
+    #[tokio::test]
+    async fn rename_part_to_final_happy_path() {
+        let dir = TempDir::new().unwrap();
+        let part = dir.path().join("photo.part");
+        let final_path = dir.path().join("photo.jpg");
+        tokio::fs::write(&part, b"image data").await.unwrap();
+
+        rename_part_to_final(&part, &final_path).await.unwrap();
+
+        assert!(!part.exists());
+        assert!(final_path.exists());
+        assert_eq!(tokio::fs::read(&final_path).await.unwrap(), b"image data");
+    }
+
+    #[tokio::test]
+    async fn rename_part_to_final_destination_already_exists() {
+        let dir = TempDir::new().unwrap();
+        let part = dir.path().join("photo.part");
+        let final_path = dir.path().join("photo.jpg");
+        tokio::fs::write(&final_path, b"existing").await.unwrap();
+        tokio::fs::write(&part, b"duplicate").await.unwrap();
+
+        // Should succeed regardless of platform behavior:
+        // - Linux: rename atomically overwrites (Ok path)
+        // - Windows: rename fails, guard detects existing file and cleans .part
+        rename_part_to_final(&part, &final_path).await.unwrap();
+
+        assert!(!part.exists(), ".part should not remain");
+        assert!(final_path.exists(), "final file should exist");
+    }
+
+    #[tokio::test]
+    async fn rename_part_to_final_nonexistent_part_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let part = dir.path().join("missing.part");
+        let final_path = dir.path().join("photo.jpg");
+
+        let result = rename_part_to_final(&part, &final_path).await;
+        assert!(result.is_err(), "should fail when .part doesn't exist");
+    }
 }

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -352,10 +352,11 @@ pub(super) async fn rename_part_to_final(
 ) -> anyhow::Result<()> {
     match fs::rename(part_path, final_path).await {
         Ok(()) => Ok(()),
-        Err(_) if fs::try_exists(final_path).await.unwrap_or(false) => {
+        Err(rename_err) if fs::try_exists(final_path).await.unwrap_or(false) => {
             // Another task won the race — clean up our .part file.
             tracing::debug!(
                 path = %final_path.display(),
+                error = %rename_err,
                 "Destination already exists, removing redundant .part file"
             );
             if let Err(rm_err) = fs::remove_file(part_path).await {

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -352,7 +352,7 @@ pub(super) async fn rename_part_to_final(
 ) -> anyhow::Result<()> {
     match fs::rename(part_path, final_path).await {
         Ok(()) => Ok(()),
-        Err(_) if final_path.is_file() => {
+        Err(_) if fs::try_exists(final_path).await.unwrap_or(false) => {
             // Another task won the race — clean up our .part file.
             tracing::debug!(
                 path = %final_path.display(),

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -29,14 +29,12 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 use crate::icloud::photos::types::AssetVersion;
-use crate::icloud::photos::{
-    AssetItemType, AssetVersionSize, ChangeReason, PhotoAlbum, PhotoAsset, SyncTokenError,
-    VersionsMap,
-};
+use crate::icloud::photos::{PhotoAlbum, PhotoAsset, SyncTokenError, VersionsMap};
 use crate::retry::RetryConfig;
 use crate::state::{AssetRecord, MediaType, StateDb, SyncRunStats, VersionSizeKey};
 use crate::types::{
-    FileMatchPolicy, LivePhotoMode, LivePhotoMovFilenamePolicy, RawTreatmentPolicy,
+    AssetItemType, AssetVersionSize, ChangeReason, FileMatchPolicy, LivePhotoMode,
+    LivePhotoMovFilenamePolicy, RawTreatmentPolicy,
 };
 
 use error::DownloadError;
@@ -1263,9 +1261,15 @@ struct PendingStateWrite {
     download_checksum: Option<String>,
 }
 
+/// Maximum retry attempts for deferred state writes.
+const STATE_WRITE_MAX_RETRIES: u32 = 6;
+
 /// Retry all pending state writes that failed during the download loop.
 ///
-/// Each write is attempted up to 3 times with exponential backoff (100ms, 200ms).
+/// Each write is attempted up to [`STATE_WRITE_MAX_RETRIES`] times with
+/// exponential backoff (200ms, 400ms, 800ms, 1.6s, 3.2s). SQLite lock
+/// contention is transient, so generous retries prevent files from ending
+/// up on disk but untracked in the state DB.
 /// Returns the number of writes that still failed after all retries.
 async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWrite]) -> usize {
     if pending.is_empty() {
@@ -1275,7 +1279,7 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
     let mut failures = 0;
     for write in pending {
         let mut succeeded = false;
-        for attempt in 1..=3u32 {
+        for attempt in 1..=STATE_WRITE_MAX_RETRIES {
             match db
                 .mark_downloaded(
                     &write.asset_id,
@@ -1291,20 +1295,25 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
                     break;
                 }
                 Err(e) => {
-                    if attempt < 3 {
+                    if attempt < STATE_WRITE_MAX_RETRIES {
                         tracing::debug!(
                             asset_id = %write.asset_id,
                             attempt,
                             error = %e,
                             "State write retry failed, will retry"
                         );
-                        tokio::time::sleep(Duration::from_millis(u64::from(attempt) * 100)).await;
+                        tokio::time::sleep(Duration::from_millis(
+                            200 * u64::from(1u32 << (attempt - 1)),
+                        ))
+                        .await;
                     } else {
                         tracing::error!(
                             asset_id = %write.asset_id,
                             path = %write.download_path.display(),
                             error = %e,
-                            "State write failed after 3 attempts — file on disk but untracked, will be re-downloaded next sync"
+                            "State write failed after {STATE_WRITE_MAX_RETRIES} attempts — \
+                             file on disk but untracked; next sync will detect it via \
+                             filesystem check and skip re-download"
                         );
                     }
                 }
@@ -2896,15 +2905,7 @@ async fn download_single_task(
 
     // Atomic rename: .part → final (only when EXIF path was used)
     if let Some(part) = &part_path {
-        tokio::fs::rename(part, &task.download_path)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to rename {} to {}",
-                    part.display(),
-                    task.download_path.display()
-                )
-            })?;
+        file::rename_part_to_final(part, &task.download_path).await?;
     }
 
     tracing::debug!(path = %task.download_path.display(), "Downloaded");
@@ -5475,8 +5476,8 @@ mod tests {
 
     #[tokio::test]
     async fn flush_pending_state_writes_reports_persistent_failure() {
-        // Fail all 3 attempts (initial call already failed once, so 3 retries = 3 failures)
-        let db = FailingStateDb::new(3);
+        // Fail all attempts — must exceed STATE_WRITE_MAX_RETRIES
+        let db = FailingStateDb::new(STATE_WRITE_MAX_RETRIES as usize);
         let pending = vec![PendingStateWrite {
             asset_id: "A1".into(),
             version_size: VersionSizeKey::Original,
@@ -5491,12 +5492,9 @@ mod tests {
 
     #[tokio::test]
     async fn flush_pending_state_writes_partial_recovery() {
-        // 2 failures: first write fails all 3 attempts, second write fails once then succeeds
-        // Total calls: write1 (3 fails) + write2 (1 fail + 1 success) = 4 fails needed
-        // But FailingStateDb counts globally, so we need 4 failures total.
-        // write1: attempts 1,2,3 all fail (3 failures consumed), write1 reported as failure
-        // write2: attempt 1 fails (4th failure consumed), attempt 2 succeeds
-        let db = FailingStateDb::new(4);
+        // First write exhausts all STATE_WRITE_MAX_RETRIES attempts (reported as failure).
+        // Second write fails once more then succeeds on retry.
+        let db = FailingStateDb::new(STATE_WRITE_MAX_RETRIES as usize + 1);
         let pending = vec![
             PendingStateWrite {
                 asset_id: "A1".into(),

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -47,7 +47,7 @@ const GLOB_CASE_INSENSITIVE: glob::MatchOptions = glob::MatchOptions {
 };
 
 /// Determine the media type for an asset based on version size and item type.
-pub fn determine_media_type(
+pub(crate) fn determine_media_type(
     version_size: VersionSizeKey,
     asset: &crate::icloud::photos::PhotoAsset,
 ) -> MediaType {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1263,13 +1263,15 @@ struct PendingStateWrite {
 
 /// Maximum retry attempts for deferred state writes.
 const STATE_WRITE_MAX_RETRIES: u32 = 6;
+const _: () = assert!(STATE_WRITE_MAX_RETRIES <= 32, "shift overflow in backoff");
 
 /// Retry all pending state writes that failed during the download loop.
 ///
 /// Each write is attempted up to [`STATE_WRITE_MAX_RETRIES`] times with
-/// exponential backoff (200ms, 400ms, 800ms, 1.6s, 3.2s). SQLite lock
-/// contention is transient, so generous retries prevent files from ending
-/// up on disk but untracked in the state DB.
+/// exponential backoff (200ms, 400ms, 800ms, 1.6s, 3.2s between attempts
+/// 1–5; attempt 6 fails immediately). SQLite lock contention is transient,
+/// so generous retries prevent files from ending up on disk but untracked
+/// in the state DB.
 /// Returns the number of writes that still failed after all retries.
 async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWrite]) -> usize {
     if pending.is_empty() {

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -516,6 +516,10 @@ impl DirCache {
     /// In async contexts, prefer `ensure_dir_async()` to avoid blocking the
     /// tokio worker thread — especially on slow or network-attached storage.
     fn ensure_dir(&mut self, dir: &Path) -> &FxHashMap<String, u64> {
+        // Fast path: avoid PathBuf allocation when directory is already cached.
+        if self.dirs.contains_key(dir) {
+            return &self.dirs[dir];
+        }
         self.dirs
             .entry(dir.to_path_buf())
             .or_insert_with(|| read_dir_entries(dir))

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -516,7 +516,10 @@ impl DirCache {
     /// In async contexts, prefer `ensure_dir_async()` to avoid blocking the
     /// tokio worker thread — especially on slow or network-attached storage.
     fn ensure_dir(&mut self, dir: &Path) -> &FxHashMap<String, u64> {
-        // Fast path: avoid PathBuf allocation when directory is already cached.
+        // Fast path: two lookups but zero allocation on cache hit.
+        // get() would be one lookup, but its returned reference borrows
+        // self.dirs immutably, which the borrow checker cannot release
+        // before the mutable entry() call below.
         if self.dirs.contains_key(dir) {
             return &self.dirs[dir];
         }

--- a/src/health.rs
+++ b/src/health.rs
@@ -5,10 +5,10 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub(crate) struct HealthStatus {
-    pub last_sync_at: Option<DateTime<Utc>>,
-    pub last_success_at: Option<DateTime<Utc>>,
-    pub consecutive_failures: u32,
-    pub last_error: Option<String>,
+    pub(crate) last_sync_at: Option<DateTime<Utc>>,
+    pub(crate) last_success_at: Option<DateTime<Utc>>,
+    pub(crate) consecutive_failures: u32,
+    pub(crate) last_error: Option<String>,
 }
 
 impl HealthStatus {

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -96,4 +96,26 @@ mod tests {
             "expected Json variant, got: {err:?}"
         );
     }
+
+    #[test]
+    fn connection_421_detected_as_misdirected() {
+        // This is how a 421 from reqwest::error_for_status() gets wrapped:
+        // reqwest::Error -> anyhow::Error -> e.to_string() -> ICloudError::Connection
+        let err = ICloudError::Connection(
+            "HTTP status client error (421 Misdirected Request) for url (https://p60-ckdatabasews.icloud.com/...)".into(),
+        );
+        assert!(
+            matches!(&err, ICloudError::Connection(msg) if msg.contains("421")),
+            "421 Connection error should be detectable as misdirected request"
+        );
+    }
+
+    #[test]
+    fn connection_non_421_not_misdirected() {
+        let err = ICloudError::Connection("HTTP status server error (503)".into());
+        assert!(
+            !matches!(&err, ICloudError::Connection(msg) if msg.contains("421")),
+            "503 should not match the misdirected request pattern"
+        );
+    }
 }

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -90,8 +90,8 @@ impl PhotoLibrary {
             if let Some(ck) = e.downcast_ref::<super::session::CloudKitServerError>() {
                 if ck.service_not_activated {
                     return ICloudError::ServiceNotActivated {
-                        code: ck.code.clone(),
-                        reason: ck.reason.clone(),
+                        code: ck.code.to_string(),
+                        reason: ck.reason.to_string(),
                     };
                 }
             }

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -15,7 +15,6 @@ pub use album::PhotoAlbum;
 pub use asset::{PhotoAsset, VersionsMap};
 pub use library::PhotoLibrary;
 pub use session::{PhotosSession, SyncTokenError};
-pub use types::{AssetItemType, AssetVersionSize, ChangeReason};
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -62,8 +62,8 @@ const SERVICE_NOT_ACTIVATED_ERRORS: &[&str] = &["ZONE_NOT_FOUND", "AUTHENTICATIO
 #[derive(Debug, thiserror::Error)]
 #[error("CloudKit server error: {code} — {reason}")]
 pub struct CloudKitServerError {
-    pub code: String,
-    pub reason: String,
+    pub code: Box<str>,
+    pub reason: Box<str>,
     pub retryable: bool,
     /// True when the error indicates the iCloud service is not activated
     /// (ADP enabled, incomplete setup, or private db access disabled).
@@ -90,12 +90,11 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
         let reason = response["reason"]
             .as_str()
             .or_else(|| response["serverErrorMessage"].as_str())
-            .unwrap_or("unknown")
-            .to_string();
+            .unwrap_or("unknown");
         let retryable = RETRYABLE_SERVER_ERRORS
             .iter()
             .any(|&s| s.eq_ignore_ascii_case(code));
-        let service_not_activated = is_service_not_activated(code, &reason);
+        let service_not_activated = is_service_not_activated(code, reason);
         tracing::warn!(
             error_code = code,
             retryable,
@@ -103,8 +102,8 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
             "CloudKit server error: {reason}"
         );
         return Err(CloudKitServerError {
-            code: code.to_string(),
-            reason,
+            code: code.into(),
+            reason: reason.into(),
             retryable,
             service_not_activated,
         }
@@ -114,19 +113,28 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
     // Per-record errors: filter out errored records and keep valid ones.
     // Only return Err if ALL records are errored.
     if let Some(records) = response["records"].as_array() {
-        let (errored, valid): (Vec<&Value>, Vec<&Value>) = records
-            .iter()
-            .partition(|r| r["serverErrorCode"].as_str().is_some());
+        // Single pass: separate errored records (by reference) from valid
+        // records (cloned for output). Avoids the double allocation of
+        // partition() followed by cloned().collect().
+        let mut errored: Vec<&Value> = Vec::new();
+        let mut valid_owned: Vec<Value> = Vec::new();
+        for record in records {
+            if record["serverErrorCode"].as_str().is_some() {
+                errored.push(record);
+            } else {
+                valid_owned.push(record.clone());
+            }
+        }
 
         if !errored.is_empty() {
             let mut last_ck_err = None;
             for record in &errored {
                 let code = record["serverErrorCode"].as_str().unwrap_or("unknown");
-                let reason = record["reason"].as_str().unwrap_or("unknown").to_string();
+                let reason = record["reason"].as_str().unwrap_or("unknown");
                 let retryable = RETRYABLE_SERVER_ERRORS
                     .iter()
                     .any(|&s| s.eq_ignore_ascii_case(code));
-                let service_not_activated = is_service_not_activated(code, &reason);
+                let service_not_activated = is_service_not_activated(code, reason);
                 tracing::warn!(
                     error_code = code,
                     retryable,
@@ -134,24 +142,23 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
                     "CloudKit per-record error: {reason}"
                 );
                 last_ck_err = Some(CloudKitServerError {
-                    code: code.to_string(),
-                    reason,
+                    code: code.into(),
+                    reason: reason.into(),
                     retryable,
                     service_not_activated,
                 });
             }
 
-            if valid.is_empty() {
+            if valid_owned.is_empty() {
                 return Err(last_ck_err.expect("errored is non-empty").into());
             }
-            let total = errored.len() + valid.len();
+            let total = errored.len() + valid_owned.len();
             tracing::warn!(
                 errored = errored.len(),
-                valid = valid.len(),
+                valid = valid_owned.len(),
                 total,
                 "Filtered errored records from CloudKit response"
             );
-            let valid_owned: Vec<Value> = valid.into_iter().cloned().collect();
             let mut response = response;
             response["records"] = Value::Array(valid_owned);
             return Ok(response);
@@ -307,7 +314,7 @@ mod tests {
         });
         let err = check_cloudkit_errors(response).unwrap_err();
         let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
-        assert_eq!(ck_err.code, "TRY_AGAIN_LATER");
+        assert_eq!(&*ck_err.code, "TRY_AGAIN_LATER");
         assert!(ck_err.retryable);
         assert!(!ck_err.service_not_activated);
         assert_eq!(classify_api_error(&err), RetryAction::Retry);
@@ -352,7 +359,7 @@ mod tests {
         });
         let err = check_cloudkit_errors(response).unwrap_err();
         let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
-        assert_eq!(ck_err.code, "RETRY_LATER");
+        assert_eq!(&*ck_err.code, "RETRY_LATER");
         assert!(ck_err.retryable);
     }
 
@@ -479,7 +486,7 @@ mod tests {
         });
         let err = check_cloudkit_errors(response).unwrap_err();
         let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
-        assert_eq!(ck_err.reason, "fallback message");
+        assert_eq!(&*ck_err.reason, "fallback message");
     }
 
     #[test]
@@ -489,7 +496,7 @@ mod tests {
         });
         let err = check_cloudkit_errors(response).unwrap_err();
         let ck_err = err.downcast_ref::<CloudKitServerError>().unwrap();
-        assert_eq!(ck_err.reason, "unknown");
+        assert_eq!(&*ck_err.reason, "unknown");
     }
 
     #[test]

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -62,12 +62,12 @@ const SERVICE_NOT_ACTIVATED_ERRORS: &[&str] = &["ZONE_NOT_FOUND", "AUTHENTICATIO
 #[derive(Debug, thiserror::Error)]
 #[error("CloudKit server error: {code} — {reason}")]
 pub struct CloudKitServerError {
-    pub code: Box<str>,
-    pub reason: Box<str>,
-    pub retryable: bool,
+    pub(crate) code: Box<str>,
+    pub(crate) reason: Box<str>,
+    pub(crate) retryable: bool,
     /// True when the error indicates the iCloud service is not activated
     /// (ADP enabled, incomplete setup, or private db access disabled).
-    pub service_not_activated: bool,
+    pub(crate) service_not_activated: bool,
 }
 
 /// Check whether an error code or reason indicates the iCloud service is not
@@ -113,18 +113,9 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
     // Per-record errors: filter out errored records and keep valid ones.
     // Only return Err if ALL records are errored.
     if let Some(records) = response["records"].as_array() {
-        // Single pass: separate errored records (by reference) from valid
-        // records (cloned for output). Avoids the double allocation of
-        // partition() followed by cloned().collect().
-        let mut errored: Vec<&Value> = Vec::new();
-        let mut valid_owned: Vec<Value> = Vec::new();
-        for record in records {
-            if record["serverErrorCode"].as_str().is_some() {
-                errored.push(record);
-            } else {
-                valid_owned.push(record.clone());
-            }
-        }
+        let (errored, valid): (Vec<&Value>, Vec<&Value>) = records
+            .iter()
+            .partition(|r| r["serverErrorCode"].as_str().is_some());
 
         if !errored.is_empty() {
             let mut last_ck_err = None;
@@ -149,16 +140,17 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
                 });
             }
 
-            if valid_owned.is_empty() {
+            if valid.is_empty() {
                 return Err(last_ck_err.expect("errored is non-empty").into());
             }
-            let total = errored.len() + valid_owned.len();
+            let total = errored.len() + valid.len();
             tracing::warn!(
                 errored = errored.len(),
-                valid = valid_owned.len(),
+                valid = valid.len(),
                 total,
                 "Filtered errored records from CloudKit response"
             );
+            let valid_owned: Vec<Value> = valid.into_iter().cloned().collect();
             let mut response = response;
             response["records"] = Value::Array(valid_owned);
             return Ok(response);

--- a/src/icloud/photos/types.rs
+++ b/src/icloud/photos/types.rs
@@ -1,4 +1,7 @@
-use crate::types::VersionSize;
+// Re-export provider-agnostic types from the core module so that existing
+// iCloud-internal imports (`super::types::AssetVersionSize`, etc.) continue
+// to resolve without changing every file in `icloud/photos/`.
+pub use crate::types::{AssetItemType, AssetVersionSize, ChangeReason};
 
 /// Information about a downloadable asset version.
 ///
@@ -11,99 +14,4 @@ pub struct AssetVersion {
     pub url: Box<str>,
     pub asset_type: Box<str>,
     pub checksum: Box<str>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum AssetItemType {
-    Image,
-    Movie,
-}
-
-/// Version size key for asset versions.
-///
-/// Uses `#[repr(u8)]` to guarantee 1-byte size for better struct packing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u8)]
-pub enum AssetVersionSize {
-    Original = 0,
-    Alternative = 1,
-    Medium = 2,
-    Thumb = 3,
-    Adjusted = 4,
-    LiveOriginal = 5,
-    LiveMedium = 6,
-    LiveThumb = 7,
-    LiveAdjusted = 8,
-}
-
-impl From<VersionSize> for AssetVersionSize {
-    fn from(v: VersionSize) -> Self {
-        match v {
-            VersionSize::Original => Self::Original,
-            VersionSize::Medium => Self::Medium,
-            VersionSize::Thumb => Self::Thumb,
-            VersionSize::Adjusted => Self::Adjusted,
-            VersionSize::Alternative => Self::Alternative,
-        }
-    }
-}
-
-/// Reason for a record change in a `changes/zone` delta response.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ChangeReason {
-    /// New record (new or modified; state DB needed to distinguish)
-    Created,
-    /// Moved to Recently Deleted (fields.isDeleted == 1)
-    SoftDeleted,
-    /// Permanently purged (record.deleted == true, recordType unknown)
-    HardDeleted,
-    /// Moved to Hidden album (fields.isHidden == 1)
-    Hidden,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::types::VersionSize;
-
-    #[test]
-    fn from_version_size_all_variants() {
-        for (input, expected) in [
-            (VersionSize::Original, AssetVersionSize::Original),
-            (VersionSize::Medium, AssetVersionSize::Medium),
-            (VersionSize::Thumb, AssetVersionSize::Thumb),
-            (VersionSize::Adjusted, AssetVersionSize::Adjusted),
-            (VersionSize::Alternative, AssetVersionSize::Alternative),
-        ] {
-            assert_eq!(AssetVersionSize::from(input), expected, "from {input:?}");
-        }
-    }
-
-    #[test]
-    fn asset_version_size_is_one_byte() {
-        assert_eq!(std::mem::size_of::<AssetVersionSize>(), 1);
-    }
-
-    #[test]
-    fn asset_version_size_variants_have_distinct_repr_values() {
-        let variants = [
-            AssetVersionSize::Original as u8,
-            AssetVersionSize::Alternative as u8,
-            AssetVersionSize::Medium as u8,
-            AssetVersionSize::Thumb as u8,
-            AssetVersionSize::Adjusted as u8,
-            AssetVersionSize::LiveOriginal as u8,
-            AssetVersionSize::LiveMedium as u8,
-            AssetVersionSize::LiveThumb as u8,
-            AssetVersionSize::LiveAdjusted as u8,
-        ];
-
-        // Check all variants have unique values
-        let unique: std::collections::HashSet<u8> = variants.iter().copied().collect();
-        assert_eq!(
-            unique.len(),
-            variants.len(),
-            "all repr(u8) values must be distinct"
-        );
-    }
 }

--- a/src/icloud/photos/types.rs
+++ b/src/icloud/photos/types.rs
@@ -1,6 +1,3 @@
-// Re-export provider-agnostic types from the core module so that existing
-// iCloud-internal imports (`super::types::AssetVersionSize`, etc.) continue
-// to resolve without changing every file in `icloud/photos/`.
 pub use crate::types::{AssetItemType, AssetVersionSize, ChangeReason};
 
 /// Information about a downloadable asset version.

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,12 +105,16 @@ const MAX_REAUTH_ATTEMPTS: u32 = 3;
 /// restrict these syscalls).
 fn harden_process() {
     #[cfg(target_os = "linux")]
+    // SAFETY: PR_SET_DUMPABLE with value 0 is a simple prctl flag toggle.
+    // No pointer arguments; failure is non-fatal (logged and ignored).
     unsafe {
         if libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) != 0 {
             tracing::debug!("prctl(PR_SET_DUMPABLE, 0) failed");
         }
     }
     #[cfg(unix)]
+    // SAFETY: rlim is stack-allocated and fully initialized. setrlimit reads
+    // from the pointer but does not store it. Failure is non-fatal.
     unsafe {
         let rlim = libc::rlimit {
             rlim_cur: 0,
@@ -149,6 +153,9 @@ fn available_disk_space(path: &Path) -> Option<u64> {
     }
 
     let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
+    // SAFETY: statvfs is zeroed before the call. libc::statvfs writes into
+    // the provided buffer and does not retain the pointer. c_path is valid
+    // for the duration of the call.
     unsafe {
         let mut stat: libc::statvfs = std::mem::zeroed();
         if libc::statvfs(c_path.as_ptr(), &raw mut stat) != 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -969,7 +969,7 @@ async fn run_import_existing(
 ) -> anyhow::Result<()> {
     use chrono::Local;
     use futures_util::StreamExt;
-    use icloud::photos::AssetVersionSize;
+    use types::AssetVersionSize;
 
     let db_path = get_db_path(globals, toml)?;
     let toml_dl = toml.and_then(|t| t.download.as_ref());

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,12 +207,20 @@ fn make_provider_from_auth(
     make_password_provider(source)
 }
 
-/// Initialize the photos service with automatic 421 retry.
+/// Initialize the photos service with automatic 421 recovery.
 ///
-/// On first attempt, uses the ckdatabasews URL from the auth result. If the
-/// CloudKit service returns 421 Misdirected Request (stale partition), clears
-/// persisted session state, creates a completely fresh session via
-/// `auth::authenticate`, and retries with the new service URL.
+/// On 421 Misdirected Request, tries two recovery strategies in order:
+///
+/// 1. **Reset HTTP clients** (cheap): drops the connection pool and retries
+///    with fresh TCP/HTTP2 connections. Fixes cases where HTTP/2 connection
+///    routing directed the request to the wrong CloudKit partition server.
+///
+/// 2. **Full re-authentication** (expensive): clears session state and
+///    performs a fresh SRP login. Fixes cases where stale session headers
+///    (scnt, session_id) cause CloudKit to route to the wrong partition.
+///    May require password + 2FA from the user.
+///
+/// If both strategies fail, the error from the second attempt is returned.
 async fn init_photos_service(
     auth_result: auth::AuthResult,
     cookie_directory: &Path,
@@ -254,93 +262,101 @@ async fn init_photos_service(
     )
     .await
     {
-        Ok(service) => Ok((shared_session, service)),
-        Err(e) if is_misdirected_request(&e) => {
-            tracing::warn!(
-                url = %ckdatabasews_url,
-                "Service endpoint returned 421 Misdirected Request, \
-                 performing full re-authentication with clean session"
-            );
-
-            // A 421 means Apple's identity service assigned a CloudKit partition
-            // that CloudKit itself rejects. Recovery requires a completely fresh
-            // session -- new reqwest::Client (clean HTTP/2 connection pool),
-            // new cookie jar, and no stale session headers (scnt, session_id).
-            // Without this, Apple treats the re-auth as session continuity and
-            // returns the same stale partition URL.
-            {
-                let session = shared_session.write().await;
-                session.clear_persisted_files().await?;
-                session.release_lock()?;
-            }
-
-            let new_auth = auth::authenticate(
-                cookie_directory,
-                username,
-                password_provider,
-                domain,
-                None,
-                None,
-                None,
-            )
-            .await?;
-
-            let fresh_url = new_auth
-                .data
-                .webservices
-                .as_ref()
-                .and_then(|ws| ws.ckdatabasews.as_ref())
-                .map(|ep| ep.url.clone())
-                .ok_or_else(|| anyhow::anyhow!("No ckdatabasews URL after re-authentication"))?;
-
-            if fresh_url == ckdatabasews_url {
-                anyhow::bail!(
-                    "Re-authentication returned the same service URL ({fresh_url}) that \
-                     produced a 421 Misdirected Request. This is likely an Apple-side \
-                     partition inconsistency -- please try again later"
-                );
-            }
-
-            let client_id = new_auth.session.client_id().unwrap_or_default().to_owned();
-            let dsid = new_auth
-                .data
-                .ds_info
-                .as_ref()
-                .and_then(|ds| ds.dsid.clone());
-            let params = build_photos_params(&client_id, dsid.as_deref());
-
-            {
-                let mut session = shared_session.write().await;
-                *session = new_auth.session;
-            }
-
-            let session_box: Box<dyn icloud::photos::PhotosSession> =
-                Box::new(shared_session.clone());
-
-            tracing::info!(
-                old_url = %ckdatabasews_url,
-                new_url = %fresh_url,
-                "Retrying with fresh service URL from clean session"
-            );
-            let service = icloud::photos::PhotosService::new(
-                fresh_url,
-                session_box,
-                params,
-                api_retry_config,
-            )
-            .await?;
-
-            Ok((shared_session, service))
-        }
-        Err(e) => Err(e.into()),
+        Ok(service) => return Ok((shared_session, service)),
+        Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
+        Err(_) => {}
     }
+
+    // ── Recovery strategy 1: fresh HTTP/2 connection pool ──────────────
+    // Cheap fix: drop old connections, keep auth state. Handles cases where
+    // the TCP connection was routed to the wrong CloudKit partition server.
+    tracing::warn!(
+        url = %ckdatabasews_url,
+        "Service returned 421 Misdirected Request, retrying with fresh connection pool"
+    );
+    {
+        let mut session = shared_session.write().await;
+        session.reset_http_clients()?;
+    }
+
+    let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
+    match icloud::photos::PhotosService::new(
+        ckdatabasews_url.clone(),
+        session_box,
+        params.clone(),
+        api_retry_config,
+    )
+    .await
+    {
+        Ok(service) => return Ok((shared_session, service)),
+        Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
+        Err(_) => {}
+    }
+
+    // ── Recovery strategy 2: full re-authentication ────────────────────
+    // Expensive fix: clear session state, perform fresh SRP + 2FA login.
+    // Handles cases where stale session headers cause wrong partition routing.
+    tracing::warn!(
+        url = %ckdatabasews_url,
+        "Fresh connection pool did not resolve 421, performing full re-authentication"
+    );
+    {
+        let session = shared_session.read().await;
+        session.release_lock()?;
+    }
+    let new_auth = auth::authenticate(
+        cookie_directory,
+        username,
+        password_provider,
+        domain,
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    let fresh_url = new_auth
+        .data
+        .webservices
+        .as_ref()
+        .and_then(|ws| ws.ckdatabasews.as_ref())
+        .map(|ep| ep.url.clone())
+        .ok_or_else(|| anyhow::anyhow!("No ckdatabasews URL after re-authentication"))?;
+
+    if fresh_url != ckdatabasews_url {
+        tracing::info!(
+            old_url = %ckdatabasews_url,
+            new_url = %fresh_url,
+            "Re-authentication returned a different service URL"
+        );
+    }
+
+    let new_client_id = new_auth.session.client_id().unwrap_or_default().to_owned();
+    let new_dsid = new_auth
+        .data
+        .ds_info
+        .as_ref()
+        .and_then(|ds| ds.dsid.clone());
+    let new_params = build_photos_params(&new_client_id, new_dsid.as_deref());
+
+    {
+        let mut session = shared_session.write().await;
+        *session = new_auth.session;
+    }
+
+    let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
+    let service =
+        icloud::photos::PhotosService::new(fresh_url, session_box, new_params, api_retry_config)
+            .await?;
+
+    Ok((shared_session, service))
 }
 
 /// Check if an iCloud error is a 421 Misdirected Request from the CloudKit service.
 ///
-/// This happens when Apple migrates an account to a different partition but the
-/// cached session still references the old ckdatabasews URL. Recovery requires
-/// a full SRP re-authentication to obtain fresh service URLs from Apple.
+/// This happens when the HTTP/2 connection is routed to a CloudKit partition
+/// server that cannot serve the user's data. Root cause may be stale
+/// connection routing or stale session state; see `init_photos_service`.
 fn is_misdirected_request(err: &icloud::error::ICloudError) -> bool {
     matches!(err, icloud::error::ICloudError::Connection(msg) if msg.contains("421"))
 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 /// Events that trigger notification scripts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Event {
+pub(crate) enum Event {
     /// 2FA code is needed (session expired in headless mode)
     TwoFaRequired,
     /// Sync cycle completed successfully
@@ -33,7 +33,7 @@ impl Event {
 /// Notification dispatcher. Holds an optional script path.
 /// When no script is configured, all methods are no-ops.
 #[derive(Debug, Clone)]
-pub struct Notifier {
+pub(crate) struct Notifier {
     script: Option<PathBuf>,
 }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -206,6 +206,16 @@ impl SqliteStateDb {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Acquire the database lock, adding the operation name to any error.
+    fn acquire_lock(
+        &self,
+        operation: &str,
+    ) -> Result<std::sync::MutexGuard<'_, rusqlite::Connection>, StateError> {
+        self.conn
+            .lock()
+            .map_err(|e| StateError::Query(format!("{operation}: {e}")))
+    }
 }
 
 #[async_trait]
@@ -220,10 +230,7 @@ impl StateDb for SqliteStateDb {
     ) -> Result<bool, StateError> {
         // Query DB in a separate scope to ensure MutexGuard is dropped before any await
         let result: Option<(String, String, Option<String>)> = {
-            let conn = self
-                .conn
-                .lock()
-                .map_err(|e| StateError::Query(e.to_string()))?;
+            let conn = self.acquire_lock("should_download")?;
 
             conn.query_row(
                 "SELECT status, checksum, local_path FROM assets WHERE id = ?1 AND version_size = ?2",
@@ -287,10 +294,7 @@ impl StateDb for SqliteStateDb {
     async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
         let last_seen_at = Utc::now().timestamp();
 
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("upsert_seen")?;
 
         // Use INSERT OR REPLACE to handle both insert and update
         // But preserve existing status, downloaded_at, local_path, download_attempts, last_error
@@ -334,10 +338,7 @@ impl StateDb for SqliteStateDb {
     ) -> Result<(), StateError> {
         let downloaded_at = Utc::now().timestamp();
 
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("mark_downloaded")?;
 
         conn.execute(
             "UPDATE assets SET status = 'downloaded', downloaded_at = ?1, local_path = ?2, \
@@ -363,10 +364,7 @@ impl StateDb for SqliteStateDb {
         version_size: &str,
         error: &str,
     ) -> Result<(), StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("mark_failed")?;
 
         conn.execute(
             "UPDATE assets SET status = 'failed', download_attempts = download_attempts + 1, last_error = ?1 WHERE id = ?2 AND version_size = ?3",
@@ -378,10 +376,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_failed")?;
 
         let mut stmt = conn
             .prepare(
@@ -399,10 +394,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn get_summary(&self) -> Result<SyncSummary, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_summary")?;
 
         let (total_assets, downloaded, pending, failed) = conn
             .query_row(
@@ -464,10 +456,7 @@ impl StateDb for SqliteStateDb {
         offset: u64,
         limit: u32,
     ) -> Result<Vec<AssetRecord>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_downloaded_page")?;
 
         let mut stmt = conn
             .prepare(
@@ -490,10 +479,7 @@ impl StateDb for SqliteStateDb {
     async fn start_sync_run(&self) -> Result<i64, StateError> {
         let started_at = Utc::now().timestamp();
 
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("start_sync_run")?;
 
         conn.execute(
             "INSERT INTO sync_runs (started_at) VALUES (?1)",
@@ -512,10 +498,7 @@ impl StateDb for SqliteStateDb {
         let assets_failed = i64::try_from(stats.assets_failed).unwrap_or(i64::MAX);
         let interrupted = i32::from(stats.interrupted);
 
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("complete_sync_run")?;
 
         conn.execute(
             "UPDATE sync_runs SET completed_at = ?1, assets_seen = ?2, assets_downloaded = ?3, assets_failed = ?4, interrupted = ?5 WHERE id = ?6",
@@ -527,10 +510,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn reset_failed(&self) -> Result<u64, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("reset_failed")?;
 
         let rows = conn
             .execute(
@@ -543,31 +523,36 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_downloaded_ids")?;
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM assets WHERE status = 'downloaded'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| StateError::query(&e))?;
+        let count = usize::try_from(count).unwrap_or(0);
 
         let mut stmt = conn
             .prepare_cached("SELECT id, version_size FROM assets WHERE status = 'downloaded'")
             .map_err(|e| StateError::query(&e))?;
 
-        let ids = stmt
+        let mut ids = HashSet::with_capacity(count);
+        let rows = stmt
             .query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
-            .map_err(|e| StateError::query(&e))?
-            .collect::<Result<HashSet<_>, _>>()
             .map_err(|e| StateError::query(&e))?;
+        for row in rows {
+            ids.insert(row.map_err(|e| StateError::query(&e))?);
+        }
 
         Ok(ids)
     }
 
     async fn get_all_known_ids(&self) -> Result<HashSet<String>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_all_known_ids")?;
 
         let mut stmt = conn
             .prepare_cached("SELECT DISTINCT id FROM assets")
@@ -585,10 +570,16 @@ impl StateDb for SqliteStateDb {
     async fn get_downloaded_checksums(
         &self,
     ) -> Result<HashMap<(String, String), String>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_downloaded_checksums")?;
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM assets WHERE status = 'downloaded'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| StateError::query(&e))?;
+        let count = usize::try_from(count).unwrap_or(0);
 
         let mut stmt = conn
             .prepare_cached(
@@ -596,25 +587,25 @@ impl StateDb for SqliteStateDb {
             )
             .map_err(|e| StateError::query(&e))?;
 
-        let checksums = stmt
+        let mut checksums = HashMap::with_capacity(count);
+        let rows = stmt
             .query_map([], |row| {
                 Ok((
                     (row.get::<_, String>(0)?, row.get::<_, String>(1)?),
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| StateError::query(&e))?
-            .collect::<Result<HashMap<_, _>, _>>()
             .map_err(|e| StateError::query(&e))?;
+        for row in rows {
+            let (key, val) = row.map_err(|e| StateError::query(&e))?;
+            checksums.insert(key, val);
+        }
 
         Ok(checksums)
     }
 
     async fn get_attempt_counts(&self) -> Result<HashMap<String, u32>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_attempt_counts")?;
 
         let mut stmt = conn
             .prepare_cached(
@@ -637,10 +628,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn get_metadata(&self, key: &str) -> Result<Option<String>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("get_metadata")?;
 
         let value = conn
             .query_row("SELECT value FROM metadata WHERE key = ?1", [key], |row| {
@@ -653,10 +641,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn set_metadata(&self, key: &str, value: &str) -> Result<(), StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("set_metadata")?;
 
         conn.execute(
             "INSERT INTO metadata (key, value) VALUES (?1, ?2) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -668,10 +653,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn delete_metadata_by_prefix(&self, prefix: &str) -> Result<u64, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("delete_metadata_by_prefix")?;
 
         let deleted = conn
             .execute(
@@ -684,10 +666,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn touch_last_seen(&self, asset_id: &str) -> Result<(), StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("touch_last_seen")?;
 
         let now = Utc::now().timestamp();
         conn.execute(
@@ -700,10 +679,7 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn sample_downloaded_paths(&self, limit: usize) -> Result<Vec<PathBuf>, StateError> {
-        let conn = self
-            .conn
-            .lock()
-            .map_err(|e| StateError::Query(e.to_string()))?;
+        let conn = self.acquire_lock("sample_downloaded_paths")?;
 
         let mut stmt = conn
             .prepare_cached(

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use crate::icloud::photos::AssetVersionSize;
+use crate::types::AssetVersionSize;
 
 /// Version size key for state tracking.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,61 @@
 use serde::{Deserialize, Serialize};
 
+/// Whether an asset is an image or a video.
+///
+/// Provider-agnostic — each provider adapter maps its native classification
+/// (e.g., iCloud UTI strings) into this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AssetItemType {
+    Image,
+    Movie,
+}
+
+/// Version size key for asset versions.
+///
+/// Uses `#[repr(u8)]` to guarantee 1-byte size for better struct packing.
+/// Provider-agnostic — maps to every provider's concept of resolution tiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum AssetVersionSize {
+    Original = 0,
+    Alternative = 1,
+    Medium = 2,
+    Thumb = 3,
+    Adjusted = 4,
+    LiveOriginal = 5,
+    LiveMedium = 6,
+    LiveThumb = 7,
+    LiveAdjusted = 8,
+}
+
+impl From<VersionSize> for AssetVersionSize {
+    fn from(v: VersionSize) -> Self {
+        match v {
+            VersionSize::Original => Self::Original,
+            VersionSize::Medium => Self::Medium,
+            VersionSize::Thumb => Self::Thumb,
+            VersionSize::Adjusted => Self::Adjusted,
+            VersionSize::Alternative => Self::Alternative,
+        }
+    }
+}
+
+/// Reason for a record change in a delta/incremental sync response.
+///
+/// Provider-agnostic — each provider maps its native change types into
+/// these categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeReason {
+    /// New or modified record (state DB determines which).
+    Created,
+    /// Soft-deleted (moved to trash / recently deleted).
+    SoftDeleted,
+    /// Permanently purged from the provider.
+    HardDeleted,
+    /// Hidden from the main library view.
+    Hidden,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum VersionSize {
@@ -93,8 +149,7 @@ pub enum LivePhotoMode {
 }
 
 impl LivePhotoSize {
-    pub fn to_asset_version_size(self) -> crate::icloud::photos::AssetVersionSize {
-        use crate::icloud::photos::AssetVersionSize;
+    pub fn to_asset_version_size(self) -> AssetVersionSize {
         match self {
             Self::Original => AssetVersionSize::LiveOriginal,
             Self::Medium => AssetVersionSize::LiveMedium,
@@ -107,7 +162,6 @@ impl LivePhotoSize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::icloud::photos::AssetVersionSize;
 
     #[test]
     fn test_live_photo_size_to_asset_version_size() {
@@ -247,5 +301,44 @@ mod tests {
             let parsed: LivePhotoMovFilenamePolicy = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed, variant);
         }
+    }
+
+    #[test]
+    fn from_version_size_all_variants() {
+        for (input, expected) in [
+            (VersionSize::Original, AssetVersionSize::Original),
+            (VersionSize::Medium, AssetVersionSize::Medium),
+            (VersionSize::Thumb, AssetVersionSize::Thumb),
+            (VersionSize::Adjusted, AssetVersionSize::Adjusted),
+            (VersionSize::Alternative, AssetVersionSize::Alternative),
+        ] {
+            assert_eq!(AssetVersionSize::from(input), expected, "from {input:?}");
+        }
+    }
+
+    #[test]
+    fn asset_version_size_is_one_byte() {
+        assert_eq!(std::mem::size_of::<AssetVersionSize>(), 1);
+    }
+
+    #[test]
+    fn asset_version_size_variants_have_distinct_repr_values() {
+        let variants = [
+            AssetVersionSize::Original as u8,
+            AssetVersionSize::Alternative as u8,
+            AssetVersionSize::Medium as u8,
+            AssetVersionSize::Thumb as u8,
+            AssetVersionSize::Adjusted as u8,
+            AssetVersionSize::LiveOriginal as u8,
+            AssetVersionSize::LiveMedium as u8,
+            AssetVersionSize::LiveThumb as u8,
+            AssetVersionSize::LiveAdjusted as u8,
+        ];
+        let unique: std::collections::HashSet<u8> = variants.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            variants.len(),
+            "all repr(u8) values must be distinct"
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -322,6 +322,41 @@ mod tests {
     }
 
     #[test]
+    fn asset_item_type_equality() {
+        assert_eq!(AssetItemType::Image, AssetItemType::Image);
+        assert_eq!(AssetItemType::Movie, AssetItemType::Movie);
+        assert_ne!(AssetItemType::Image, AssetItemType::Movie);
+    }
+
+    #[test]
+    fn asset_item_type_debug() {
+        assert_eq!(format!("{:?}", AssetItemType::Image), "Image");
+        assert_eq!(format!("{:?}", AssetItemType::Movie), "Movie");
+    }
+
+    #[test]
+    fn change_reason_equality() {
+        assert_eq!(ChangeReason::Created, ChangeReason::Created);
+        assert_eq!(ChangeReason::SoftDeleted, ChangeReason::SoftDeleted);
+        assert_eq!(ChangeReason::HardDeleted, ChangeReason::HardDeleted);
+        assert_eq!(ChangeReason::Hidden, ChangeReason::Hidden);
+        assert_ne!(ChangeReason::Created, ChangeReason::SoftDeleted);
+        assert_ne!(ChangeReason::HardDeleted, ChangeReason::Hidden);
+    }
+
+    #[test]
+    fn change_reason_debug() {
+        for (variant, expected) in [
+            (ChangeReason::Created, "Created"),
+            (ChangeReason::SoftDeleted, "SoftDeleted"),
+            (ChangeReason::HardDeleted, "HardDeleted"),
+            (ChangeReason::Hidden, "Hidden"),
+        ] {
+            assert_eq!(format!("{variant:?}"), expected);
+        }
+    }
+
+    #[test]
     fn asset_version_size_variants_have_distinct_repr_values() {
         let variants = [
             AssetVersionSize::Original as u8,

--- a/src/types.rs
+++ b/src/types.rs
@@ -322,41 +322,6 @@ mod tests {
     }
 
     #[test]
-    fn asset_item_type_equality() {
-        assert_eq!(AssetItemType::Image, AssetItemType::Image);
-        assert_eq!(AssetItemType::Movie, AssetItemType::Movie);
-        assert_ne!(AssetItemType::Image, AssetItemType::Movie);
-    }
-
-    #[test]
-    fn asset_item_type_debug() {
-        assert_eq!(format!("{:?}", AssetItemType::Image), "Image");
-        assert_eq!(format!("{:?}", AssetItemType::Movie), "Movie");
-    }
-
-    #[test]
-    fn change_reason_equality() {
-        assert_eq!(ChangeReason::Created, ChangeReason::Created);
-        assert_eq!(ChangeReason::SoftDeleted, ChangeReason::SoftDeleted);
-        assert_eq!(ChangeReason::HardDeleted, ChangeReason::HardDeleted);
-        assert_eq!(ChangeReason::Hidden, ChangeReason::Hidden);
-        assert_ne!(ChangeReason::Created, ChangeReason::SoftDeleted);
-        assert_ne!(ChangeReason::HardDeleted, ChangeReason::Hidden);
-    }
-
-    #[test]
-    fn change_reason_debug() {
-        for (variant, expected) in [
-            (ChangeReason::Created, "Created"),
-            (ChangeReason::SoftDeleted, "SoftDeleted"),
-            (ChangeReason::HardDeleted, "HardDeleted"),
-            (ChangeReason::Hidden, "Hidden"),
-        ] {
-            assert_eq!(format!("{variant:?}"), expected);
-        }
-    }
-
-    #[test]
     fn asset_version_size_variants_have_distinct_repr_values() {
         let variants = [
             AssetVersionSize::Original as u8,


### PR DESCRIPTION
## Summary

Fixes the 421 Misdirected Request recovery that broke for users where Apple consistently returns the same CloudKit partition URL (#199). The v0.7.2 fix forced full SRP re-auth + 2FA on every 421, then bailed if the URL didn't change. That was wrong - the URL isn't the problem, stale connection state is.

New approach tries two strategies in order:

1. **Reset HTTP clients** - drop the connection pool, retry with fresh TCP connections. Keeps all auth state, no password or 2FA prompt. This is the cheap fix that handles HTTP/2 routing issues.
2. **Full re-auth** - only if step 1 still gets 421. Releases the session lock, does fresh SRP login. Retries regardless of whether the service URL changed.

Also bundles cleanup across the codebase:

- Move `AssetItemType`, `AssetVersionSize`, `ChangeReason` from `icloud/photos/types.rs` to `types.rs` (provider-agnostic)
- Extract `build_clients()` to deduplicate HTTP client construction between `Session::build()` and `reset_http_clients()`
- Store `api_timeout` in Session so connection pool reset preserves configured timeout
- `acquire_lock()` helper replacing 15+ identical lock patterns in state DB
- Pre-allocate bulk DB loads with `COUNT(*)` + `with_capacity`
- `rename_part_to_final()` for concurrent download race handling
- Tighten `pub` to `pub(crate)` on internal types
- `// SAFETY:` comments on all unsafe blocks
- Increase state-write retry from 3 to 6 attempts with proper exponential backoff
- `Box<str>` for CloudKit error fields, deferred clone in record filtering
- Const assertion guarding shift overflow in retry backoff

## Test plan

- [x] `cargo test` passes (1111 unit tests)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual test: trigger 421 recovery path (needs account that hits the partition routing issue)
- [ ] Verify no 2FA prompt on first 421 recovery attempt