### PR TITLE
Preserve trust_token during 421 re-authentication

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 use self::endpoints::Endpoints;
 use self::error::AuthError;
 pub use self::responses::AccountLoginResponse;
+pub(crate) use self::session::strip_session_routing_state;
 use self::session::Session;
 pub use self::session::SharedSession;
 

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -125,6 +125,49 @@ async fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// Strip routing state from a persisted session file, keeping only `trust_token`
+/// and `client_id`.
+///
+/// Clearing `session_token` forces `authenticate()` through the SRP path instead
+/// of the validate shortcut. Preserving `trust_token` lets SRP send it in
+/// `trustTokens`, so Apple can recognise a trusted device and skip 2FA.
+///
+/// Deletes the file if it is corrupt or unreadable (falling back to the old
+/// delete-everything behaviour).
+pub(crate) async fn strip_session_routing_state(session_file: &Path) {
+    let contents = match fs::read_to_string(session_file).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(_) => {
+            let _ = fs::remove_file(session_file).await;
+            return;
+        }
+    };
+
+    let mut map: HashMap<String, String> = match serde_json::from_str(&contents) {
+        Ok(m) => m,
+        Err(_) => {
+            let _ = fs::remove_file(session_file).await;
+            return;
+        }
+    };
+
+    map.retain(|k, _| k == "trust_token" || k == "client_id");
+
+    match serde_json::to_string_pretty(&map) {
+        Ok(json) => {
+            if let Err(e) = atomic_write(session_file, json.as_bytes()).await {
+                tracing::warn!(error = %e, "Could not rewrite session file, removing");
+                let _ = fs::remove_file(session_file).await;
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Could not serialise stripped session, removing");
+            let _ = fs::remove_file(session_file).await;
+        }
+    }
+}
+
 /// Build the API and download HTTP clients for a session.
 ///
 /// Both share the same cookie jar. The API client uses a total-request timeout;
@@ -1040,5 +1083,70 @@ mod tests {
             Duration::from_secs(45),
             "reset_http_clients must preserve the configured timeout"
         );
