### PR TITLE
Fix assets stuck in pending after exceeding retry limit

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2187,7 +2187,7 @@ where
                         producer_pb.inc(1);
                     } else {
                         for task in tasks {
-                            // Skip assets that have exceeded the retry limit.
+                            // Mark assets that have exceeded the retry limit as failed.
                             if let Some(&attempts) =
                                 download_ctx.attempt_counts.get(task.asset_id.as_ref())
                             {
@@ -2198,8 +2198,28 @@ where
                                         asset_id = %task.asset_id,
                                         attempts,
                                         max = config.max_download_attempts,
-                                        "Skipping asset: exceeded max download attempts"
+                                        "Asset exceeded max download attempts, marking as failed"
                                     );
+                                    if let Some(db) = &producer_state_db {
+                                        let error = format!(
+                                            "Exceeded max download attempts ({attempts}/{})",
+                                            config.max_download_attempts
+                                        );
+                                        if let Err(e) = db
+                                            .mark_failed(
+                                                &task.asset_id,
+                                                task.version_size.as_str(),
+                                                &error,
+                                            )
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                asset_id = %task.asset_id,
+                                                error = %e,
+                                                "Failed to mark asset as failed"
+                                            );
+                                        }
+                                    }
                                     continue;
                                 }
                             }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1432,6 +1432,27 @@ pub async fn download_photos_with_sync(
 ) -> Result<SyncResult> {
     cleanup_orphan_part_files(&config).await;
 
+    // Transition any pending assets that already exceeded the retry limit to
+    // failed. This cleans up assets stuck from before the fix that marks them
+    // at skip time.
+    if config.max_download_attempts > 0 {
+        if let Some(db) = &config.state_db {
+            match db.fail_exceeded_pending(config.max_download_attempts).await {
+                Ok(n) if n > 0 => {
+                    tracing::info!(
+                        count = n,
+                        max = config.max_download_attempts,
+                        "Marked stuck pending assets as failed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to clean up stuck pending assets");
+                }
+                _ => {}
+            }
+        }
+    }
+
     match &config.sync_mode {
         SyncMode::Full => {
             download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
@@ -2187,7 +2208,7 @@ where
                         producer_pb.inc(1);
                     } else {
                         for task in tasks {
-                            // Mark assets that have exceeded the retry limit as failed.
+                            // Skip assets that have exceeded the retry limit.
                             if let Some(&attempts) =
                                 download_ctx.attempt_counts.get(task.asset_id.as_ref())
                             {
@@ -2198,28 +2219,8 @@ where
                                         asset_id = %task.asset_id,
                                         attempts,
                                         max = config.max_download_attempts,
-                                        "Asset exceeded max download attempts, marking as failed"
+                                        "Skipping asset: exceeded max download attempts"
                                     );
-                                    if let Some(db) = &producer_state_db {
-                                        let error = format!(
-                                            "Exceeded max download attempts ({attempts}/{})",
-                                            config.max_download_attempts
-                                        );
-                                        if let Err(e) = db
-                                            .mark_failed(
-                                                &task.asset_id,
-                                                task.version_size.as_str(),
-                                                &error,
-                                            )
-                                            .await
-                                        {
-                                            tracing::warn!(
-                                                asset_id = %task.asset_id,
-                                                error = %e,
-                                                "Failed to mark asset as failed"
-                                            );
-                                        }
-                                    }
                                     continue;
                                 }
                             }
@@ -5422,6 +5423,9 @@ mod tests {
         }
         async fn reset_failed(&self) -> Result<u64, StateError> {
             unimplemented!()
+        }
+        async fn fail_exceeded_pending(&self, _: u32) -> Result<u64, StateError> {
+            Ok(0)
         }
         async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
             unimplemented!()

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -2212,7 +2212,7 @@ where
                         producer_pb.inc(1);
                     } else {
                         for task in tasks {
-                            // Skip assets that have exceeded the retry limit.
+                            // Mark assets that have exceeded the retry limit as failed.
                             if let Some(&attempts) =
                                 download_ctx.attempt_counts.get(task.asset_id.as_ref())
                             {
@@ -2223,8 +2223,28 @@ where
                                         asset_id = %task.asset_id,
                                         attempts,
                                         max = config.max_download_attempts,
-                                        "Skipping asset: exceeded max download attempts"
+                                        "Asset exceeded max download attempts, marking as failed"
                                     );
+                                    if let Some(db) = &producer_state_db {
+                                        let error = format!(
+                                            "Exceeded max download attempts ({attempts}/{})",
+                                            config.max_download_attempts
+                                        );
+                                        if let Err(e) = db
+                                            .mark_failed(
+                                                &task.asset_id,
+                                                task.version_size.as_str(),
+                                                &error,
+                                            )
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                asset_id = %task.asset_id,
+                                                error = %e,
+                                                "Failed to mark asset as failed"
+                                            );
+                                        }
+                                    }
                                     continue;
                                 }
                             }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1432,24 +1432,28 @@ pub async fn download_photos_with_sync(
 ) -> Result<SyncResult> {
     cleanup_orphan_part_files(&config).await;
 
-    // Transition any pending assets that already exceeded the retry limit to
-    // failed. This cleans up assets stuck from before the fix that marks them
-    // at skip time.
-    if config.max_download_attempts > 0 {
-        if let Some(db) = &config.state_db {
-            match db.fail_exceeded_pending(config.max_download_attempts).await {
-                Ok(n) if n > 0 => {
-                    tracing::info!(
-                        count = n,
-                        max = config.max_download_attempts,
-                        "Marked stuck pending assets as failed"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to clean up stuck pending assets");
-                }
-                _ => {}
+    // Give every non-downloaded asset a fresh start this sync:
+    // 1. Failed -> pending (with attempts reset) so they re-enter the pipeline.
+    // 2. Pending with stale attempt counts -> attempts cleared, covering legacy
+    //    assets that were silently skipped before this fix.
+    if let Some(db) = &config.state_db {
+        match db.reset_failed().await {
+            Ok(n) if n > 0 => {
+                tracing::info!(count = n, "Reset failed assets for retry");
             }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to reset failed assets");
+            }
+            _ => {}
+        }
+        match db.reset_pending_attempts().await {
+            Ok(n) if n > 0 => {
+                tracing::info!(count = n, "Cleared stale attempt counts on pending assets");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to reset pending attempt counts");
+            }
+            _ => {}
         }
     }
 
@@ -5422,9 +5426,9 @@ mod tests {
             unimplemented!()
         }
         async fn reset_failed(&self) -> Result<u64, StateError> {
-            unimplemented!()
+            Ok(0)
         }
-        async fn fail_exceeded_pending(&self, _: u32) -> Result<u64, StateError> {
+        async fn reset_pending_attempts(&self) -> Result<u64, StateError> {
             Ok(0)
         }
         async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1454,8 +1454,33 @@ pub async fn download_photos_with_sync(
         }
     }
 
+    // Incremental sync only returns new changes — it won't re-enumerate
+    // pending assets from previous syncs. If any exist, fall back to full
+    // so they get retried. Once everything is downloaded, incremental resumes.
+    let force_full = if matches!(&config.sync_mode, SyncMode::Incremental { .. }) {
+        if let Some(db) = &config.state_db {
+            match db.get_summary().await {
+                Ok(summary) if summary.pending > 0 => {
+                    tracing::info!(
+                        pending = summary.pending,
+                        "Pending assets require full enumeration, skipping incremental sync"
+                    );
+                    true
+                }
+                _ => false,
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
     match &config.sync_mode {
         SyncMode::Full => {
+            download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
+        }
+        SyncMode::Incremental { .. } if force_full => {
             download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
         }
         SyncMode::Incremental { zone_sync_token } => {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1435,52 +1435,41 @@ pub async fn download_photos_with_sync(
     // Give every non-downloaded asset a fresh start this sync:
     // failed -> pending (with attempts reset), and stale attempt counts on
     // pending assets cleared so the per-sync cap starts from zero.
-    if let Some(db) = &config.state_db {
+    let total_pending = if let Some(db) = &config.state_db {
         match db.prepare_for_retry().await {
-            Ok((failed, pending)) => {
+            Ok((failed, stale, total_pending)) => {
                 if failed > 0 {
                     tracing::info!(count = failed, "Reset failed assets for retry");
                 }
-                if pending > 0 {
+                if stale > 0 {
                     tracing::info!(
-                        count = pending,
+                        count = stale,
                         "Cleared stale attempt counts on pending assets"
                     );
                 }
+                total_pending
             }
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to reset assets for retry");
+                0
             }
-        }
-    }
-
-    // Incremental sync only returns new changes — it won't re-enumerate
-    // pending assets from previous syncs. If any exist, fall back to full
-    // so they get retried. Once everything is downloaded, incremental resumes.
-    let force_full = if matches!(&config.sync_mode, SyncMode::Incremental { .. }) {
-        if let Some(db) = &config.state_db {
-            match db.get_summary().await {
-                Ok(summary) if summary.pending > 0 => {
-                    tracing::info!(
-                        pending = summary.pending,
-                        "Pending assets require full enumeration, skipping incremental sync"
-                    );
-                    true
-                }
-                _ => false,
-            }
-        } else {
-            false
         }
     } else {
-        false
+        0
     };
 
     match &config.sync_mode {
         SyncMode::Full => {
             download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
         }
-        SyncMode::Incremental { .. } if force_full => {
+        // Incremental sync only returns new changes — it won't re-enumerate
+        // pending assets from previous syncs. Fall back to full so they get
+        // retried. Once everything is downloaded, incremental resumes.
+        SyncMode::Incremental { .. } if total_pending > 0 => {
+            tracing::info!(
+                pending = total_pending,
+                "Pending assets require full enumeration, skipping incremental sync"
+            );
             download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
         }
         SyncMode::Incremental { zone_sync_token } => {
@@ -5470,8 +5459,8 @@ mod tests {
         async fn reset_failed(&self) -> Result<u64, StateError> {
             Ok(0)
         }
-        async fn prepare_for_retry(&self) -> Result<(u64, u64), StateError> {
-            Ok((0, 0))
+        async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
+            Ok((0, 0, 0))
         }
         async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
             unimplemented!()

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1433,27 +1433,24 @@ pub async fn download_photos_with_sync(
     cleanup_orphan_part_files(&config).await;
 
     // Give every non-downloaded asset a fresh start this sync:
-    // 1. Failed -> pending (with attempts reset) so they re-enter the pipeline.
-    // 2. Pending with stale attempt counts -> attempts cleared, covering legacy
-    //    assets that were silently skipped before this fix.
+    // failed -> pending (with attempts reset), and stale attempt counts on
+    // pending assets cleared so the per-sync cap starts from zero.
     if let Some(db) = &config.state_db {
-        match db.reset_failed().await {
-            Ok(n) if n > 0 => {
-                tracing::info!(count = n, "Reset failed assets for retry");
+        match db.prepare_for_retry().await {
+            Ok((failed, pending)) => {
+                if failed > 0 {
+                    tracing::info!(count = failed, "Reset failed assets for retry");
+                }
+                if pending > 0 {
+                    tracing::info!(
+                        count = pending,
+                        "Cleared stale attempt counts on pending assets"
+                    );
+                }
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to reset failed assets");
+                tracing::warn!(error = %e, "Failed to reset assets for retry");
             }
-            _ => {}
-        }
-        match db.reset_pending_attempts().await {
-            Ok(n) if n > 0 => {
-                tracing::info!(count = n, "Cleared stale attempt counts on pending assets");
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to reset pending attempt counts");
-            }
-            _ => {}
         }
     }
 
@@ -5448,8 +5445,8 @@ mod tests {
         async fn reset_failed(&self) -> Result<u64, StateError> {
             Ok(0)
         }
-        async fn reset_pending_attempts(&self) -> Result<u64, StateError> {
-            Ok(0)
+        async fn prepare_for_retry(&self) -> Result<(u64, u64), StateError> {
+            Ok((0, 0))
         }
         async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
             unimplemented!()

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -90,11 +90,11 @@ pub trait StateDb: Send + Sync {
     /// Returns the number of assets reset.
     async fn reset_failed(&self) -> Result<u64, StateError>;
 
-    /// Mark pending assets that have exceeded `max_attempts` as failed.
+    /// Clear download attempt counters on pending assets.
     ///
-    /// Cleans up assets stuck in pending from before this fix existed.
-    /// Returns the number of assets transitioned.
-    async fn fail_exceeded_pending(&self, max_attempts: u32) -> Result<u64, StateError>;
+    /// Fixes legacy stuck pending assets that accumulated attempts but were
+    /// never transitioned to failed.
+    async fn reset_pending_attempts(&self) -> Result<u64, StateError>;
 
     // ── Bulk read operations ──
 
@@ -528,15 +528,14 @@ impl StateDb for SqliteStateDb {
         Ok(rows as u64) // usize -> u64 is lossless on 64-bit
     }
 
-    async fn fail_exceeded_pending(&self, max_attempts: u32) -> Result<u64, StateError> {
-        let conn = self.acquire_lock("fail_exceeded_pending")?;
+    async fn reset_pending_attempts(&self) -> Result<u64, StateError> {
+        let conn = self.acquire_lock("reset_pending_attempts")?;
 
-        let error = format!("Exceeded max download attempts (limit: {max_attempts})");
         let rows = conn
             .execute(
-                "UPDATE assets SET status = 'failed', last_error = ?1 \
-                 WHERE status = 'pending' AND download_attempts >= ?2",
-                rusqlite::params![error, max_attempts],
+                "UPDATE assets SET download_attempts = 0, last_error = NULL \
+                 WHERE status = 'pending' AND download_attempts > 0",
+                [],
             )
             .map_err(|e| StateError::query(&e))?;
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -90,6 +90,12 @@ pub trait StateDb: Send + Sync {
     /// Returns the number of assets reset.
     async fn reset_failed(&self) -> Result<u64, StateError>;
 
+    /// Mark pending assets that have exceeded `max_attempts` as failed.
+    ///
+    /// Cleans up assets stuck in pending from before this fix existed.
+    /// Returns the number of assets transitioned.
+    async fn fail_exceeded_pending(&self, max_attempts: u32) -> Result<u64, StateError>;
+
     // ── Bulk read operations ──
 
     /// Get all downloaded asset IDs as (id, `version_size`) pairs.
@@ -520,6 +526,21 @@ impl StateDb for SqliteStateDb {
             .map_err(|e| StateError::query(&e))?;
 
         Ok(rows as u64) // usize -> u64 is lossless on 64-bit
+    }
+
+    async fn fail_exceeded_pending(&self, max_attempts: u32) -> Result<u64, StateError> {
+        let conn = self.acquire_lock("fail_exceeded_pending")?;
+
+        let error = format!("Exceeded max download attempts (limit: {max_attempts})");
+        let rows = conn
+            .execute(
+                "UPDATE assets SET status = 'failed', last_error = ?1 \
+                 WHERE status = 'pending' AND download_attempts >= ?2",
+                rusqlite::params![error, max_attempts],
+            )
+            .map_err(|e| StateError::query(&e))?;
+
+        Ok(rows as u64)
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -93,8 +93,9 @@ pub trait StateDb: Send + Sync {
     /// Reset all non-downloaded assets for a fresh sync attempt.
     ///
     /// Moves failed -> pending and clears stale attempt counts on pending
-    /// assets, all in one lock acquisition. Returns (failed_reset, pending_reset).
-    async fn prepare_for_retry(&self) -> Result<(u64, u64), StateError>;
+    /// assets, all in one lock acquisition. Returns
+    /// (failed_reset, pending_reset, total_pending).
+    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError>;
 
     // ── Bulk read operations ──
 
@@ -516,19 +517,11 @@ impl StateDb for SqliteStateDb {
     }
 
     async fn reset_failed(&self) -> Result<u64, StateError> {
-        let conn = self.acquire_lock("reset_failed")?;
-
-        let rows = conn
-            .execute(
-                "UPDATE assets SET status = 'pending', download_attempts = 0, last_error = NULL WHERE status = 'failed'",
-                [],
-            )
-            .map_err(|e| StateError::query(&e))?;
-
-        Ok(rows as u64) // usize -> u64 is lossless on 64-bit
+        let (failed, _, _) = self.prepare_for_retry().await?;
+        Ok(failed)
     }
 
-    async fn prepare_for_retry(&self) -> Result<(u64, u64), StateError> {
+    async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
         let conn = self.acquire_lock("prepare_for_retry")?;
 
         let failed = conn
@@ -547,7 +540,16 @@ impl StateDb for SqliteStateDb {
             )
             .map_err(|e| StateError::query(&e))? as u64;
 
-        Ok((failed, pending))
+        let total_pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM assets WHERE status = 'pending'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| StateError::query(&e))?;
+        let total_pending = total_pending as u64;
+
+        Ok((failed, pending, total_pending))
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
@@ -1800,14 +1802,15 @@ mod tests {
         assert_eq!(before.pending, 2); // normal + stuck
         assert_eq!(before.failed, 2);
 
-        let (failed_reset, pending_reset) = db.prepare_for_retry().await.unwrap();
+        let (failed_reset, pending_reset, total_pending) = db.prepare_for_retry().await.unwrap();
 
         assert_eq!(failed_reset, 2);
         assert_eq!(pending_reset, 1); // only the stuck one
+        assert_eq!(total_pending, 4); // 2 original pending + 2 reset from failed
 
         let after = db.get_summary().await.unwrap();
         assert_eq!(after.downloaded, 1);
-        assert_eq!(after.pending, 4); // 2 original pending + 2 reset from failed
+        assert_eq!(after.pending, 4);
         assert_eq!(after.failed, 0);
 
         // Verify attempt counts are all zero now

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -90,11 +90,11 @@ pub trait StateDb: Send + Sync {
     /// Returns the number of assets reset.
     async fn reset_failed(&self) -> Result<u64, StateError>;
 
-    /// Clear download attempt counters on pending assets.
+    /// Reset all non-downloaded assets for a fresh sync attempt.
     ///
-    /// Fixes legacy stuck pending assets that accumulated attempts but were
-    /// never transitioned to failed.
-    async fn reset_pending_attempts(&self) -> Result<u64, StateError>;
+    /// Moves failed -> pending and clears stale attempt counts on pending
+    /// assets, all in one lock acquisition. Returns (failed_reset, pending_reset).
+    async fn prepare_for_retry(&self) -> Result<(u64, u64), StateError>;
 
     // ── Bulk read operations ──
 
@@ -528,18 +528,26 @@ impl StateDb for SqliteStateDb {
         Ok(rows as u64) // usize -> u64 is lossless on 64-bit
     }
 
-    async fn reset_pending_attempts(&self) -> Result<u64, StateError> {
-        let conn = self.acquire_lock("reset_pending_attempts")?;
+    async fn prepare_for_retry(&self) -> Result<(u64, u64), StateError> {
+        let conn = self.acquire_lock("prepare_for_retry")?;
 
-        let rows = conn
+        let failed = conn
+            .execute(
+                "UPDATE assets SET status = 'pending', download_attempts = 0, last_error = NULL \
+                 WHERE status = 'failed'",
+                [],
+            )
+            .map_err(|e| StateError::query(&e))? as u64;
+
+        let pending = conn
             .execute(
                 "UPDATE assets SET download_attempts = 0, last_error = NULL \
                  WHERE status = 'pending' AND download_attempts > 0",
                 [],
             )
-            .map_err(|e| StateError::query(&e))?;
+            .map_err(|e| StateError::query(&e))? as u64;
 
-        Ok(rows as u64)
+        Ok((failed, pending))
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
@@ -1725,6 +1733,86 @@ mod tests {
         // Verify the formerly-failed assets have cleared error and zero attempts
         let failed_after = db.get_failed().await.unwrap();
         assert!(failed_after.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepare_for_retry_resets_failed_and_stuck_pending() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let dir = test_dir();
+
+        // 1 downloaded (should be untouched)
+        let record = TestAssetRecord::new("ADwnloaded1")
+            .checksum("aaaa")
+            .filename("IMG_1000.HEIC")
+            .size(1000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        let path = dir.path().join("IMG_1000.HEIC");
+        fs::write(&path, b"payload").unwrap();
+        db.mark_downloaded("ADwnloaded1", "original", &path, "localhash1", None)
+            .await
+            .unwrap();
+
+        // 1 normal pending (attempts = 0, should be untouched)
+        let record = TestAssetRecord::new("APending1")
+            .checksum("bbbb")
+            .filename("IMG_2000.JPG")
+            .size(2000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+
+        // 1 stuck pending (attempts > 0, should get attempts cleared)
+        let record = TestAssetRecord::new("AStuck1")
+            .checksum("cccc")
+            .filename("IMG_3000.JPG")
+            .size(3000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        // Simulate accumulated attempts by marking failed then resetting status to pending
+        // but keeping attempts high (as the old bug would produce)
+        db.mark_failed("AStuck1", "original", "transient error")
+            .await
+            .unwrap();
+        // Manually set back to pending with attempts preserved (simulating the old bug)
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE assets SET status = 'pending' WHERE id = 'AStuck1'",
+                [],
+            )
+            .unwrap();
+
+        // 2 failed (should transition to pending)
+        for i in 0..2 {
+            let id = format!("AFailed{i}");
+            let record = TestAssetRecord::new(&id)
+                .checksum(&format!("dddd{i}"))
+                .filename(&format!("IMG_400{i}.MOV"))
+                .size(5000)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_failed(&id, "original", "HTTP 500").await.unwrap();
+        }
+
+        let before = db.get_summary().await.unwrap();
+        assert_eq!(before.downloaded, 1);
+        assert_eq!(before.pending, 2); // normal + stuck
+        assert_eq!(before.failed, 2);
+
+        let (failed_reset, pending_reset) = db.prepare_for_retry().await.unwrap();
+
+        assert_eq!(failed_reset, 2);
+        assert_eq!(pending_reset, 1); // only the stuck one
+
+        let after = db.get_summary().await.unwrap();
+        assert_eq!(after.downloaded, 1);
+        assert_eq!(after.pending, 4); // 2 original pending + 2 reset from failed
+        assert_eq!(after.failed, 0);
+
+        // Verify attempt counts are all zero now
+        let attempts = db.get_attempt_counts().await.unwrap();
+        assert!(attempts.is_empty(), "all attempt counts should be zero");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Assets that exceeded `max_download_attempts` were silently skipped in the producer loop, stuck as "pending" forever. They didn't show in `kei status --failed` and `kei reset failed` couldn't touch them.

This PR fixes the immediate bug and closes two related gaps:

- Mark exceeded assets as `failed` with "Exceeded max download attempts (N/M)" so they're visible and recoverable
- Auto-retry all failed assets at sync start via `prepare_for_retry()` - resets failed -> pending and clears stale attempt counts, single lock acquisition
- Fall back from incremental to full sync when pending assets exist, since the changes/zone API only returns new modifications and would never re-enumerate pending assets from previous syncs. Incremental resumes once everything is downloaded.

## Tradeoff

Users with permanently failing assets (e.g. Apple CDN issues for specific files) won't get incremental sync until those assets succeed or are otherwise resolved. This is the correct behavior - incremental sync can't retry what it can't see - but it's worth knowing about.

## Test plan

- [x] All 1121 tests pass (1 new for `prepare_for_retry`)
- [x] Verify `kei status --failed` shows assets that exceeded the retry limit
- [x] Verify next sync automatically retries previously failed assets
- [x] Verify incremental sync falls back to full when pending assets exist
- [x] Verify incremental sync resumes after all assets are downloaded