### PR TITLE
Promote pending assets to failed at end of sync

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1458,10 +1458,15 @@ pub async fn download_photos_with_sync(
         0
     };
 
-    let was_interrupted = shutdown_token.clone();
     let result = match &config.sync_mode {
         SyncMode::Full => {
-            download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
+            download_photos_full_with_token(
+                download_client,
+                albums,
+                &config,
+                shutdown_token.clone(),
+            )
+            .await
         }
         // Incremental sync only returns new changes — it won't re-enumerate
         // pending assets from previous syncs. Fall back to full so they get
@@ -1471,7 +1476,13 @@ pub async fn download_photos_with_sync(
                 pending = total_pending,
                 "Pending assets require full enumeration, skipping incremental sync"
             );
-            download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
+            download_photos_full_with_token(
+                download_client,
+                albums,
+                &config,
+                shutdown_token.clone(),
+            )
+            .await
         }
         SyncMode::Incremental { zone_sync_token } => {
             let token = zone_sync_token.clone();
@@ -1512,7 +1523,7 @@ pub async fn download_photos_with_sync(
                             download_client,
                             albums,
                             &config,
-                            shutdown_token,
+                            shutdown_token.clone(),
                         )
                         .await
                     } else {
@@ -1523,12 +1534,10 @@ pub async fn download_photos_with_sync(
         }
     };
 