+    }
+
+    #[tokio::test]
+    async fn strip_session_preserves_trust_token_and_client_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.session");
+        let data = serde_json::json!({
+            "session_token": "tok_abc",
+            "session_id": "sid_123",
+            "scnt": "scnt_val",
+            "trust_token": "trust_xyz",
+            "client_id": "auth-1234",
+            "account_country": "USA"
+        });
+        std::fs::write(&path, data.to_string()).unwrap();
+
+        strip_session_routing_state(&path).await;
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let map: HashMap<String, String> = serde_json::from_str(&contents).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["trust_token"], "trust_xyz");
+        assert_eq!(map["client_id"], "auth-1234");
+        assert!(!map.contains_key("session_token"));
+        assert!(!map.contains_key("session_id"));
+        assert!(!map.contains_key("scnt"));
+    }
+
+    #[tokio::test]
+    async fn strip_session_corrupt_file_gets_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.session");
+        std::fs::write(&path, "not valid json {{{").unwrap();
+
+        strip_session_routing_state(&path).await;
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn strip_session_missing_file_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.session");
+
+        strip_session_routing_state(&path).await;
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn strip_session_no_trust_token_leaves_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_trust.session");
+        let data = serde_json::json!({
+            "session_token": "tok_abc",
+            "session_id": "sid_123",
+            "scnt": "scnt_val"
+        });
+        std::fs::write(&path, data.to_string()).unwrap();
+
+        strip_session_routing_state(&path).await;
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let map: HashMap<String, String> = serde_json::from_str(&contents).unwrap();
+        assert!(map.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,28 +323,7 @@ async fn init_photos_service(
         session.release_lock()?;
     }
     let session_file = auth::session_file_path(cookie_directory, username);
-    match tokio::fs::read_to_string(&session_file).await {
-        Ok(contents) => {
-            match serde_json::from_str::<HashMap<String, serde_json::Value>>(&contents) {
-                Ok(mut map) => {
-                    map.retain(|k, _| k == "trust_token" || k == "client_id");
-                    if let Ok(json) = serde_json::to_string_pretty(&map) {
-                        if let Err(e) = tokio::fs::write(&session_file, json.as_bytes()).await {
-                            tracing::warn!(error = %e, "Could not rewrite session file, removing");
-                            let _ = tokio::fs::remove_file(&session_file).await;
-                        }
-                    }
-                }
-                Err(_) => {
-                    let _ = tokio::fs::remove_file(&session_file).await;
-                }
-            }
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(_) => {
-            let _ = tokio::fs::remove_file(&session_file).await;
-        }
-    }
+    strip_session_routing_state(&session_file).await;
     let new_auth = auth::authenticate(
         cookie_directory,
         username,
@@ -456,6 +435,38 @@ async fn init_photos_service(
         fresh_url,
         BACKOFF_SECS.len()
     )
+}
+
+/// Strip routing state from a session file, keeping only `trust_token` and `client_id`.
+///
+/// Clearing `session_token` forces `authenticate()` through the SRP path instead of the
+/// validate shortcut. Preserving `trust_token` lets SRP send it in `trustTokens`, so
+/// Apple can recognise a trusted device and skip 2FA.
+///
+/// Deletes the file if it's corrupt or unreadable (fallback to old behavior).
+async fn strip_session_routing_state(session_file: &Path) {
+    match tokio::fs::read_to_string(session_file).await {
+        Ok(contents) => {
+            match serde_json::from_str::<HashMap<String, serde_json::Value>>(&contents) {
+                Ok(mut map) => {
+                    map.retain(|k, _| k == "trust_token" || k == "client_id");
+                    if let Ok(json) = serde_json::to_string_pretty(&map) {
+                        if let Err(e) = tokio::fs::write(session_file, json.as_bytes()).await {
+                            tracing::warn!(error = %e, "Could not rewrite session file, removing");
+                            let _ = tokio::fs::remove_file(session_file).await;
+                        }
+                    }
+                }
+                Err(_) => {
+                    let _ = tokio::fs::remove_file(session_file).await;
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(_) => {
+            let _ = tokio::fs::remove_file(session_file).await;
+        }
+    }
 }
 
 /// Check if an iCloud error is a 421 Misdirected Request from the CloudKit service.
@@ -2420,6 +2431,71 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn strip_session_preserves_trust_token_and_client_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.session");
+        let data = serde_json::json!({
+            "session_token": "tok_abc",
+            "session_id": "sid_123",
+            "scnt": "scnt_val",
+            "trust_token": "trust_xyz",
+            "client_id": "auth-1234",
+            "account_country": "USA"
+        });
+        std::fs::write(&path, data.to_string()).unwrap();
+
+        strip_session_routing_state(&path).await;
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let map: HashMap<String, serde_json::Value> = serde_json::from_str(&contents).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["trust_token"], "trust_xyz");
+        assert_eq!(map["client_id"], "auth-1234");
+        assert!(!map.contains_key("session_token"));
+        assert!(!map.contains_key("session_id"));
+        assert!(!map.contains_key("scnt"));
+    }
+
+    #[tokio::test]
+    async fn strip_session_corrupt_file_gets_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.session");
+        std::fs::write(&path, "not valid json {{{").unwrap();
+
+        strip_session_routing_state(&path).await;
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn strip_session_missing_file_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.session");
+
+        strip_session_routing_state(&path).await;
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn strip_session_no_trust_token_leaves_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_trust.session");
+        let data = serde_json::json!({
+            "session_token": "tok_abc",
+            "session_id": "sid_123",
+            "scnt": "scnt_val"
+        });
+        std::fs::write(&path, data.to_string()).unwrap();
+
+        strip_session_routing_state(&path).await;
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let map: HashMap<String, serde_json::Value> = serde_json::from_str(&contents).unwrap();
+        assert!(map.is_empty());
+    }
 
     #[test]
     fn pid_file_guard_creates_and_removes() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod types;
 #[cfg(test)]
 mod test_helpers;
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -309,12 +310,10 @@ async fn init_photos_service(
     // Expensive fix: clear session state, perform fresh SRP + 2FA login.
     // Handles cases where stale session headers cause wrong partition routing.
     //
-    // We must delete the persisted session file first. Otherwise
-    // `authenticate()` finds the still-valid session_token, calls
-    // `/validate` (which succeeds), and returns the same stale ckdatabasews
-    // URL without ever performing SRP. Removing the file forces a fresh
-    // SRP login → `/accountLogin`, giving Apple the best chance of
-    // returning an updated partition URL.
+    // Clear routing-related session state (session_token, session_id, scnt)
+    // so `authenticate()` falls through to fresh SRP instead of the validate
+    // shortcut. We preserve trust_token so SRP can include it in `trustTokens`,
+    // letting Apple recognise this as a trusted device and skip 2FA.
     tracing::warn!(
         url = %ckdatabasews_url,
         "Fresh connection pool did not resolve 421, performing full re-authentication"
@@ -324,13 +323,26 @@ async fn init_photos_service(
         session.release_lock()?;
     }
     let session_file = auth::session_file_path(cookie_directory, username);
-    if let Err(e) = tokio::fs::remove_file(&session_file).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!(
-                path = %session_file.display(),
-                error = %e,
-                "Could not remove session file before re-authentication"
-            );
+    match tokio::fs::read_to_string(&session_file).await {
+        Ok(contents) => {
+            match serde_json::from_str::<HashMap<String, serde_json::Value>>(&contents) {
+                Ok(mut map) => {
+                    map.retain(|k, _| k == "trust_token" || k == "client_id");
+                    if let Ok(json) = serde_json::to_string_pretty(&map) {
+                        if let Err(e) = tokio::fs::write(&session_file, json.as_bytes()).await {
+                            tracing::warn!(error = %e, "Could not rewrite session file, removing");
+                            let _ = tokio::fs::remove_file(&session_file).await;
+                        }
+                    }
+                }
+                Err(_) => {
+                    let _ = tokio::fs::remove_file(&session_file).await;
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(_) => {
+            let _ = tokio::fs::remove_file(&session_file).await;
         }
     }
     let new_auth = auth::authenticate(

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ mod types;
 #[cfg(test)]
 mod test_helpers;
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -323,7 +322,7 @@ async fn init_photos_service(
         session.release_lock()?;
     }
     let session_file = auth::session_file_path(cookie_directory, username);
-    strip_session_routing_state(&session_file).await;
+    auth::strip_session_routing_state(&session_file).await;
     let new_auth = auth::authenticate(
         cookie_directory,
         username,
@@ -435,38 +434,6 @@ async fn init_photos_service(
         fresh_url,
         BACKOFF_SECS.len()
     )
-}
-
-/// Strip routing state from a session file, keeping only `trust_token` and `client_id`.
-///
-/// Clearing `session_token` forces `authenticate()` through the SRP path instead of the
-/// validate shortcut. Preserving `trust_token` lets SRP send it in `trustTokens`, so
-/// Apple can recognise a trusted device and skip 2FA.
-///
-/// Deletes the file if it's corrupt or unreadable (fallback to old behavior).
-async fn strip_session_routing_state(session_file: &Path) {
-    match tokio::fs::read_to_string(session_file).await {
-        Ok(contents) => {
-            match serde_json::from_str::<HashMap<String, serde_json::Value>>(&contents) {
-                Ok(mut map) => {
-                    map.retain(|k, _| k == "trust_token" || k == "client_id");
-                    if let Ok(json) = serde_json::to_string_pretty(&map) {
-                        if let Err(e) = tokio::fs::write(session_file, json.as_bytes()).await {
-                            tracing::warn!(error = %e, "Could not rewrite session file, removing");
-                            let _ = tokio::fs::remove_file(session_file).await;
-                        }
-                    }
-                }
-                Err(_) => {
-                    let _ = tokio::fs::remove_file(session_file).await;
-                }
-            }
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(_) => {
-            let _ = tokio::fs::remove_file(session_file).await;
-        }
-    }
 }
 
 /// Check if an iCloud error is a 421 Misdirected Request from the CloudKit service.
@@ -2431,71 +2398,6 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[tokio::test]
-    async fn strip_session_preserves_trust_token_and_client_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.session");
-        let data = serde_json::json!({
-            "session_token": "tok_abc",
-            "session_id": "sid_123",
-            "scnt": "scnt_val",
-            "trust_token": "trust_xyz",
-            "client_id": "auth-1234",
-            "account_country": "USA"
-        });
-        std::fs::write(&path, data.to_string()).unwrap();
-
-        strip_session_routing_state(&path).await;
-
-        let contents = std::fs::read_to_string(&path).unwrap();
-        let map: HashMap<String, serde_json::Value> = serde_json::from_str(&contents).unwrap();
-        assert_eq!(map.len(), 2);
-        assert_eq!(map["trust_token"], "trust_xyz");
-        assert_eq!(map["client_id"], "auth-1234");
-        assert!(!map.contains_key("session_token"));
-        assert!(!map.contains_key("session_id"));
-        assert!(!map.contains_key("scnt"));
-    }
-
-    #[tokio::test]
-    async fn strip_session_corrupt_file_gets_deleted() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("corrupt.session");
-        std::fs::write(&path, "not valid json {{{").unwrap();
-
-        strip_session_routing_state(&path).await;
-
-        assert!(!path.exists());
-    }
-
-    #[tokio::test]
-    async fn strip_session_missing_file_is_noop() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("nonexistent.session");
-
-        strip_session_routing_state(&path).await;
-
-        assert!(!path.exists());
-    }
-
-    #[tokio::test]
-    async fn strip_session_no_trust_token_leaves_empty_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("no_trust.session");
-        let data = serde_json::json!({
-            "session_token": "tok_abc",
-            "session_id": "sid_123",
-            "scnt": "scnt_val"
-        });
-        std::fs::write(&path, data.to_string()).unwrap();
-
-        strip_session_routing_state(&path).await;
-
-        let contents = std::fs::read_to_string(&path).unwrap();
-        let map: HashMap<String, serde_json::Value> = serde_json::from_str(&contents).unwrap();
-        assert!(map.is_empty());
-    }
 
     #[test]
     fn pid_file_guard_creates_and_removes() {


### PR DESCRIPTION
## Summary

- 421 recovery strategy 2 (full re-auth) was deleting the session file entirely, which nuked the `trust_token`. Without it, Apple treats every re-auth as a new device and demands password + 2FA - even if the user authenticated seconds ago.
- Now rewrites the session file keeping `trust_token` and `client_id`, clearing only the routing state (`session_token`, `session_id`, `scnt`). SRP still runs fresh, but sends the preserved token in `trustTokens` so Apple can skip 2FA for recognised devices.
- Fallback behavior unchanged: corrupt or unreadable session files still get deleted.

## Context

Reported in #199 - user on `p60` partition hit persistent 421s. Strategy 1 (connection pool reset) couldn't fix it, but strategy 2 (re-auth) did because fresh session headers get a fresh routing decision from the partition server. The re-auth itself works, but losing `trust_token` every time made it require 2FA on every single run.

## Test plan

- [x] `cargo check`, `cargo clippy`, `cargo test --test cli`, `cargo test --test behavioral` all pass
- [x] Verify session file after 421 recovery contains `trust_token` and `client_id` only
- [ ] Confirm re-auth after 421 doesn't prompt for 2FA when trust_token is present
- [x] Confirm corrupt session file still gets deleted (fallback path)