### PR TITLE
Add core metadata model (#83)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "little_exif",
  "num-bigint",
  "pbkdf2",
+ "plist",
  "predicates",
  "rand 0.10.0",
  "reqwest",
@@ -1534,7 +1535,7 @@ dependencies = [
  "log",
  "miniz_oxide",
  "paste",
- "quick-xml",
+ "quick-xml 0.37.5",
 ]
 
 [[package]]
@@ -1739,6 +1740,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1864,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ smallvec = "1.15"
 rustc-hash = "2.1"
 data-encoding = "2.10.0"
 sha1 = "0.10"
+plist = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3", features = ["apple-native"] }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -39,6 +39,8 @@ use crate::types::{
 
 use error::DownloadError;
 
+use crate::state::types::SOURCE_ICLOUD;
+
 /// Case-insensitive glob matching options for filename exclusion patterns.
 const GLOB_CASE_INSENSITIVE: glob::MatchOptions = glob::MatchOptions {
     case_sensitive: false,
@@ -1679,25 +1681,19 @@ async fn download_photos_incremental(
                         downloadable_assets.push((asset, Arc::clone(&album.name)));
                     }
                 }
-                ChangeReason::SoftDeleted => {
-                    soft_deleted_count += 1;
+                ChangeReason::SoftDeleted | ChangeReason::HardDeleted => {
+                    if event.reason == ChangeReason::SoftDeleted {
+                        soft_deleted_count += 1;
+                    } else {
+                        hard_deleted_count += 1;
+                    }
                     if let Some(db) = &config.state_db {
                         let ts = chrono::Utc::now().timestamp();
                         if let Err(e) = db.mark_asset_deleted(&event.record_name, Some(ts)).await {
                             tracing::warn!(asset_id = %event.record_name, error = %e, "Failed to mark asset deleted");
                         }
                     }
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Marked soft-deleted");
-                }
-                ChangeReason::HardDeleted => {
-                    hard_deleted_count += 1;
-                    if let Some(db) = &config.state_db {
-                        let ts = chrono::Utc::now().timestamp();
-                        if let Err(e) = db.mark_asset_deleted(&event.record_name, Some(ts)).await {
-                            tracing::warn!(asset_id = %event.record_name, error = %e, "Failed to mark asset deleted");
-                        }
-                    }
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Marked hard-deleted");
+                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, reason = ?event.reason, "Marked deleted");
                 }
                 ChangeReason::Hidden => {
                     hidden_count += 1;
@@ -1803,6 +1799,7 @@ async fn download_photos_incremental(
         // Without this, the UPDATE in mark_downloaded matches 0 rows and the
         // file ends up on disk but untracked in the state DB.
         if let Some(db) = &config.state_db {
+            let cloned_meta = asset.metadata().cloned().map(Box::new);
             for task in &asset_tasks {
                 let media_type = determine_media_type(task.version_size, asset);
                 let mut record = AssetRecord::new_pending(
@@ -1819,9 +1816,7 @@ async fn download_photos_incremental(
                     task.size,
                     media_type,
                 );
-                if let Some(meta) = asset.metadata().cloned() {
-                    record.metadata = Some(Box::new(meta));
-                }
+                record.metadata = cloned_meta.clone();
                 if let Err(e) = db.upsert_seen(&record).await {
                     tracing::warn!(
                         asset_id = %task.asset_id,
@@ -1829,12 +1824,14 @@ async fn download_photos_incremental(
                         "Failed to record asset in state DB"
                     );
                 }
+            }
 
-                // Track album membership
-                let albums = [(album_name.to_string(), "icloud".to_string())];
-                if let Err(e) = db.upsert_asset_albums(&task.asset_id, &albums).await {
+            // Track album membership (once per asset, not per version)
+            if let Some(first_task) = asset_tasks.first() {
+                let albums = [(album_name.to_string(), SOURCE_ICLOUD.to_string())];
+                if let Err(e) = db.upsert_asset_albums(&first_task.asset_id, &albums).await {
                     tracing::warn!(
-                        asset_id = %task.asset_id,
+                        asset_id = %first_task.asset_id,
                         error = %e,
                         "Failed to record album membership"
                     );
@@ -2216,6 +2213,20 @@ where
                         skipped_by_filter += 1;
                         producer_pb.inc(1);
                     } else {
+                        let asset_meta = asset.metadata().cloned().map(Box::new);
+                        // Track album membership once per asset, not per version
+                        if let Some(db) = &producer_state_db {
+                            if let Some(album) = config.album_name.as_deref() {
+                                let albums = [(album.to_string(), SOURCE_ICLOUD.to_string())];
+                                if let Err(e) = db.upsert_asset_albums(asset.id(), &albums).await {
+                                    tracing::warn!(
+                                        asset_id = %asset.id(),
+                                        error = %e,
+                                        "Failed to record album membership"
+                                    );
+                                }
+                            }
+                        }
                         for task in tasks {
                             // Skip assets that have exceeded the retry limit.
                             if let Some(&attempts) =
@@ -2260,29 +2271,13 @@ where
                                     task.size,
                                     media_type,
                                 );
-                                if let Some(meta) = asset.metadata().cloned() {
-                                    record.metadata = Some(Box::new(meta));
-                                }
+                                record.metadata = asset_meta.clone();
                                 if let Err(e) = db.upsert_seen(&record).await {
                                     tracing::warn!(
                                         asset_id = %task.asset_id,
                                         error = %e,
                                         "Failed to record asset"
                                     );
-                                }
-
-                                // Track album membership
-                                if let Some(album) = config.album_name.as_deref() {
-                                    let albums = [(album.to_string(), "icloud".to_string())];
-                                    if let Err(e) =
-                                        db.upsert_asset_albums(&task.asset_id, &albums).await
-                                    {
-                                        tracing::warn!(
-                                            asset_id = %task.asset_id,
-                                            error = %e,
-                                            "Failed to record album membership"
-                                        );
-                                    }
                                 }
 
                                 match download_ctx.should_download_fast(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1681,15 +1681,32 @@ async fn download_photos_incremental(
                 }
                 ChangeReason::SoftDeleted => {
                     soft_deleted_count += 1;
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping soft-deleted record");
+                    if let Some(db) = &config.state_db {
+                        let ts = chrono::Utc::now().timestamp();
+                        if let Err(e) = db.mark_asset_deleted(&event.record_name, Some(ts)).await {
+                            tracing::warn!(asset_id = %event.record_name, error = %e, "Failed to mark asset deleted");
+                        }
+                    }
+                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Marked soft-deleted");
                 }
                 ChangeReason::HardDeleted => {
                     hard_deleted_count += 1;
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hard-deleted record");
+                    if let Some(db) = &config.state_db {
+                        let ts = chrono::Utc::now().timestamp();
+                        if let Err(e) = db.mark_asset_deleted(&event.record_name, Some(ts)).await {
+                            tracing::warn!(asset_id = %event.record_name, error = %e, "Failed to mark asset deleted");
+                        }
+                    }
+                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Marked hard-deleted");
                 }
                 ChangeReason::Hidden => {
                     hidden_count += 1;
-                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Skipping hidden record");
+                    if let Some(db) = &config.state_db {
+                        if let Err(e) = db.mark_asset_hidden(&event.record_name).await {
+                            tracing::warn!(asset_id = %event.record_name, error = %e, "Failed to mark asset hidden");
+                        }
+                    }
+                    tracing::debug!(record_name = %event.record_name, record_type = ?event.record_type, "Marked hidden");
                 }
             }
         }
@@ -1788,7 +1805,7 @@ async fn download_photos_incremental(
         if let Some(db) = &config.state_db {
             for task in &asset_tasks {
                 let media_type = determine_media_type(task.version_size, asset);
-                let record = AssetRecord::new_pending(
+                let mut record = AssetRecord::new_pending(
                     task.asset_id.to_string(),
                     task.version_size,
                     task.checksum.to_string(),
@@ -1802,11 +1819,24 @@ async fn download_photos_incremental(
                     task.size,
                     media_type,
                 );
+                if let Some(meta) = asset.metadata().cloned() {
+                    record.metadata = Some(Box::new(meta));
+                }
                 if let Err(e) = db.upsert_seen(&record).await {
                     tracing::warn!(
                         asset_id = %task.asset_id,
                         error = %e,
                         "Failed to record asset in state DB"
+                    );
+                }
+
+                // Track album membership
+                let albums = [(album_name.to_string(), "icloud".to_string())];
+                if let Err(e) = db.upsert_asset_albums(&task.asset_id, &albums).await {
+                    tracing::warn!(
+                        asset_id = %task.asset_id,
+                        error = %e,
+                        "Failed to record album membership"
                     );
                 }
             }
@@ -2216,7 +2246,7 @@ where
 
                             if let Some(db) = &producer_state_db {
                                 let media_type = determine_media_type(task.version_size, &asset);
-                                let record = AssetRecord::new_pending(
+                                let mut record = AssetRecord::new_pending(
                                     task.asset_id.to_string(),
                                     task.version_size,
                                     task.checksum.to_string(),
@@ -2230,12 +2260,29 @@ where
                                     task.size,
                                     media_type,
                                 );
+                                if let Some(meta) = asset.metadata().cloned() {
+                                    record.metadata = Some(Box::new(meta));
+                                }
                                 if let Err(e) = db.upsert_seen(&record).await {
                                     tracing::warn!(
                                         asset_id = %task.asset_id,
                                         error = %e,
                                         "Failed to record asset"
                                     );
+                                }
+
+                                // Track album membership
+                                if let Some(album) = config.album_name.as_deref() {
+                                    let albums = [(album.to_string(), "icloud".to_string())];
+                                    if let Err(e) =
+                                        db.upsert_asset_albums(&task.asset_id, &albums).await
+                                    {
+                                        tracing::warn!(
+                                            asset_id = %task.asset_id,
+                                            error = %e,
+                                            "Failed to record album membership"
+                                        );
+                                    }
                                 }
 
                                 match download_ctx.should_download_fast(
@@ -5433,6 +5480,28 @@ mod tests {
             &self,
             _: usize,
         ) -> Result<Vec<std::path::PathBuf>, StateError> {
+            unimplemented!()
+        }
+        async fn upsert_asset_albums(
+            &self,
+            _: &str,
+            _: &[(String, String)],
+        ) -> Result<(), StateError> {
+            unimplemented!()
+        }
+        async fn upsert_asset_people(&self, _: &str, _: &[String]) -> Result<(), StateError> {
+            unimplemented!()
+        }
+        async fn get_asset_albums(&self, _: &str) -> Result<Vec<String>, StateError> {
+            unimplemented!()
+        }
+        async fn get_asset_people(&self, _: &str) -> Result<Vec<String>, StateError> {
+            unimplemented!()
+        }
+        async fn mark_asset_deleted(&self, _: &str, _: Option<i64>) -> Result<(), StateError> {
+            unimplemented!()
+        }
+        async fn mark_asset_hidden(&self, _: &str) -> Result<(), StateError> {
             unimplemented!()
         }
     }

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -1,4 +1,3 @@
-use base64::Engine;
 use chrono::{DateTime, TimeZone, Utc};
 use rustc_hash::FxHashMap;
 use serde_json::Value;
@@ -55,28 +54,8 @@ pub struct PhotoAsset {
 }
 
 /// Decode filename from `CloudKit`'s `filenameEnc` field.
-/// Apple uses either plain STRING or base64-encoded `ENCRYPTED_BYTES` depending
-/// on the user's iCloud configuration.
 fn decode_filename(fields: &Value) -> Option<String> {
-    let enc = &fields["filenameEnc"];
-    if enc.is_null() {
-        return None;
-    }
-    let value = enc["value"].as_str()?;
-    let enc_type = enc["type"].as_str().unwrap_or("STRING");
-    match enc_type {
-        "STRING" => Some(value.to_string()),
-        "ENCRYPTED_BYTES" => {
-            let decoded = base64::engine::general_purpose::STANDARD
-                .decode(value)
-                .ok()?;
-            String::from_utf8(decoded).ok()
-        }
-        other => {
-            warn!(enc_type = %other, "Unsupported filenameEnc type");
-            None
-        }
-    }
+    super::decode::decode_enc_string(&fields["filenameEnc"])
 }
 
 /// Convert an `f64` millisecond timestamp to a `DateTime<Utc>`, returning

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -8,6 +8,7 @@ use tracing::warn;
 use super::cloudkit::Record;
 use super::queries::{item_type_from_str, PHOTO_VERSION_LOOKUP, VIDEO_VERSION_LOOKUP};
 use super::types::{AssetItemType, AssetVersion, AssetVersionSize, ChangeReason};
+use crate::state::types::AssetMetadata;
 
 /// Type alias for the versions map.
 ///
@@ -44,6 +45,8 @@ pub struct PhotoAsset {
     filename: Option<String>,
     // SmallVec with inline storage
     versions: VersionsMap,
+    // Metadata extracted from CloudKit fields at construction time
+    metadata: Option<Box<AssetMetadata>>,
     // f64 primitives
     asset_date_ms: Option<f64>,
     added_date_ms: Option<f64>,
@@ -214,6 +217,10 @@ impl PhotoAsset {
         let asset_date_ms = asset_fields["assetDate"]["value"].as_f64();
         let added_date_ms = asset_fields["addedDate"]["value"].as_f64();
         let versions = extract_versions(item_type_val, &master_fields, &asset_fields, &record_name);
+        let metadata = Some(Box::new(super::decode::extract_metadata(
+            &master_fields,
+            &asset_fields,
+        )));
         Self {
             record_name,
             filename,
@@ -221,6 +228,7 @@ impl PhotoAsset {
             asset_date_ms,
             added_date_ms,
             versions,
+            metadata,
         }
     }
 
@@ -236,6 +244,10 @@ impl PhotoAsset {
             &asset.fields,
             &master.record_name,
         );
+        let metadata = Some(Box::new(super::decode::extract_metadata(
+            &master.fields,
+            &asset.fields,
+        )));
         Self {
             record_name: master.record_name,
             filename,
@@ -243,6 +255,7 @@ impl PhotoAsset {
             asset_date_ms,
             added_date_ms,
             versions,
+            metadata,
         }
     }
 
@@ -278,6 +291,11 @@ impl PhotoAsset {
 
     pub fn item_type(&self) -> Option<AssetItemType> {
         self.item_type_val
+    }
+
+    /// Extracted metadata (favorites, GPS, keywords, etc.), if available.
+    pub fn metadata(&self) -> Option<&AssetMetadata> {
+        self.metadata.as_deref()
     }
 
     /// Available download versions, as a list of (size, version) pairs.

--- a/src/icloud/photos/decode.rs
+++ b/src/icloud/photos/decode.rs
@@ -164,7 +164,7 @@ pub(crate) fn extract_metadata(
     let (latitude, longitude, altitude) = decode_location(master_fields, asset_fields);
 
     let mut meta = crate::state::types::AssetMetadata {
-        source: "icloud".to_string(),
+        source: crate::state::types::SOURCE_ICLOUD.to_string(),
         is_favorite: decode_plain_bool(&asset_fields["isFavorite"]),
         is_hidden: decode_plain_bool(&asset_fields["isHidden"]),
         is_deleted: decode_plain_bool(&asset_fields["isDeleted"]),

--- a/src/icloud/photos/decode.rs
+++ b/src/icloud/photos/decode.rs
@@ -1,0 +1,409 @@
+//! Decoders for iCloud CloudKit `*Enc` fields.
+//!
+//! Despite the `Enc` suffix, these fields are **not encrypted** for non-ADP
+//! accounts. Apple's servers decrypt them before returning them via the web
+//! API. What arrives is base64-encoded plaintext (UTF-8 strings) or binary
+//! plist data. See `.scratch/metadata-plan.md` "iCloud `*Enc` field decoding".
+
+use base64::Engine;
+use serde_json::Value;
+use tracing::warn;
+
+/// Decode a CloudKit `ENCRYPTED_BYTES` or `STRING` field to a UTF-8 string.
+///
+/// Handles both type variants that Apple uses for text fields like
+/// `captionEnc`, `extendedDescEnc`, and `filenameEnc`. Returns `None`
+/// for null/missing fields or decoding failures.
+pub(crate) fn decode_enc_string(field: &Value) -> Option<String> {
+    if field.is_null() {
+        return None;
+    }
+    let value = field["value"].as_str()?;
+    if value.is_empty() {
+        return None;
+    }
+    let enc_type = field["type"].as_str().unwrap_or("STRING");
+    match enc_type {
+        "STRING" => Some(value.to_string()),
+        "ENCRYPTED_BYTES" => {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(value)
+                .ok()?;
+            let s = String::from_utf8(decoded).ok()?;
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+        other => {
+            warn!(enc_type = %other, "Unsupported *Enc field type");
+            None
+        }
+    }
+}
+
+/// Decode `keywordsEnc` from base64-encoded binary plist to a list of strings.
+///
+/// The plist contains an array of strings (keyword tags). Returns an empty
+/// `Vec` on null/missing fields, decoding errors, or unexpected plist structure.
+pub(crate) fn decode_keywords_plist(field: &Value) -> Vec<String> {
+    let bytes = match decode_enc_bytes(field) {
+        Some(b) => b,
+        None => return Vec::new(),
+    };
+
+    match plist::from_bytes::<Vec<String>>(&bytes) {
+        Ok(keywords) => keywords,
+        Err(e) => {
+            warn!(error = %e, "Failed to parse keywordsEnc plist");
+            Vec::new()
+        }
+    }
+}
+
+/// Decode GPS location from `locationEnc` (binary plist) or fall back to
+/// plain `locationLatitude`/`locationLongitude` fields.
+///
+/// Returns `(latitude, longitude, altitude)`. Any component may be `None`.
+pub(crate) fn decode_location(
+    master_fields: &Value,
+    asset_fields: &Value,
+) -> (Option<f64>, Option<f64>, Option<f64>) {
+    // Try locationEnc plist first (has altitude)
+    if let Some(loc) = decode_location_plist(&asset_fields["locationEnc"]) {
+        return loc;
+    }
+    // Fall back to locationV2Enc
+    if let Some(loc) = decode_location_plist(&asset_fields["locationV2Enc"]) {
+        return loc;
+    }
+    // Fall back to plain fields on the master record (no altitude)
+    let lat = decode_plain_float(&master_fields["locationLatitude"]);
+    let lon = decode_plain_float(&master_fields["locationLongitude"]);
+    if lat.is_some() || lon.is_some() {
+        return (lat, lon, None);
+    }
+    // Also check asset fields for plain coordinates
+    let lat = decode_plain_float(&asset_fields["locationLatitude"]);
+    let lon = decode_plain_float(&asset_fields["locationLongitude"]);
+    (lat, lon, None)
+}
+
+/// Decode a `locationEnc` or `locationV2Enc` binary plist.
+///
+/// Expected plist structure: dictionary with `lat`, `lng`, `alt` keys (all f64).
+fn decode_location_plist(field: &Value) -> Option<(Option<f64>, Option<f64>, Option<f64>)> {
+    let bytes = decode_enc_bytes(field)?;
+
+    let dict: plist::Dictionary = match plist::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(error = %e, "Failed to parse locationEnc plist");
+            return None;
+        }
+    };
+
+    let lat = dict.get("lat").and_then(plist::Value::as_real);
+    let lon = dict.get("lng").and_then(plist::Value::as_real);
+    let alt = dict.get("alt").and_then(plist::Value::as_real);
+
+    // Only return if we got at least latitude and longitude
+    if lat.is_some() && lon.is_some() {
+        Some((lat, lon, alt))
+    } else {
+        None
+    }
+}
+
+/// Extract raw bytes from a CloudKit `ENCRYPTED_BYTES` field (base64 decode).
+fn decode_enc_bytes(field: &Value) -> Option<Vec<u8>> {
+    if field.is_null() {
+        return None;
+    }
+    let value = field["value"].as_str()?;
+    if value.is_empty() {
+        return None;
+    }
+    base64::engine::general_purpose::STANDARD.decode(value).ok()
+}
+
+/// Read a plain numeric CloudKit field as f64.
+fn decode_plain_float(field: &Value) -> Option<f64> {
+    field["value"].as_f64()
+}
+
+/// Read a plain numeric CloudKit field as i32.
+pub(crate) fn decode_plain_i32(field: &Value) -> Option<i32> {
+    field["value"].as_i64().and_then(|v| i32::try_from(v).ok())
+}
+
+/// Read a plain numeric CloudKit field as i64.
+pub(crate) fn decode_plain_i64(field: &Value) -> Option<i64> {
+    field["value"].as_i64()
+}
+
+/// Read a plain string CloudKit field.
+pub(crate) fn decode_plain_string(field: &Value) -> Option<String> {
+    field["value"].as_str().map(String::from)
+}
+
+/// Read a plain boolean-as-integer CloudKit field (0/1).
+pub(crate) fn decode_plain_bool(field: &Value) -> bool {
+    field["value"].as_i64() == Some(1)
+}
+
+/// Extract all available metadata from iCloud CloudKit master + asset fields.
+///
+/// Decodes `*Enc` fields, reads plain fields, and computes the metadata hash.
+/// Returns an `AssetMetadata` with `source` set to `"icloud"`.
+pub(crate) fn extract_metadata(
+    master_fields: &Value,
+    asset_fields: &Value,
+) -> crate::state::types::AssetMetadata {
+    let (latitude, longitude, altitude) = decode_location(master_fields, asset_fields);
+
+    let mut meta = crate::state::types::AssetMetadata {
+        source: "icloud".to_string(),
+        is_favorite: decode_plain_bool(&asset_fields["isFavorite"]),
+        is_hidden: decode_plain_bool(&asset_fields["isHidden"]),
+        is_deleted: decode_plain_bool(&asset_fields["isDeleted"]),
+        is_archived: false, // iCloud doesn't have an archive concept
+        orientation: decode_plain_i32(&asset_fields["orientation"])
+            .or_else(|| decode_plain_i32(&master_fields["originalOrientation"])),
+        duration_secs: asset_fields["duration"]["value"].as_f64(),
+        timezone_offset: decode_plain_i32(&asset_fields["timeZoneOffset"]),
+        latitude,
+        longitude,
+        altitude,
+        title: decode_enc_string(&asset_fields["captionEnc"]),
+        description: decode_enc_string(&asset_fields["extendedDescEnc"]),
+        keywords: decode_keywords_plist(&asset_fields["keywordsEnc"]),
+        burst_id: decode_plain_string(&asset_fields["burstId"]),
+        media_subtype: decode_plain_i32(&asset_fields["assetSubtype"]).map(|v| v.to_string()),
+        deleted_at: decode_plain_i64(&asset_fields["dateExpunged"]),
+        // Fields not yet populated from iCloud
+        rating: None,
+        width: None,
+        height: None,
+        modified_at: None,
+        provider_data: None,
+        metadata_hash: None,
+    };
+
+    meta.metadata_hash = Some(meta.compute_hash());
+    meta
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- decode_enc_string ----
+
+    #[test]
+    fn string_type_returns_value() {
+        let field = json!({"value": "Hello World", "type": "STRING"});
+        assert_eq!(decode_enc_string(&field), Some("Hello World".to_string()));
+    }
+
+    #[test]
+    fn encrypted_bytes_base64_utf8() {
+        // "Hello" in base64 = "SGVsbG8="
+        let field = json!({"value": "SGVsbG8=", "type": "ENCRYPTED_BYTES"});
+        assert_eq!(decode_enc_string(&field), Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn encrypted_bytes_empty_returns_none() {
+        let field = json!({"value": "", "type": "ENCRYPTED_BYTES"});
+        assert_eq!(decode_enc_string(&field), None);
+    }
+
+    #[test]
+    fn null_field_returns_none() {
+        assert_eq!(decode_enc_string(&Value::Null), None);
+    }
+
+    #[test]
+    fn missing_value_returns_none() {
+        let field = json!({"type": "STRING"});
+        assert_eq!(decode_enc_string(&field), None);
+    }
+
+    #[test]
+    fn invalid_base64_returns_none() {
+        let field = json!({"value": "not-valid-base64!!!", "type": "ENCRYPTED_BYTES"});
+        assert_eq!(decode_enc_string(&field), None);
+    }
+
+    #[test]
+    fn invalid_utf8_returns_none() {
+        // \xFF\xFE is not valid UTF-8. Base64 of [0xFF, 0xFE] = "//4="
+        let field = json!({"value": "//4=", "type": "ENCRYPTED_BYTES"});
+        assert_eq!(decode_enc_string(&field), None);
+    }
+
+    #[test]
+    fn default_type_is_string() {
+        let field = json!({"value": "test caption"});
+        assert_eq!(decode_enc_string(&field), Some("test caption".to_string()));
+    }
+
+    // ---- decode_keywords_plist ----
+
+    #[test]
+    fn keywords_plist_decodes_string_array() {
+        let keywords = vec!["sunset", "beach", "vacation"];
+        let plist_bytes = plist_to_bytes(&keywords);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&plist_bytes);
+
+        let field = json!({"value": b64, "type": "ENCRYPTED_BYTES"});
+        let result = decode_keywords_plist(&field);
+        assert_eq!(result, vec!["sunset", "beach", "vacation"]);
+    }
+
+    #[test]
+    fn keywords_plist_empty_array() {
+        let keywords: Vec<&str> = vec![];
+        let plist_bytes = plist_to_bytes(&keywords);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&plist_bytes);
+
+        let field = json!({"value": b64, "type": "ENCRYPTED_BYTES"});
+        assert!(decode_keywords_plist(&field).is_empty());
+    }
+
+    #[test]
+    fn keywords_null_returns_empty() {
+        assert!(decode_keywords_plist(&Value::Null).is_empty());
+    }
+
+    #[test]
+    fn keywords_invalid_plist_returns_empty() {
+        let b64 = base64::engine::general_purpose::STANDARD.encode(b"not a plist");
+        let field = json!({"value": b64, "type": "ENCRYPTED_BYTES"});
+        assert!(decode_keywords_plist(&field).is_empty());
+    }
+
+    // ---- decode_location ----
+
+    #[test]
+    fn location_from_plist() {
+        let mut dict = plist::Dictionary::new();
+        dict.insert("lat".to_string(), plist::Value::Real(37.7749));
+        dict.insert("lng".to_string(), plist::Value::Real(-122.4194));
+        dict.insert("alt".to_string(), plist::Value::Real(10.5));
+
+        let plist_bytes = plist_dict_to_bytes(&dict);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&plist_bytes);
+
+        let asset_fields = json!({"locationEnc": {"value": b64, "type": "ENCRYPTED_BYTES"}});
+        let master_fields = json!({});
+
+        let (lat, lon, alt) = decode_location(&master_fields, &asset_fields);
+        assert!((lat.unwrap() - 37.7749).abs() < 1e-10);
+        assert!((lon.unwrap() - (-122.4194)).abs() < 1e-10);
+        assert!((alt.unwrap() - 10.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn location_falls_back_to_plain_fields() {
+        let asset_fields = json!({});
+        let master_fields = json!({
+            "locationLatitude": {"value": 40.7128},
+            "locationLongitude": {"value": -74.0060}
+        });
+
+        let (lat, lon, alt) = decode_location(&master_fields, &asset_fields);
+        assert!((lat.unwrap() - 40.7128).abs() < 1e-10);
+        assert!((lon.unwrap() - (-74.0060)).abs() < 1e-10);
+        assert!(alt.is_none());
+    }
+
+    #[test]
+    fn location_all_missing_returns_none() {
+        let (lat, lon, alt) = decode_location(&json!({}), &json!({}));
+        assert!(lat.is_none());
+        assert!(lon.is_none());
+        assert!(alt.is_none());
+    }
+
+    #[test]
+    fn location_plist_without_altitude() {
+        let mut dict = plist::Dictionary::new();
+        dict.insert("lat".to_string(), plist::Value::Real(51.5074));
+        dict.insert("lng".to_string(), plist::Value::Real(-0.1278));
+
+        let plist_bytes = plist_dict_to_bytes(&dict);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&plist_bytes);
+
+        let asset_fields = json!({"locationEnc": {"value": b64, "type": "ENCRYPTED_BYTES"}});
+        let (lat, lon, alt) = decode_location(&json!({}), &asset_fields);
+        assert!(lat.is_some());
+        assert!(lon.is_some());
+        assert!(alt.is_none());
+    }
+
+    // ---- plain field helpers ----
+
+    #[test]
+    fn plain_i32_valid() {
+        assert_eq!(decode_plain_i32(&json!({"value": 6})), Some(6));
+    }
+
+    #[test]
+    fn plain_i32_null() {
+        assert_eq!(decode_plain_i32(&Value::Null), None);
+    }
+
+    #[test]
+    fn plain_i64_valid() {
+        assert_eq!(
+            decode_plain_i64(&json!({"value": 1618000000})),
+            Some(1618000000)
+        );
+    }
+
+    #[test]
+    fn plain_string_valid() {
+        assert_eq!(
+            decode_plain_string(&json!({"value": "abc"})),
+            Some("abc".to_string())
+        );
+    }
+
+    #[test]
+    fn plain_string_null() {
+        assert_eq!(decode_plain_string(&Value::Null), None);
+    }
+
+    #[test]
+    fn plain_bool_true() {
+        assert!(decode_plain_bool(&json!({"value": 1})));
+    }
+
+    #[test]
+    fn plain_bool_false_on_zero() {
+        assert!(!decode_plain_bool(&json!({"value": 0})));
+    }
+
+    #[test]
+    fn plain_bool_false_on_null() {
+        assert!(!decode_plain_bool(&Value::Null));
+    }
+
+    // ---- test helpers ----
+
+    fn plist_to_bytes<T: serde::Serialize>(value: &T) -> Vec<u8> {
+        let mut buf = Vec::new();
+        plist::to_writer_binary(&mut buf, value).unwrap();
+        buf
+    }
+
+    fn plist_dict_to_bytes(dict: &plist::Dictionary) -> Vec<u8> {
+        let mut buf = Vec::new();
+        plist::to_writer_binary(&mut buf, dict).unwrap();
+        buf
+    }
+}

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -4,6 +4,7 @@
 mod album;
 pub(crate) mod asset;
 pub mod cloudkit;
+pub(crate) mod decode;
 pub mod error;
 mod library;
 pub mod queries;

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -326,7 +326,7 @@ impl StateDb for SqliteStateDb {
         let meta = record.metadata.as_deref();
 
         // Precompute metadata fields (default to None/false when metadata absent)
-        let source = meta.map_or("icloud", |m| m.source.as_str());
+        let source = meta.map_or(super::types::SOURCE_ICLOUD, |m| m.source.as_str());
         let is_favorite = meta.is_some_and(|m| m.is_favorite);
         let is_hidden = meta.is_some_and(|m| m.is_hidden);
         let is_archived = meta.is_some_and(|m| m.is_archived);
@@ -832,26 +832,36 @@ impl StateDb for SqliteStateDb {
     ) -> Result<(), StateError> {
         let conn = self.acquire_lock("upsert_asset_albums")?;
 
-        conn.execute(
-            "DELETE FROM asset_albums WHERE asset_id = ?1",
-            rusqlite::params![asset_id],
-        )
-        .map_err(|e| StateError::query(&e))?;
+        // Atomic DELETE+INSERT to avoid data loss on crash between statements
+        conn.execute_batch("SAVEPOINT album_upsert")
+            .map_err(|e| StateError::query(&e))?;
 
-        if !albums.is_empty() {
-            let mut stmt = conn
-                .prepare_cached(
+        let result = (|| {
+            conn.execute(
+                "DELETE FROM asset_albums WHERE asset_id = ?1",
+                rusqlite::params![asset_id],
+            )?;
+
+            if !albums.is_empty() {
+                let mut stmt = conn.prepare_cached(
                     "INSERT INTO asset_albums (asset_id, album_name, source) VALUES (?1, ?2, ?3)",
-                )
-                .map_err(|e| StateError::query(&e))?;
+                )?;
+                for (album_name, source) in albums {
+                    stmt.execute(rusqlite::params![asset_id, album_name, source])?;
+                }
+            }
+            Ok::<(), rusqlite::Error>(())
+        })();
 
-            for (album_name, source) in albums {
-                stmt.execute(rusqlite::params![asset_id, album_name, source])
-                    .map_err(|e| StateError::query(&e))?;
+        match result {
+            Ok(()) => conn
+                .execute_batch("RELEASE album_upsert")
+                .map_err(|e| StateError::query(&e)),
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK TO album_upsert");
+                Err(StateError::query(&e))
             }
         }
-
-        Ok(())
     }
 
     async fn upsert_asset_people(
@@ -861,24 +871,35 @@ impl StateDb for SqliteStateDb {
     ) -> Result<(), StateError> {
         let conn = self.acquire_lock("upsert_asset_people")?;
 
-        conn.execute(
-            "DELETE FROM asset_people WHERE asset_id = ?1",
-            rusqlite::params![asset_id],
-        )
-        .map_err(|e| StateError::query(&e))?;
+        conn.execute_batch("SAVEPOINT people_upsert")
+            .map_err(|e| StateError::query(&e))?;
 
-        if !people.is_empty() {
-            let mut stmt = conn
-                .prepare_cached("INSERT INTO asset_people (asset_id, person_name) VALUES (?1, ?2)")
-                .map_err(|e| StateError::query(&e))?;
+        let result = (|| {
+            conn.execute(
+                "DELETE FROM asset_people WHERE asset_id = ?1",
+                rusqlite::params![asset_id],
+            )?;
 
-            for name in people {
-                stmt.execute(rusqlite::params![asset_id, name])
-                    .map_err(|e| StateError::query(&e))?;
+            if !people.is_empty() {
+                let mut stmt = conn.prepare_cached(
+                    "INSERT INTO asset_people (asset_id, person_name) VALUES (?1, ?2)",
+                )?;
+                for name in people {
+                    stmt.execute(rusqlite::params![asset_id, name])?;
+                }
+            }
+            Ok::<(), rusqlite::Error>(())
+        })();
+
+        match result {
+            Ok(()) => conn
+                .execute_batch("RELEASE people_upsert")
+                .map_err(|e| StateError::query(&e)),
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK TO people_upsert");
+                Err(StateError::query(&e))
             }
         }
-
-        Ok(())
     }
 
     async fn get_asset_albums(&self, asset_id: &str) -> Result<Vec<String>, StateError> {

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -142,6 +142,7 @@ pub trait StateDb: Send + Sync {
     ) -> Result<(), StateError>;
 
     /// Replace people tags for an asset (DELETE + INSERT).
+    #[cfg(test)]
     async fn upsert_asset_people(
         &self,
         asset_id: &str,
@@ -149,9 +150,11 @@ pub trait StateDb: Send + Sync {
     ) -> Result<(), StateError>;
 
     /// Get album names for an asset.
+    #[cfg(test)]
     async fn get_asset_albums(&self, asset_id: &str) -> Result<Vec<String>, StateError>;
 
     /// Get people tagged in an asset.
+    #[cfg(test)]
     async fn get_asset_people(&self, asset_id: &str) -> Result<Vec<String>, StateError>;
 
     /// Mark all versions of an asset as deleted.
@@ -864,6 +867,7 @@ impl StateDb for SqliteStateDb {
         }
     }
 
+    #[cfg(test)]
     async fn upsert_asset_people(
         &self,
         asset_id: &str,
@@ -902,6 +906,7 @@ impl StateDb for SqliteStateDb {
         }
     }
 
+    #[cfg(test)]
     async fn get_asset_albums(&self, asset_id: &str) -> Result<Vec<String>, StateError> {
         let conn = self.acquire_lock("get_asset_albums")?;
 
@@ -920,6 +925,7 @@ impl StateDb for SqliteStateDb {
         Ok(albums)
     }
 
+    #[cfg(test)]
     async fn get_asset_people(&self, asset_id: &str) -> Result<Vec<String>, StateError> {
         let conn = self.acquire_lock("get_asset_people")?;
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -11,7 +11,7 @@ use rusqlite::{Connection, OptionalExtension};
 use super::error::StateError;
 use super::schema;
 use super::types::{
-    AssetRecord, AssetStatus, MediaType, SyncRunStats, SyncSummary, VersionSizeKey,
+    AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, SyncSummary, VersionSizeKey,
 };
 
 /// Trait for state database operations.
@@ -133,6 +133,36 @@ pub trait StateDb: Send + Sync {
     /// Sample up to `limit` local paths of downloaded assets.
     /// Used to spot-check that "downloaded" files still exist on disk.
     async fn sample_downloaded_paths(&self, limit: usize) -> Result<Vec<PathBuf>, StateError>;
+
+    /// Replace album memberships for an asset (DELETE + INSERT).
+    async fn upsert_asset_albums(
+        &self,
+        asset_id: &str,
+        albums: &[(String, String)],
+    ) -> Result<(), StateError>;
+
+    /// Replace people tags for an asset (DELETE + INSERT).
+    async fn upsert_asset_people(
+        &self,
+        asset_id: &str,
+        people: &[String],
+    ) -> Result<(), StateError>;
+
+    /// Get album names for an asset.
+    async fn get_asset_albums(&self, asset_id: &str) -> Result<Vec<String>, StateError>;
+
+    /// Get people tagged in an asset.
+    async fn get_asset_people(&self, asset_id: &str) -> Result<Vec<String>, StateError>;
+
+    /// Mark all versions of an asset as deleted.
+    async fn mark_asset_deleted(
+        &self,
+        asset_id: &str,
+        deleted_at: Option<i64>,
+    ) -> Result<(), StateError>;
+
+    /// Mark all versions of an asset as hidden.
+    async fn mark_asset_hidden(&self, asset_id: &str) -> Result<(), StateError>;
 }
 
 /// `SQLite` implementation of the state database.
@@ -293,15 +323,64 @@ impl StateDb for SqliteStateDb {
 
     async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError> {
         let last_seen_at = Utc::now().timestamp();
+        let meta = record.metadata.as_deref();
+
+        // Precompute metadata fields (default to None/false when metadata absent)
+        let source = meta.map_or("icloud", |m| m.source.as_str());
+        let is_favorite = meta.is_some_and(|m| m.is_favorite);
+        let is_hidden = meta.is_some_and(|m| m.is_hidden);
+        let is_archived = meta.is_some_and(|m| m.is_archived);
+        let is_deleted = meta.is_some_and(|m| m.is_deleted);
+        let rating = meta.and_then(|m| m.rating);
+        let latitude = meta.and_then(|m| m.latitude);
+        let longitude = meta.and_then(|m| m.longitude);
+        let altitude = meta.and_then(|m| m.altitude);
+        let orientation = meta.and_then(|m| m.orientation);
+        let duration_secs = meta.and_then(|m| m.duration_secs);
+        let timezone_offset = meta.and_then(|m| m.timezone_offset);
+        let width = meta.and_then(|m| m.width);
+        let height = meta.and_then(|m| m.height);
+        let title = meta.and_then(|m| m.title.as_deref());
+        let description = meta.and_then(|m| m.description.as_deref());
+        let burst_id = meta.and_then(|m| m.burst_id.as_deref());
+        let media_subtype = meta.and_then(|m| m.media_subtype.as_deref());
+        let provider_data = meta.and_then(|m| m.provider_data.as_deref());
+        let metadata_hash = meta.and_then(|m| m.metadata_hash.as_deref());
+        let modified_at = meta.and_then(|m| m.modified_at);
+        let deleted_at = meta.and_then(|m| m.deleted_at);
+        let keywords_json = meta
+            .map(|m| {
+                if m.keywords.is_empty() {
+                    None
+                } else {
+                    serde_json::to_string(&m.keywords).ok()
+                }
+            })
+            .unwrap_or(None);
 
         let conn = self.acquire_lock("upsert_seen")?;
 
-        // Use INSERT OR REPLACE to handle both insert and update
-        // But preserve existing status, downloaded_at, local_path, download_attempts, last_error
+        // Preserve existing status, downloaded_at, local_path, download_attempts, last_error
         conn.execute(
             r"
-            INSERT INTO assets (id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, last_seen_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9)
+            INSERT INTO assets (
+                id, version_size, checksum, filename, created_at, added_at,
+                size_bytes, media_type, status, last_seen_at,
+                source, is_favorite, is_hidden, is_archived, is_deleted,
+                rating, latitude, longitude, altitude, orientation,
+                duration_secs, timezone_offset, width, height,
+                title, description, keywords, burst_id, media_subtype,
+                provider_data, metadata_hash, modified_at, deleted_at
+            )
+            VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6,
+                ?7, ?8, 'pending', ?9,
+                ?10, ?11, ?12, ?13, ?14,
+                ?15, ?16, ?17, ?18, ?19,
+                ?20, ?21, ?22, ?23,
+                ?24, ?25, ?26, ?27, ?28,
+                ?29, ?30, ?31, ?32
+            )
             ON CONFLICT(id, version_size) DO UPDATE SET
                 checksum = excluded.checksum,
                 filename = excluded.filename,
@@ -309,7 +388,30 @@ impl StateDb for SqliteStateDb {
                 added_at = excluded.added_at,
                 size_bytes = excluded.size_bytes,
                 media_type = excluded.media_type,
-                last_seen_at = excluded.last_seen_at
+                last_seen_at = excluded.last_seen_at,
+                source = excluded.source,
+                is_favorite = excluded.is_favorite,
+                is_hidden = excluded.is_hidden,
+                is_archived = excluded.is_archived,
+                is_deleted = excluded.is_deleted,
+                rating = excluded.rating,
+                latitude = excluded.latitude,
+                longitude = excluded.longitude,
+                altitude = excluded.altitude,
+                orientation = excluded.orientation,
+                duration_secs = excluded.duration_secs,
+                timezone_offset = excluded.timezone_offset,
+                width = excluded.width,
+                height = excluded.height,
+                title = excluded.title,
+                description = excluded.description,
+                keywords = excluded.keywords,
+                burst_id = excluded.burst_id,
+                media_subtype = excluded.media_subtype,
+                provider_data = excluded.provider_data,
+                metadata_hash = excluded.metadata_hash,
+                modified_at = excluded.modified_at,
+                deleted_at = excluded.deleted_at
             ",
             rusqlite::params![
                 &record.id,
@@ -321,6 +423,29 @@ impl StateDb for SqliteStateDb {
                 i64::try_from(record.size_bytes).unwrap_or(i64::MAX),
                 record.media_type.as_str(),
                 last_seen_at,
+                source,
+                is_favorite,
+                is_hidden,
+                is_archived,
+                is_deleted,
+                rating,
+                latitude,
+                longitude,
+                altitude,
+                orientation,
+                duration_secs,
+                timezone_offset,
+                width,
+                height,
+                title,
+                description,
+                keywords_json,
+                burst_id,
+                media_subtype,
+                provider_data,
+                metadata_hash,
+                modified_at,
+                deleted_at,
             ],
         )
         .map_err(|e| StateError::query(&e))?;
@@ -379,9 +504,9 @@ impl StateDb for SqliteStateDb {
         let conn = self.acquire_lock("get_failed")?;
 
         let mut stmt = conn
-            .prepare(
-                "SELECT id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, downloaded_at, local_path, last_seen_at, download_attempts, last_error, local_checksum FROM assets WHERE status = 'failed'",
-            )
+            .prepare(&format!(
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed'"
+            ))
             .map_err(|e| StateError::query(&e))?;
 
         let records = stmt
@@ -459,9 +584,9 @@ impl StateDb for SqliteStateDb {
         let conn = self.acquire_lock("get_downloaded_page")?;
 
         let mut stmt = conn
-            .prepare(
-                "SELECT id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, downloaded_at, local_path, last_seen_at, download_attempts, last_error, local_checksum FROM assets WHERE status = 'downloaded' ORDER BY rowid LIMIT ?1 OFFSET ?2",
-            )
+            .prepare(&format!(
+                "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'downloaded' ORDER BY rowid LIMIT ?1 OFFSET ?2"
+            ))
             .map_err(|e| StateError::query(&e))?;
 
         let records = stmt
@@ -699,13 +824,150 @@ impl StateDb for SqliteStateDb {
 
         Ok(paths)
     }
+
+    async fn upsert_asset_albums(
+        &self,
+        asset_id: &str,
+        albums: &[(String, String)],
+    ) -> Result<(), StateError> {
+        let conn = self.acquire_lock("upsert_asset_albums")?;
+
+        conn.execute(
+            "DELETE FROM asset_albums WHERE asset_id = ?1",
+            rusqlite::params![asset_id],
+        )
+        .map_err(|e| StateError::query(&e))?;
+
+        if !albums.is_empty() {
+            let mut stmt = conn
+                .prepare_cached(
+                    "INSERT INTO asset_albums (asset_id, album_name, source) VALUES (?1, ?2, ?3)",
+                )
+                .map_err(|e| StateError::query(&e))?;
+
+            for (album_name, source) in albums {
+                stmt.execute(rusqlite::params![asset_id, album_name, source])
+                    .map_err(|e| StateError::query(&e))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn upsert_asset_people(
+        &self,
+        asset_id: &str,
+        people: &[String],
+    ) -> Result<(), StateError> {
+        let conn = self.acquire_lock("upsert_asset_people")?;
+
+        conn.execute(
+            "DELETE FROM asset_people WHERE asset_id = ?1",
+            rusqlite::params![asset_id],
+        )
+        .map_err(|e| StateError::query(&e))?;
+
+        if !people.is_empty() {
+            let mut stmt = conn
+                .prepare_cached("INSERT INTO asset_people (asset_id, person_name) VALUES (?1, ?2)")
+                .map_err(|e| StateError::query(&e))?;
+
+            for name in people {
+                stmt.execute(rusqlite::params![asset_id, name])
+                    .map_err(|e| StateError::query(&e))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_asset_albums(&self, asset_id: &str) -> Result<Vec<String>, StateError> {
+        let conn = self.acquire_lock("get_asset_albums")?;
+
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT album_name FROM asset_albums WHERE asset_id = ?1 ORDER BY album_name",
+            )
+            .map_err(|e| StateError::query(&e))?;
+
+        let albums = stmt
+            .query_map(rusqlite::params![asset_id], |row| row.get(0))
+            .map_err(|e| StateError::query(&e))?
+            .collect::<Result<Vec<String>, _>>()
+            .map_err(|e| StateError::query(&e))?;
+
+        Ok(albums)
+    }
+
+    async fn get_asset_people(&self, asset_id: &str) -> Result<Vec<String>, StateError> {
+        let conn = self.acquire_lock("get_asset_people")?;
+
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT person_name FROM asset_people WHERE asset_id = ?1 ORDER BY person_name",
+            )
+            .map_err(|e| StateError::query(&e))?;
+
+        let people = stmt
+            .query_map(rusqlite::params![asset_id], |row| row.get(0))
+            .map_err(|e| StateError::query(&e))?
+            .collect::<Result<Vec<String>, _>>()
+            .map_err(|e| StateError::query(&e))?;
+
+        Ok(people)
+    }
+
+    async fn mark_asset_deleted(
+        &self,
+        asset_id: &str,
+        deleted_at: Option<i64>,
+    ) -> Result<(), StateError> {
+        let conn = self.acquire_lock("mark_asset_deleted")?;
+
+        conn.execute(
+            "UPDATE assets SET is_deleted = 1, deleted_at = ?1 WHERE id = ?2",
+            rusqlite::params![deleted_at, asset_id],
+        )
+        .map_err(|e| StateError::query(&e))?;
+
+        Ok(())
+    }
+
+    async fn mark_asset_hidden(&self, asset_id: &str) -> Result<(), StateError> {
+        let conn = self.acquire_lock("mark_asset_hidden")?;
+
+        conn.execute(
+            "UPDATE assets SET is_hidden = 1 WHERE id = ?1",
+            rusqlite::params![asset_id],
+        )
+        .map_err(|e| StateError::query(&e))?;
+
+        Ok(())
+    }
 }
+
+/// Full column list for SELECT queries that use `row_to_asset_record()`.
+///
+/// Column indices 0-14 are the original v1-v4 columns.
+/// Indices 15-37 are the v5 metadata columns.
+/// This constant keeps `get_failed()` and `get_downloaded_page()` in sync.
+const ASSET_COLUMNS: &str = "\
+    id, version_size, checksum, filename, created_at, added_at, \
+    size_bytes, media_type, status, downloaded_at, local_path, \
+    last_seen_at, download_attempts, last_error, local_checksum, \
+    source, is_favorite, rating, latitude, longitude, altitude, \
+    orientation, duration_secs, timezone_offset, width, height, \
+    title, keywords, description, media_subtype, burst_id, \
+    is_hidden, is_archived, modified_at, is_deleted, deleted_at, \
+    provider_data, metadata_hash";
 
 /// Convert a database row to an `AssetRecord`.
 ///
 /// Returns `rusqlite::Error` on column extraction failures instead of silently
 /// falling back to defaults, so schema mismatches or corruption are surfaced.
+/// Column order must match [`ASSET_COLUMNS`].
 fn row_to_asset_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRecord> {
+    // v1-v4 columns (indices 0-14)
     let id: String = row.get(0)?;
     let version_size_str: String = row.get(1)?;
     let checksum: String = row.get(2)?;
@@ -722,6 +984,62 @@ fn row_to_asset_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRecord>
     let last_error: Option<String> = row.get(13)?;
     let local_checksum: Option<String> = row.get(14)?;
 
+    // v5 metadata columns (indices 15-37)
+    let source: String = row.get(15)?;
+    let is_favorite: bool = row.get(16)?;
+    let rating: Option<i32> = row.get(17)?;
+    let latitude: Option<f64> = row.get(18)?;
+    let longitude: Option<f64> = row.get(19)?;
+    let altitude: Option<f64> = row.get(20)?;
+    let orientation: Option<i32> = row.get(21)?;
+    let duration_secs: Option<f64> = row.get(22)?;
+    let timezone_offset: Option<i32> = row.get(23)?;
+    let width: Option<i32> = row.get(24)?;
+    let height: Option<i32> = row.get(25)?;
+    let title: Option<String> = row.get(26)?;
+    let keywords_json: Option<String> = row.get(27)?;
+    let description: Option<String> = row.get(28)?;
+    let media_subtype: Option<String> = row.get(29)?;
+    let burst_id: Option<String> = row.get(30)?;
+    let is_hidden: bool = row.get(31)?;
+    let is_archived: bool = row.get(32)?;
+    let modified_at: Option<i64> = row.get(33)?;
+    let is_deleted: bool = row.get(34)?;
+    let deleted_at: Option<i64> = row.get(35)?;
+    let provider_data: Option<String> = row.get(36)?;
+    let metadata_hash: Option<String> = row.get(37)?;
+
+    let keywords: Vec<String> = keywords_json
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    let metadata = Box::new(AssetMetadata {
+        source,
+        title,
+        description,
+        keywords,
+        burst_id,
+        media_subtype,
+        provider_data,
+        metadata_hash,
+        latitude,
+        longitude,
+        altitude,
+        duration_secs,
+        orientation,
+        timezone_offset,
+        width,
+        height,
+        rating,
+        modified_at,
+        deleted_at,
+        is_favorite,
+        is_hidden,
+        is_archived,
+        is_deleted,
+    });
+
     Ok(AssetRecord {
         id,
         checksum,
@@ -729,6 +1047,7 @@ fn row_to_asset_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<AssetRecord>
         local_path: local_path_str.map(PathBuf::from),
         last_error,
         local_checksum,
+        metadata: Some(metadata),
         size_bytes: u64::try_from(size_bytes).unwrap_or(0),
         created_at: Utc
             .timestamp_opt(created_at_ts, 0)
@@ -1812,5 +2131,199 @@ mod tests {
         let db = SqliteStateDb::open_in_memory().unwrap();
         let counts = db.get_attempt_counts().await.unwrap();
         assert!(counts.is_empty());
+    }
+
+    // ── v5 metadata tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_upsert_seen_with_metadata_round_trip() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let meta = AssetMetadata {
+            source: "icloud".to_string(),
+            is_favorite: true,
+            latitude: Some(37.7749),
+            longitude: Some(-122.4194),
+            altitude: Some(10.5),
+            title: Some("Sunset".to_string()),
+            keywords: vec!["beach".to_string(), "vacation".to_string()],
+            orientation: Some(6),
+            duration_secs: Some(3.5),
+            timezone_offset: Some(-28800),
+            media_subtype: Some("panorama".to_string()),
+            metadata_hash: Some("abc123def456".to_string()),
+            ..AssetMetadata::default()
+        };
+        let mut record = TestAssetRecord::new("META_1").build();
+        record.metadata = Some(Box::new(meta));
+
+        db.upsert_seen(&record).await.unwrap();
+
+        let failed = db.get_failed().await.unwrap();
+        assert!(failed.is_empty());
+
+        // Read back via get_downloaded_page (need to mark downloaded first)
+        db.mark_downloaded(
+            "META_1",
+            "original",
+            Path::new("/tmp/photo.jpg"),
+            "lc",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let page = db.get_downloaded_page(0, 10).await.unwrap();
+        assert_eq!(page.len(), 1);
+
+        let read_meta = page[0]
+            .metadata
+            .as_ref()
+            .expect("metadata should be present");
+        assert!(read_meta.is_favorite);
+        assert!((read_meta.latitude.unwrap() - 37.7749).abs() < 1e-10);
+        assert!((read_meta.longitude.unwrap() - (-122.4194)).abs() < 1e-10);
+        assert!((read_meta.altitude.unwrap() - 10.5).abs() < 1e-10);
+        assert_eq!(read_meta.title.as_deref(), Some("Sunset"));
+        assert_eq!(read_meta.keywords, vec!["beach", "vacation"]);
+        assert_eq!(read_meta.orientation, Some(6));
+        assert!((read_meta.duration_secs.unwrap() - 3.5).abs() < 1e-10);
+        assert_eq!(read_meta.timezone_offset, Some(-28800));
+        assert_eq!(read_meta.media_subtype.as_deref(), Some("panorama"));
+        assert_eq!(read_meta.metadata_hash.as_deref(), Some("abc123def456"));
+        assert_eq!(read_meta.source, "icloud");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_seen_without_metadata_preserves_defaults() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("NO_META").build();
+
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_downloaded("NO_META", "original", Path::new("/tmp/p.jpg"), "lc", None)
+            .await
+            .unwrap();
+
+        let page = db.get_downloaded_page(0, 10).await.unwrap();
+        let read_meta = page[0].metadata.as_ref().expect("metadata present");
+        assert_eq!(read_meta.source, "icloud");
+        assert!(!read_meta.is_favorite);
+        assert!(!read_meta.is_hidden);
+        assert!(read_meta.title.is_none());
+        assert!(read_meta.keywords.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_upsert_seen_metadata_update_on_conflict() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // First upsert: not favorite
+        let record = TestAssetRecord::new("UPD_1").build();
+        db.upsert_seen(&record).await.unwrap();
+
+        // Second upsert: now favorite with title
+        let meta = AssetMetadata {
+            is_favorite: true,
+            title: Some("New Title".to_string()),
+            ..AssetMetadata::default()
+        };
+        let mut record2 = TestAssetRecord::new("UPD_1").build();
+        record2.metadata = Some(Box::new(meta));
+        db.upsert_seen(&record2).await.unwrap();
+
+        db.mark_downloaded("UPD_1", "original", Path::new("/tmp/p.jpg"), "lc", None)
+            .await
+            .unwrap();
+
+        let page = db.get_downloaded_page(0, 10).await.unwrap();
+        let read_meta = page[0].metadata.as_ref().unwrap();
+        assert!(read_meta.is_favorite);
+        assert_eq!(read_meta.title.as_deref(), Some("New Title"));
+    }
+
+    #[tokio::test]
+    async fn test_album_crud() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        db.upsert_asset_albums(
+            "ASSET_1",
+            &[
+                ("Vacation".to_string(), "icloud".to_string()),
+                ("Family".to_string(), "icloud".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let albums = db.get_asset_albums("ASSET_1").await.unwrap();
+        assert_eq!(albums, vec!["Family", "Vacation"]); // sorted
+
+        // Replace albums
+        db.upsert_asset_albums("ASSET_1", &[("Work".to_string(), "icloud".to_string())])
+            .await
+            .unwrap();
+
+        let albums = db.get_asset_albums("ASSET_1").await.unwrap();
+        assert_eq!(albums, vec!["Work"]);
+
+        // Clear albums
+        db.upsert_asset_albums("ASSET_1", &[]).await.unwrap();
+        let albums = db.get_asset_albums("ASSET_1").await.unwrap();
+        assert!(albums.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_people_crud() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        db.upsert_asset_people("ASSET_1", &["Alice".to_string(), "Bob".to_string()])
+            .await
+            .unwrap();
+
+        let people = db.get_asset_people("ASSET_1").await.unwrap();
+        assert_eq!(people, vec!["Alice", "Bob"]); // sorted
+
+        // Replace
+        db.upsert_asset_people("ASSET_1", &["Charlie".to_string()])
+            .await
+            .unwrap();
+        let people = db.get_asset_people("ASSET_1").await.unwrap();
+        assert_eq!(people, vec!["Charlie"]);
+    }
+
+    #[tokio::test]
+    async fn test_mark_asset_deleted() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("DEL_1").build();
+        db.upsert_seen(&record).await.unwrap();
+
+        db.mark_asset_deleted("DEL_1", Some(1700000000))
+            .await
+            .unwrap();
+
+        db.mark_downloaded("DEL_1", "original", Path::new("/tmp/p.jpg"), "lc", None)
+            .await
+            .unwrap();
+
+        let page = db.get_downloaded_page(0, 10).await.unwrap();
+        let meta = page[0].metadata.as_ref().unwrap();
+        assert!(meta.is_deleted);
+        assert_eq!(meta.deleted_at, Some(1700000000));
+    }
+
+    #[tokio::test]
+    async fn test_mark_asset_hidden() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let record = TestAssetRecord::new("HID_1").build();
+        db.upsert_seen(&record).await.unwrap();
+
+        db.mark_asset_hidden("HID_1").await.unwrap();
+
+        db.mark_downloaded("HID_1", "original", Path::new("/tmp/p.jpg"), "lc", None)
+            .await
+            .unwrap();
+
+        let page = db.get_downloaded_page(0, 10).await.unwrap();
+        let meta = page[0].metadata.as_ref().unwrap();
+        assert!(meta.is_hidden);
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,4 +13,6 @@ pub mod schema;
 pub mod types;
 
 pub use db::{SqliteStateDb, StateDb};
-pub use types::{AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};
+pub use types::{
+    AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey, SOURCE_ICLOUD,
+};

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,4 +13,4 @@ pub mod schema;
 pub mod types;
 
 pub use db::{SqliteStateDb, StateDb};
-pub use types::{AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};
+pub use types::{AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,6 +13,4 @@ pub mod schema;
 pub mod types;
 
 pub use db::{SqliteStateDb, StateDb};
-pub use types::{
-    AssetMetadata, AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey, SOURCE_ICLOUD,
-};
+pub use types::{AssetRecord, AssetStatus, MediaType, SyncRunStats, VersionSizeKey};

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use super::error::StateError;
 
 /// Current schema version. Increment when making schema changes.
-pub(crate) const SCHEMA_VERSION: i32 = 4;
+pub(crate) const SCHEMA_VERSION: i32 = 5;
 
 /// Schema DDL for version 1.
 const SCHEMA_V1: &str = r"
@@ -132,6 +132,7 @@ fn migrate_to_version(conn: &Connection, version: i32) -> Result<(), StateError>
                 conn.execute_batch(SCHEMA_V4)?;
             }
         }
+        5 => migrate_to_v5(conn)?,
         other => {
             return Err(StateError::Query(format!(
                 "No migration defined for version {other}"
@@ -140,6 +141,72 @@ fn migrate_to_version(conn: &Connection, version: i32) -> Result<(), StateError>
     }
     set_schema_version(conn, version)?;
     tracing::info!(version, "Migrated database schema");
+    Ok(())
+}
+
+/// V5 migration: add metadata columns, junction tables, and invalidate sync tokens.
+fn migrate_to_v5(conn: &Connection) -> Result<(), StateError> {
+    // Metadata columns on assets table, each guarded by column_exists()
+    // for crash recovery (column added but version not yet bumped).
+    let columns: &[(&str, &str)] = &[
+        ("source", "TEXT NOT NULL DEFAULT 'icloud'"),
+        ("is_favorite", "INTEGER NOT NULL DEFAULT 0"),
+        ("rating", "INTEGER"),
+        ("latitude", "REAL"),
+        ("longitude", "REAL"),
+        ("altitude", "REAL"),
+        ("orientation", "INTEGER"),
+        ("duration_secs", "REAL"),
+        ("timezone_offset", "INTEGER"),
+        ("width", "INTEGER"),
+        ("height", "INTEGER"),
+        ("title", "TEXT"),
+        ("keywords", "TEXT"),
+        ("description", "TEXT"),
+        ("media_subtype", "TEXT"),
+        ("burst_id", "TEXT"),
+        ("is_hidden", "INTEGER NOT NULL DEFAULT 0"),
+        ("is_archived", "INTEGER NOT NULL DEFAULT 0"),
+        ("modified_at", "INTEGER"),
+        ("is_deleted", "INTEGER NOT NULL DEFAULT 0"),
+        ("deleted_at", "INTEGER"),
+        ("provider_data", "TEXT"),
+        ("metadata_hash", "TEXT"),
+    ];
+
+    for (col, col_type) in columns {
+        if !column_exists(conn, "assets", col)? {
+            conn.execute_batch(&format!("ALTER TABLE assets ADD COLUMN {col} {col_type};"))?;
+        }
+    }
+
+    // Index for metadata change detection queries
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_assets_metadata_hash ON assets(metadata_hash);",
+    )?;
+
+    // Junction tables for album membership and people tags
+    conn.execute_batch(
+        r"
+        CREATE TABLE IF NOT EXISTS asset_albums (
+            asset_id    TEXT NOT NULL,
+            album_name  TEXT NOT NULL,
+            source      TEXT NOT NULL,
+            PRIMARY KEY (asset_id, album_name, source)
+        );
+
+        CREATE TABLE IF NOT EXISTS asset_people (
+            asset_id      TEXT NOT NULL,
+            person_name   TEXT NOT NULL,
+            PRIMARY KEY (asset_id, person_name)
+        );
+        ",
+    )?;
+
+    // Invalidate sync tokens to force full re-enumeration on next run.
+    // This populates metadata for all existing assets (one-time upgrade cost).
+    conn.execute_batch("DELETE FROM metadata WHERE key LIKE 'sync_token:%';")?;
+
     Ok(())
 }
 
@@ -205,7 +272,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(count, 3); // status, local_path, checksum
+        assert_eq!(count, 4); // status, local_path, checksum, metadata_hash
     }
 
     #[test]
@@ -363,5 +430,121 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM assets", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_v4_to_v5_migration() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(SCHEMA_V1).unwrap();
+        conn.execute_batch(SCHEMA_V2).unwrap();
+        conn.execute_batch(SCHEMA_V3).unwrap();
+        conn.execute_batch(SCHEMA_V4).unwrap();
+        set_schema_version(&conn, 4).unwrap();
+
+        // Insert a sync token to verify it gets deleted
+        conn.execute(
+            "INSERT INTO metadata (key, value) VALUES ('sync_token:zone1', 'tok123')",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), 5);
+
+        // Metadata columns should exist
+        assert!(conn
+            .prepare(
+                "SELECT source, is_favorite, latitude, title, metadata_hash FROM assets LIMIT 0"
+            )
+            .is_ok());
+
+        // Junction tables should exist
+        assert!(conn
+            .prepare("SELECT asset_id, album_name, source FROM asset_albums LIMIT 0")
+            .is_ok());
+        assert!(conn
+            .prepare("SELECT asset_id, person_name FROM asset_people LIMIT 0")
+            .is_ok());
+
+        // Sync tokens should be deleted
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM metadata WHERE key LIKE 'sync_token:%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_v5_migration_idempotent_crash_recovery() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(SCHEMA_V1).unwrap();
+        conn.execute_batch(SCHEMA_V2).unwrap();
+        conn.execute_batch(SCHEMA_V3).unwrap();
+        conn.execute_batch(SCHEMA_V4).unwrap();
+        set_schema_version(&conn, 4).unwrap();
+
+        // Simulate crash: add some v5 columns manually without bumping version
+        conn.execute_batch("ALTER TABLE assets ADD COLUMN source TEXT NOT NULL DEFAULT 'icloud'")
+            .unwrap();
+        conn.execute_batch("ALTER TABLE assets ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0")
+            .unwrap();
+        conn.execute_batch("ALTER TABLE assets ADD COLUMN latitude REAL")
+            .unwrap();
+
+        // Migration should succeed despite pre-existing columns
+        migrate(&conn).unwrap();
+        assert_eq!(get_schema_version(&conn).unwrap(), 5);
+
+        // All columns should exist
+        assert!(conn
+            .prepare(
+                "SELECT source, is_favorite, latitude, metadata_hash, is_deleted FROM assets LIMIT 0"
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn test_v5_existing_rows_get_defaults() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(SCHEMA_V1).unwrap();
+        conn.execute_batch(SCHEMA_V2).unwrap();
+        conn.execute_batch(SCHEMA_V3).unwrap();
+        conn.execute_batch(SCHEMA_V4).unwrap();
+        set_schema_version(&conn, 4).unwrap();
+
+        // Insert an asset before migration
+        conn.execute(
+            "INSERT INTO assets (id, version_size, checksum, filename, created_at, size_bytes, media_type, last_seen_at) \
+             VALUES ('old_asset', 'original', 'ck', 'photo.jpg', 0, 100, 'photo', 0)",
+            [],
+        ).unwrap();
+
+        migrate(&conn).unwrap();
+
+        // Existing row should have defaults
+        let (source, is_favorite, is_hidden, is_deleted): (String, i32, i32, i32) = conn
+            .query_row(
+                "SELECT source, is_favorite, is_hidden, is_deleted FROM assets WHERE id = 'old_asset'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(source, "icloud");
+        assert_eq!(is_favorite, 0);
+        assert_eq!(is_hidden, 0);
+        assert_eq!(is_deleted, 0);
+
+        // Nullable columns should be NULL
+        let title: Option<String> = conn
+            .query_row(
+                "SELECT title FROM assets WHERE id = 'old_asset'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(title.is_none());
     }
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -8,6 +8,9 @@ use sha2::{Digest, Sha256};
 
 use crate::types::AssetVersionSize;
 
+/// Provider identifier for iCloud assets.
+pub const SOURCE_ICLOUD: &str = "icloud";
+
 /// Version size key for state tracking.
 ///
 /// This is a 1-byte enum representing the version size, saving ~23 bytes
@@ -145,11 +148,7 @@ impl MediaType {
 /// Boxed inside `AssetRecord` (`Option<Box<AssetMetadata>>`) to avoid
 /// inflating the base record on code paths that don't use metadata.
 ///
-/// Fields are ordered for optimal memory layout:
-/// - Heap types first (String, `Vec`, `Option<String>`)
-/// - f64 fields
-/// - i32/i64 fields
-/// - bool fields last
+/// Fields are grouped by type for readability (heap types, f64, integers, bools).
 #[derive(Debug, Clone, PartialEq)]
 pub struct AssetMetadata {
     // Heap types
@@ -242,10 +241,10 @@ impl AssetMetadata {
         hash_opt_str(&mut hasher, self.burst_id.as_deref());
         hash_opt_str(&mut hasher, self.media_subtype.as_deref());
 
-        // Keywords: sorted for determinism
-        let mut sorted_kw = self.keywords.clone();
+        // Keywords: sort refs to avoid cloning the Vec
+        let mut sorted_kw: Vec<&str> = self.keywords.iter().map(String::as_str).collect();
         sorted_kw.sort_unstable();
-        for kw in &sorted_kw {
+        for kw in sorted_kw {
             hasher.update(kw.as_bytes());
             hasher.update(b"\0");
         }
@@ -263,7 +262,7 @@ impl AssetMetadata {
 impl Default for AssetMetadata {
     fn default() -> Self {
         Self {
-            source: "icloud".to_string(),
+            source: SOURCE_ICLOUD.to_string(),
             title: None,
             description: None,
             keywords: Vec::new(),

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -1,8 +1,10 @@
 //! Types for the state tracking module.
 
+use std::fmt::Write;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
 
 use crate::types::AssetVersionSize;
 
@@ -138,6 +140,187 @@ impl MediaType {
     }
 }
 
+/// Provider-agnostic metadata for an asset.
+///
+/// Boxed inside `AssetRecord` (`Option<Box<AssetMetadata>>`) to avoid
+/// inflating the base record on code paths that don't use metadata.
+///
+/// Fields are ordered for optimal memory layout:
+/// - Heap types first (String, `Vec`, `Option<String>`)
+/// - f64 fields
+/// - i32/i64 fields
+/// - bool fields last
+#[derive(Debug, Clone, PartialEq)]
+pub struct AssetMetadata {
+    // Heap types
+    /// Provider that created this record ("icloud", "takeout", etc.).
+    pub source: String,
+    /// Short title / caption (iCloud: `captionEnc`).
+    pub title: Option<String>,
+    /// Longer description / notes (iCloud: `extendedDescEnc`).
+    pub description: Option<String>,
+    /// Keyword tags (stored as JSON array in DB).
+    pub keywords: Vec<String>,
+    /// Groups burst shots.
+    pub burst_id: Option<String>,
+    /// Asset subtype: "screenshot", "panorama", "hdr", "burst", etc.
+    pub media_subtype: Option<String>,
+    /// Opaque JSON blob for provider-specific fields.
+    pub provider_data: Option<String>,
+    /// SHA-256 hash of metadata fields for change detection.
+    pub metadata_hash: Option<String>,
+
+    // f64 fields
+    /// Decimal degrees, WGS84.
+    pub latitude: Option<f64>,
+    /// Decimal degrees, WGS84.
+    pub longitude: Option<f64>,
+    /// Meters above sea level.
+    pub altitude: Option<f64>,
+    /// Duration in seconds (video, live photo).
+    pub duration_secs: Option<f64>,
+
+    // Integer fields
+    /// EXIF orientation (1-8).
+    pub orientation: Option<i32>,
+    /// Seconds from UTC.
+    pub timezone_offset: Option<i32>,
+    /// Pixel width.
+    pub width: Option<i32>,
+    /// Pixel height.
+    pub height: Option<i32>,
+    /// Star rating (1-5).
+    pub rating: Option<i32>,
+    /// When the photo/metadata was last edited at source (unix timestamp).
+    pub modified_at: Option<i64>,
+    /// When asset was deleted/expunged at source (unix timestamp).
+    pub deleted_at: Option<i64>,
+
+    // Booleans
+    /// Provider-native favorite/heart flag.
+    pub is_favorite: bool,
+    /// Hidden from main library view.
+    pub is_hidden: bool,
+    /// Hidden from main timeline but retained.
+    pub is_archived: bool,
+    /// Soft-deleted at source.
+    pub is_deleted: bool,
+}
+
+impl AssetMetadata {
+    /// Compute a deterministic hash of all metadata fields for change detection.
+    ///
+    /// Excludes `source` (immutable) and `metadata_hash` itself. Uses SHA-256
+    /// truncated to 16 hex chars, matching the `hash_download_config()` pattern.
+    pub fn compute_hash(&self) -> String {
+        let mut hasher = Sha256::new();
+
+        // Booleans
+        hasher.update([u8::from(self.is_favorite)]);
+        hasher.update([u8::from(self.is_hidden)]);
+        hasher.update([u8::from(self.is_archived)]);
+        hasher.update([u8::from(self.is_deleted)]);
+
+        // Optional integers
+        hash_opt_i32(&mut hasher, self.orientation);
+        hash_opt_i32(&mut hasher, self.timezone_offset);
+        hash_opt_i32(&mut hasher, self.width);
+        hash_opt_i32(&mut hasher, self.height);
+        hash_opt_i32(&mut hasher, self.rating);
+        hash_opt_i64(&mut hasher, self.modified_at);
+        hash_opt_i64(&mut hasher, self.deleted_at);
+
+        // Optional f64
+        hash_opt_f64(&mut hasher, self.latitude);
+        hash_opt_f64(&mut hasher, self.longitude);
+        hash_opt_f64(&mut hasher, self.altitude);
+        hash_opt_f64(&mut hasher, self.duration_secs);
+
+        // Optional strings
+        hash_opt_str(&mut hasher, self.title.as_deref());
+        hash_opt_str(&mut hasher, self.description.as_deref());
+        hash_opt_str(&mut hasher, self.burst_id.as_deref());
+        hash_opt_str(&mut hasher, self.media_subtype.as_deref());
+
+        // Keywords: sorted for determinism
+        let mut sorted_kw = self.keywords.clone();
+        sorted_kw.sort_unstable();
+        for kw in &sorted_kw {
+            hasher.update(kw.as_bytes());
+            hasher.update(b"\0");
+        }
+        hasher.update(b"\x01"); // separator after keywords list
+
+        let hash = hasher.finalize();
+        let mut hex = String::with_capacity(16);
+        for &b in &hash[..8] {
+            let _ = Write::write_fmt(&mut hex, format_args!("{b:02x}"));
+        }
+        hex
+    }
+}
+
+impl Default for AssetMetadata {
+    fn default() -> Self {
+        Self {
+            source: "icloud".to_string(),
+            title: None,
+            description: None,
+            keywords: Vec::new(),
+            burst_id: None,
+            media_subtype: None,
+            provider_data: None,
+            metadata_hash: None,
+            latitude: None,
+            longitude: None,
+            altitude: None,
+            duration_secs: None,
+            orientation: None,
+            timezone_offset: None,
+            width: None,
+            height: None,
+            rating: None,
+            modified_at: None,
+            deleted_at: None,
+            is_favorite: false,
+            is_hidden: false,
+            is_archived: false,
+            is_deleted: false,
+        }
+    }
+}
+
+fn hash_opt_str(hasher: &mut Sha256, val: Option<&str>) {
+    match val {
+        Some(s) => {
+            hasher.update(s.as_bytes());
+            hasher.update(b"\0");
+        }
+        None => hasher.update(b"\xff"),
+    }
+}
+
+fn hash_opt_i32(hasher: &mut Sha256, val: Option<i32>) {
+    match val {
+        Some(v) => hasher.update(v.to_le_bytes()),
+        None => hasher.update(b"\xff"),
+    }
+}
+
+fn hash_opt_i64(hasher: &mut Sha256, val: Option<i64>) {
+    match val {
+        Some(v) => hasher.update(v.to_le_bytes()),
+        None => hasher.update(b"\xff"),
+    }
+}
+
+fn hash_opt_f64(hasher: &mut Sha256, val: Option<f64>) {
+    match val {
+        Some(v) => hasher.update(v.to_le_bytes()),
+        None => hasher.update(b"\xff"),
+    }
+}
+
 /// A record of an asset's state in the database.
 ///
 /// Fields are ordered for optimal memory layout:
@@ -162,6 +345,9 @@ pub struct AssetRecord {
     /// Locally-computed SHA-256 hash of the downloaded file (hex-encoded).
     /// None for assets downloaded before schema v3.
     pub local_checksum: Option<String>,
+    /// Provider-agnostic metadata. Heap-allocated to keep `AssetRecord` small
+    /// on code paths that don't use metadata (bulk pre-load, skip decisions).
+    pub metadata: Option<Box<AssetMetadata>>,
 
     // 8-byte primitives
     /// File size in bytes.
@@ -209,6 +395,7 @@ impl AssetRecord {
             local_path: None,
             last_error: None,
             local_checksum: None,
+            metadata: None,
             size_bytes,
             created_at,
             added_at,
@@ -435,5 +622,97 @@ mod tests {
         for (avs, expected) in conversions {
             assert_eq!(VersionSizeKey::from(avs), expected, "{:?}", avs);
         }
+    }
+
+    #[test]
+    fn test_asset_metadata_default() {
+        let meta = AssetMetadata::default();
+        assert_eq!(meta.source, "icloud");
+        assert!(!meta.is_favorite);
+        assert!(!meta.is_hidden);
+        assert!(meta.title.is_none());
+        assert!(meta.keywords.is_empty());
+    }
+
+    #[test]
+    fn test_metadata_hash_determinism() {
+        let meta = AssetMetadata {
+            is_favorite: true,
+            latitude: Some(37.7749),
+            longitude: Some(-122.4194),
+            title: Some("Sunset".to_string()),
+            keywords: vec!["beach".to_string(), "sunset".to_string()],
+            ..AssetMetadata::default()
+        };
+        let hash1 = meta.compute_hash();
+        let hash2 = meta.compute_hash();
+        assert_eq!(hash1, hash2);
+        assert_eq!(hash1.len(), 16);
+    }
+
+    #[test]
+    fn test_metadata_hash_sensitivity() {
+        let base = AssetMetadata {
+            is_favorite: true,
+            title: Some("Photo".to_string()),
+            ..AssetMetadata::default()
+        };
+        let changed = AssetMetadata {
+            is_favorite: false,
+            title: Some("Photo".to_string()),
+            ..AssetMetadata::default()
+        };
+        assert_ne!(base.compute_hash(), changed.compute_hash());
+    }
+
+    #[test]
+    fn test_metadata_hash_keyword_order_independent() {
+        let meta1 = AssetMetadata {
+            keywords: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            ..AssetMetadata::default()
+        };
+        let meta2 = AssetMetadata {
+            keywords: vec!["c".to_string(), "a".to_string(), "b".to_string()],
+            ..AssetMetadata::default()
+        };
+        assert_eq!(meta1.compute_hash(), meta2.compute_hash());
+    }
+
+    #[test]
+    fn test_metadata_hash_none_vs_empty_string() {
+        let with_none = AssetMetadata {
+            title: None,
+            ..AssetMetadata::default()
+        };
+        let with_empty = AssetMetadata {
+            title: Some(String::new()),
+            ..AssetMetadata::default()
+        };
+        assert_ne!(with_none.compute_hash(), with_empty.compute_hash());
+    }
+
+    #[test]
+    fn test_asset_record_with_metadata_stays_under_size_limit() {
+        // Box<AssetMetadata> adds only 8 bytes (a pointer)
+        assert!(
+            size_of::<AssetRecord>() <= 288,
+            "AssetRecord size {} exceeds 288 bytes",
+            size_of::<AssetRecord>()
+        );
+    }
+
+    #[test]
+    fn test_new_pending_has_no_metadata() {
+        let record = AssetRecord::new_pending(
+            "test".to_string(),
+            VersionSizeKey::Original,
+            "ck".to_string(),
+            "photo.jpg".to_string(),
+            Utc::now(),
+            None,
+            100,
+            MediaType::Photo,
+        );
+        assert!(record.metadata.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Schema v5 migration: 23 new columns on `assets` (favorites, GPS, orientation, keywords, description, ratings, deleted/hidden state, etc.), plus `asset_albums` and `asset_people` junction tables
- iCloud `*Enc` field decoders for `captionEnc`, `keywordsEnc`, `locationEnc`, `extendedDescEnc` - these are base64-encoded plaintext/plists, not actually encrypted for non-ADP accounts
- Metadata extracted at `PhotoAsset` construction and persisted via `upsert_seen()` on every enumerated asset, including assets that are skipped for download
- Album membership tracked in `asset_albums` table during both full and incremental sync
- Incremental sync now updates `is_deleted`/`deleted_at`/`is_hidden` in the DB for deleted and hidden change events (previously just logged and skipped)
- `AssetMetadata` type with deterministic SHA-256 hash for change detection in later features
- Idempotent migration with `column_exists()` guards matching the v3/v4 crash recovery pattern
- New `plist` crate dependency for binary plist decoding (pure Rust, no system deps)

This is Feature 1 of the metadata plan (`.scratch/metadata-plan.md`). It's the data layer that #84 (EXIF enrichment), #19 (XMP sidecars), #52 (HEIC conversion), and #85 (metadata change detection) all read from.

## Upgrade behavior

The v5 migration invalidates sync tokens, so the first post-upgrade sync does a full enumeration. This populates metadata for all existing assets. No files are re-downloaded - it's API pagination + DB writes only. For large libraries this may take a few minutes instead of the usual few seconds.

## Test plan

- [ ] `cargo test` - 41 new tests (decode, types, schema, DB CRUD), 1351 total passing
- [ ] `cargo clippy` - clean (only expected dead-code warnings for functions not yet called by consumers)
- [ ] Run sync against test account, verify metadata columns populated in SQLite DB
- [ ] Verify `kei status` and `kei verify` still work
- [ ] Confirm first post-upgrade sync logs full enumeration, subsequent syncs resume incremental