-    // Pending is a transient state that should only exist during a sync.
-    // Promote any remaining pending assets to failed so they're visible in
-    // `kei status --failed` and don't block incremental sync on next run.
-    // Skip on interrupted syncs where pending assets are expected.
+    // Pending is transient — anything still pending after a complete sync either
+    // wasn't enumerated or failed silently. Skip on interrupt where pending is expected.
     if let Some(db) = &config.state_db {
-        if !was_interrupted.is_cancelled() {
+        if !shutdown_token.is_cancelled() {
             match db.promote_pending_to_failed().await {
                 Ok(promoted) if promoted > 0 => {
                     tracing::warn!(

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1458,7 +1458,8 @@ pub async fn download_photos_with_sync(
         0
     };
 
-    match &config.sync_mode {
+    let was_interrupted = shutdown_token.clone();
+    let result = match &config.sync_mode {
         SyncMode::Full => {
             download_photos_full_with_token(download_client, albums, &config, shutdown_token).await
         }
@@ -1520,7 +1521,30 @@ pub async fn download_photos_with_sync(
                 }
             }
         }
+    };
+
+    // Pending is a transient state that should only exist during a sync.
+    // Promote any remaining pending assets to failed so they're visible in
+    // `kei status --failed` and don't block incremental sync on next run.
+    // Skip on interrupted syncs where pending assets are expected.
+    if let Some(db) = &config.state_db {
+        if !was_interrupted.is_cancelled() {
+            match db.promote_pending_to_failed().await {
+                Ok(promoted) if promoted > 0 => {
+                    tracing::warn!(
+                        count = promoted,
+                        "Promoted unresolved pending assets to failed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to promote pending assets");
+                }
+                _ => {}
+            }
+        }
     }
+
+    result
 }
 
 /// Full enumeration with syncToken capture.
@@ -5461,6 +5485,9 @@ mod tests {
         }
         async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError> {
             Ok((0, 0, 0))
+        }
+        async fn promote_pending_to_failed(&self) -> Result<u64, StateError> {
+            Ok(0)
         }
         async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
             unimplemented!()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1496,11 +1496,11 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     let config_required = config_explicitly_set && !can_auto_create;
     let mut toml_config = config::load_toml_config(&config_path, config_required)?;
 
-    // Resolve log level: CLI > TOML > default (info)
+    // Resolve log level: CLI > TOML > default (warn)
     let effective_log_level = cli
         .log_level
         .or_else(|| toml_config.as_ref().and_then(|t| t.log_level))
-        .unwrap_or(types::LogLevel::Info);
+        .unwrap_or(types::LogLevel::Warn);
 
     // Scope debug/info to the app crate so dependency crates stay quieter.
     // Users can override with RUST_LOG env var for full control.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -660,7 +660,7 @@ fn generate_toml(answers: &SetupAnswers) -> String {
     // Log level
     match answers.log_level {
         Some(level) => writeln!(out, "log_level = \"{}\"", log_level_str(level)).ok(),
-        None => writeln!(out, "# log_level = \"info\"").ok(),
+        None => writeln!(out, "# log_level = \"warn\"").ok(),
     };
 
     // [auth]
@@ -899,7 +899,7 @@ mod tests {
         // Defaults should be commented out
         assert!(toml.contains("# size = \"original\""));
         assert!(toml.contains("# threads_num = 10"));
-        assert!(toml.contains("# log_level = \"info\""));
+        assert!(toml.contains("# log_level = \"warn\""));
     }
 
     #[test]

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -97,6 +97,14 @@ pub trait StateDb: Send + Sync {
     /// (failed_reset, pending_reset, total_pending).
     async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError>;
 
+    /// Promote all remaining pending assets to failed.
+    ///
+    /// Called at the end of a non-interrupted sync run. Pending is a transient
+    /// state that should only exist during a sync — anything still pending
+    /// when the run finishes either wasn't enumerated by the API or failed
+    /// silently. Returns the number of assets promoted.
+    async fn promote_pending_to_failed(&self) -> Result<u64, StateError>;
+
     // ── Bulk read operations ──
 
     /// Get all downloaded asset IDs as (id, `version_size`) pairs.
@@ -550,6 +558,20 @@ impl StateDb for SqliteStateDb {
         let total_pending = total_pending as u64;
 
         Ok((failed, pending, total_pending))
+    }
+
+    async fn promote_pending_to_failed(&self) -> Result<u64, StateError> {
+        let conn = self.acquire_lock("promote_pending_to_failed")?;
+
+        let promoted = conn
+            .execute(
+                "UPDATE assets SET status = 'failed', last_error = 'Not resolved during sync' \
+                 WHERE status = 'pending'",
+                [],
+            )
+            .map_err(|e| StateError::query(&e))? as u64;
+
+        Ok(promoted)
     }
 
     async fn get_downloaded_ids(&self) -> Result<HashSet<(String, String)>, StateError> {
@@ -1816,6 +1838,72 @@ mod tests {
         // Verify attempt counts are all zero now
         let attempts = db.get_attempt_counts().await.unwrap();
         assert!(attempts.is_empty(), "all attempt counts should be zero");
+    }
+
+    #[tokio::test]
+    async fn promote_pending_to_failed_only_affects_pending() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+        let dir = test_dir();
+
+        // 1 downloaded (should be untouched)
+        let record = TestAssetRecord::new("ADownloaded")
+            .checksum("aaaa")
+            .filename("IMG_1000.HEIC")
+            .size(1000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        let path = dir.path().join("IMG_1000.HEIC");
+        fs::write(&path, b"payload").unwrap();
+        db.mark_downloaded("ADownloaded", "original", &path, "localhash", None)
+            .await
+            .unwrap();
+
+        // 2 pending (should be promoted to failed)
+        for i in 0..2 {
+            let id = format!("APending{i}");
+            let record = TestAssetRecord::new(&id)
+                .checksum(&format!("bbbb{i}"))
+                .filename(&format!("IMG_200{i}.JPG"))
+                .size(2000)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+        }
+
+        // 1 already failed (should be untouched)
+        let record = TestAssetRecord::new("AFailed")
+            .checksum("cccc")
+            .filename("IMG_3000.MOV")
+            .size(3000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        db.mark_failed("AFailed", "original", "HTTP 500")
+            .await
+            .unwrap();
+
+        let before = db.get_summary().await.unwrap();
+        assert_eq!(before.downloaded, 1);
+        assert_eq!(before.pending, 2);
+        assert_eq!(before.failed, 1);
+
+        let promoted = db.promote_pending_to_failed().await.unwrap();
+        assert_eq!(promoted, 2);
+
+        let after = db.get_summary().await.unwrap();
+        assert_eq!(after.downloaded, 1);
+        assert_eq!(after.pending, 0);
+        assert_eq!(after.failed, 3);
+
+        // Verify the promoted assets have the right error message
+        let failed = db.get_failed().await.unwrap();
+        let promoted_errors: Vec<_> = failed
+            .iter()
+            .filter(|a| a.id.starts_with("APending"))
+            .map(|a| a.last_error.as_deref())
+            .collect();
+        assert_eq!(promoted_errors.len(), 2);
+        for error in &promoted_errors {
+            assert_eq!(*error, Some("Not resolved during sync"));
+        }
     }
 
     #[tokio::test]

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2159,7 +2159,7 @@ fn exit_1_for_missing_username_on_sync() {
 #[test]
 fn log_level_default_info() {
     let dir = tempfile::tempdir().unwrap();
-    // sync with username + directory will fail at auth. Check stderr for INFO.
+    // sync with username + directory will fail at auth. Check stderr for WARN.
     let out = clean_cmd()
         .args([
             "sync",
@@ -2175,10 +2175,10 @@ fn log_level_default_info() {
         .get_output()
         .clone();
     let stderr = String::from_utf8_lossy(&out.stderr);
-    // Default level is INFO; the binary logs info-level messages like "Starting kei"
+    // Default level is WARN; INFO-level messages like "Starting kei" should not appear.
     assert!(
-        stderr.contains("INFO") || stderr.contains("info"),
-        "default log level should produce INFO-level messages, stderr: {stderr}"
+        !stderr.contains("INFO") && !stderr.contains("info"),
+        "default log level should suppress INFO-level messages, stderr: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Pending assets that survive a complete sync are promoted to failed with error "Not resolved during sync". `promote_pending_to_failed()` runs at the end of `download_photos_with_sync()`, skipped only on interrupted syncs (Ctrl+C / SIGTERM). Stuck assets now show up in `kei status --failed` and don't block incremental sync indefinitely.
- Default log level changed from `info` to `warn`. `--log-level info` or `log_level = "info"` in config restores the old behavior.

Follows up on #207, which fixed assets exceeding retry limits but left a gap: if the iCloud API stops returning an asset (or it fails silently), `prepare_for_retry()` resets its attempts to 0 each sync, the pending count forces full enumeration, and the cycle repeats forever. Reported in #199.

## Test plan

- [x] `cargo test` - all 1316 tests pass (includes new `promote_pending_to_failed_only_affects_pending` unit test)
- [x] `cargo clippy` - clean
- [x] `log_level_default_info` behavioral test updated to match new default
- [ ] Verify `kei status --failed` shows promoted assets after a sync with unresolvable pending items