### PR TITLE
Sync reporting, skip breakdown, and extended notifications

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -141,8 +141,7 @@ async fn authenticate_inner(
                 {
                     tracing::warn!(
                         error = %e,
-                        "Misdirected request persists after connection pool reset, \
-                         falling back to SRP"
+                        "validate returned persistent 421 Misdirected Request"
                     );
                 } else {
                     tracing::debug!(

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -182,8 +182,7 @@ async fn authenticate_inner(
                 {
                     tracing::warn!(
                         error = %e,
-                        "accountLogin misdirected after connection pool reset, \
-                         falling back to SRP"
+                        "accountLogin also returned 421 Misdirected Request"
                     );
                 } else {
                     tracing::debug!(
@@ -192,6 +191,21 @@ async fn authenticate_inner(
                     );
                 }
             }
+        }
+    }
+
+    // 421 fallback: if both /validate and /accountLogin returned 421,
+    // the auth endpoints have a routing issue but the session is likely
+    // still valid. Use cached auth data (no time limit) and let the
+    // CloudKit layer discover any real auth failures downstream. This
+    // avoids an unnecessary SRP handshake that would trigger 2FA.
+    if data.is_none() && has_session_token {
+        if let Some(cached) = session.load_validation_cache(i64::MAX).await {
+            tracing::info!(
+                "Auth endpoints returned 421, using cached session data \
+                 (CloudKit will re-auth if needed)"
+            );
+            data = Some(cached);
         }
     }
 

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -395,12 +395,12 @@ impl Session {
                             .collect()
                     }
                     Err(e) => {
-                        tracing::debug!(path = %session_path.display(), error = %e, "Session file corrupt, starting fresh");
+                        tracing::warn!(path = %session_path.display(), error = %e, "Session file corrupt, starting fresh");
                         HashMap::new()
                     }
                 },
                 Err(e) => {
-                    tracing::debug!(path = %session_path.display(), error = %e, "Could not read session file, starting fresh");
+                    tracing::warn!(path = %session_path.display(), error = %e, "Could not read session file, starting fresh");
                     HashMap::new()
                 }
             }

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -1292,6 +1292,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn validation_cache_no_time_limit_returns_stale_data() {
+        // When 421 fallback uses i64::MAX, even very old cached data should load
+        let (_td, dir) = test_dir("cache_no_limit");
+        let session = Session::new(&dir, "user@test.com", "https://www.icloud.com", None)
+            .await
+            .unwrap();
+
+        // Write a cache with a very old timestamp (1 week ago)
+        let cache = responses::ValidationCache {
+            validated_at: chrono::Utc::now().timestamp() - 604_800,
+            account_data: responses::AccountLoginResponse {
+                ds_info: None,
+                webservices: Some(responses::Webservices {
+                    ckdatabasews: Some(responses::WebserviceEndpoint {
+                        url: "https://p60-ckdatabasews.icloud.com".to_string(),
+                    }),
+                }),
+                hsa_challenge_required: false,
+                hsa_trusted_browser: true,
+                domain_to_use: None,
+                has_error: false,
+                service_errors: vec![],
+                i_cdp_enabled: false,
+            },
+        };
+        let json = serde_json::to_string_pretty(&cache).unwrap();
+        std::fs::write(session.cache_path(), json).unwrap();
+
+        // With normal grace (600s), should be expired
+        let loaded = session.load_validation_cache(600).await;
+        assert!(loaded.is_none(), "Should be expired with 600s grace");
+
+        // With i64::MAX grace (421 fallback), should load
+        let loaded = session.load_validation_cache(i64::MAX).await;
+        assert!(
+            loaded.is_some(),
+            "Should load with i64::MAX grace (421 fallback)"
+        );
+        let loaded = loaded.unwrap();
+        assert!(loaded.hsa_trusted_browser);
+        let ws = loaded.webservices.unwrap();
+        assert_eq!(
+            ws.ckdatabasews.unwrap().url,
+            "https://p60-ckdatabasews.icloud.com"
+        );
+    }
+
+    #[tokio::test]
     async fn strip_session_invalidates_cache() {
         let dir = tempfile::tempdir().unwrap();
         let session_path = dir.path().join("test.session");

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -62,6 +62,28 @@ pub fn sanitize_username(username: &str) -> String {
     }
 }
 
+/// Derive the broad cookie domain from a hostname.
+///
+/// Apple sets auth cookies with `Domain=.icloud.com` (or `.apple.com`),
+/// making them available to all subdomains. `reqwest::Jar::cookies()` strips
+/// the `Domain` attribute when serializing, so on reload we need to restore
+/// it. Without this, cookies scoped to `setup.icloud.com` won't be sent to
+/// `ckdatabasews.icloud.com`, causing 401 errors after container restarts.
+fn broad_cookie_domain(host: Option<&str>) -> Option<&str> {
+    let host = host?;
+    if host.ends_with(".icloud.com.cn") || host == "icloud.com.cn" {
+        Some("icloud.com.cn")
+    } else if host.ends_with(".apple.com.cn") || host == "apple.com.cn" {
+        Some("apple.com.cn")
+    } else if host.ends_with(".icloud.com") || host == "icloud.com" {
+        Some("icloud.com")
+    } else if host.ends_with(".apple.com") || host == "apple.com" {
+        Some("apple.com")
+    } else {
+        None
+    }
+}
+
 /// Check if a Set-Cookie header string represents an expired cookie.
 /// Parses the `cookie` crate's `Cookie::parse()` to extract `Expires`.
 fn is_cookie_expired(cookie_str: &str, now: &chrono::DateTime<chrono::Utc>) -> bool {
@@ -324,7 +346,13 @@ impl Session {
                             continue;
                         }
                         if let Ok(url) = entry.url.parse::<url::Url>() {
-                            cookie_jar.add_cookie_str(&entry.cookie, &url);
+                            let cookie_with_domain =
+                                if let Some(domain) = broad_cookie_domain(url.host_str()) {
+                                    format!("{}; Domain={domain}", entry.cookie)
+                                } else {
+                                    entry.cookie.clone()
+                                };
+                            cookie_jar.add_cookie_str(&cookie_with_domain, &url);
                         }
                     }
                     #[cfg(unix)]
@@ -1359,6 +1387,90 @@ mod tests {
         assert!(
             !cache_path.exists(),
             "Cache should be deleted on session strip"
+        );
+    }
+
+    #[test]
+    fn broad_cookie_domain_icloud() {
+        assert_eq!(
+            broad_cookie_domain(Some("setup.icloud.com")),
+            Some("icloud.com")
+        );
+        assert_eq!(
+            broad_cookie_domain(Some("www.icloud.com")),
+            Some("icloud.com")
+        );
+        assert_eq!(
+            broad_cookie_domain(Some("p150-ckdatabasews.icloud.com")),
+            Some("icloud.com")
+        );
+        assert_eq!(broad_cookie_domain(Some("icloud.com")), Some("icloud.com"));
+    }
+
+    #[test]
+    fn broad_cookie_domain_apple() {
+        assert_eq!(
+            broad_cookie_domain(Some("idmsa.apple.com")),
+            Some("apple.com")
+        );
+        assert_eq!(broad_cookie_domain(Some("apple.com")), Some("apple.com"));
+    }
+
+    #[test]
+    fn broad_cookie_domain_cn() {
+        assert_eq!(
+            broad_cookie_domain(Some("setup.icloud.com.cn")),
+            Some("icloud.com.cn")
+        );
+        assert_eq!(
+            broad_cookie_domain(Some("idmsa.apple.com.cn")),
+            Some("apple.com.cn")
+        );
+    }
+
+    #[test]
+    fn broad_cookie_domain_unknown() {
+        assert_eq!(broad_cookie_domain(Some("example.com")), None);
+        assert_eq!(broad_cookie_domain(None), None);
+    }
+
+    #[tokio::test]
+    async fn cookies_reload_with_broad_domain_scope() {
+        let (_td, dir) = test_dir("broad_domain");
+        let session = Session::new(&dir, "user@test.com", "https://www.icloud.com", None)
+            .await
+            .unwrap();
+
+        // Simulate cookies set by Apple's auth (scoped to setup.icloud.com)
+        let setup_url: url::Url = "https://setup.icloud.com/".parse().unwrap();
+        session.cookie_jar.add_cookie_str(
+            "X-APPLE-WEBAUTH-TOKEN=test123; Domain=icloud.com",
+            &setup_url,
+        );
+
+        // Persist and reload
+        session.persist_jar_cookies().await.unwrap();
+        drop(session);
+
+        let session2 = Session::new(&dir, "user@test.com", "https://www.icloud.com", None)
+            .await
+            .unwrap();
+
+        // After reload, cookies should be available for ckdatabasews.icloud.com too
+        let ck_url: url::Url = "https://p150-ckdatabasews.icloud.com/".parse().unwrap();
+        let cookies = session2.cookie_jar.cookies(&ck_url);
+        assert!(
+            cookies.is_some(),
+            "Cookies should be available for ckdatabasews.icloud.com after reload"
+        );
+        let cookie_str = cookies.unwrap();
+        assert!(
+            cookie_str
+                .to_str()
+                .unwrap()
+                .contains("X-APPLE-WEBAUTH-TOKEN=test123"),
+            "Expected WEBAUTH cookie for ckdatabasews, got: {}",
+            cookie_str.to_str().unwrap()
         );
     }
 }

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -395,17 +395,17 @@ impl Session {
                             .collect()
                     }
                     Err(e) => {
-                        tracing::info!(path = %session_path.display(), error = %e, "Session file corrupt, starting fresh");
+                        tracing::debug!(path = %session_path.display(), error = %e, "Session file corrupt, starting fresh");
                         HashMap::new()
                     }
                 },
                 Err(e) => {
-                    tracing::info!(path = %session_path.display(), error = %e, "Could not read session file, starting fresh");
+                    tracing::debug!(path = %session_path.display(), error = %e, "Could not read session file, starting fresh");
                     HashMap::new()
                 }
             }
         } else {
-            tracing::info!("Session file does not exist");
+            tracing::debug!("Session file does not exist");
             HashMap::new()
         };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,6 +191,10 @@ pub struct SyncArgs {
     #[arg(long, env = "KEI_NOTIFICATION_SCRIPT")]
     pub notification_script: Option<String>,
 
+    /// Write a JSON run report to this path after each sync cycle.
+    #[arg(long, env = "KEI_REPORT_JSON")]
+    pub report_json: Option<std::path::PathBuf>,
+
     /// After successful auth, persist the password to the credential store
     /// (OS keyring or encrypted file).
     #[arg(long)]
@@ -603,6 +607,9 @@ impl SyncArgs {
         if self.notification_script.is_none() {
             self.notification_script
                 .clone_from(&fallback.notification_script);
+        }
+        if self.report_json.is_none() {
+            self.report_json.clone_from(&fallback.report_json);
         }
         self.save_password = self.save_password || fallback.save_password;
         self.retry_failed = self.retry_failed || fallback.retry_failed;
@@ -1467,6 +1474,17 @@ mod tests {
         assert_eq!(
             cli.sync.notification_script.as_deref(),
             Some("/path/to/notify.sh")
+        );
+    }
+
+    #[test]
+    fn test_report_json_flag() {
+        let mut args = base_args();
+        args.extend(["--report-json", "/tmp/report.json"]);
+        let cli = parse(&args);
+        assert_eq!(
+            cli.sync.report_json.as_deref(),
+            Some(std::path::Path::new("/tmp/report.json"))
         );
     }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -53,7 +53,7 @@ pub(crate) async fn run_import_existing(
 
     // Create or open the state database
     let db = Arc::new(state::SqliteStateDb::open(&db_path).await?);
-    tracing::info!(path = %db_path.display(), "State database opened");
+    tracing::debug!(path = %db_path.display(), "State database opened");
 
     // Resolve auth from globals + TOML
     let (username, password, domain, cookie_directory) =
@@ -103,7 +103,7 @@ pub(crate) async fn run_import_existing(
     let mut total = 0u64;
 
     for library in &libraries {
-        tracing::info!(zone = %library.zone_name(), "Scanning library");
+        tracing::debug!(zone = %library.zone_name(), "Scanning library");
         let all_album = library.all();
         let stream = all_album.photo_stream(args.recent, None, 1);
         tokio::pin!(stream);

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -217,7 +217,7 @@ pub(crate) async fn init_photos_service(
     }
 
     if fresh_url != ckdatabasews_url {
-        tracing::debug!(
+        tracing::info!(
             old_url = %ckdatabasews_url,
             new_url = %fresh_url,
             "Re-authentication returned a different service URL"
@@ -312,7 +312,7 @@ where
         return Ok(());
     }
 
-    tracing::debug!("Session invalid, performing full re-authentication...");
+    tracing::info!("Session invalid, performing full re-authentication...");
     session.release_lock()?;
     drop(session);
 
@@ -329,7 +329,7 @@ where
 
     let mut session = shared_session.write().await;
     *session = new_auth.session;
-    tracing::debug!("Re-authentication successful");
+    tracing::info!("Re-authentication successful");
     Ok(())
 }
 

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -81,7 +81,7 @@ pub(crate) async fn init_photos_service(
         std::sync::Arc::new(tokio::sync::RwLock::new(auth_result.session));
     let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
 
-    tracing::info!("Initializing photos service...");
+    tracing::debug!("Initializing photos service...");
     match icloud::photos::PhotosService::new(
         ckdatabasews_url.clone(),
         session_box,
@@ -217,7 +217,7 @@ pub(crate) async fn init_photos_service(
     }
 
     if fresh_url != ckdatabasews_url {
-        tracing::info!(
+        tracing::debug!(
             old_url = %ckdatabasews_url,
             new_url = %fresh_url,
             "Re-authentication returned a different service URL"
@@ -312,7 +312,7 @@ where
         return Ok(());
     }
 
-    tracing::info!("Session invalid, performing full re-authentication...");
+    tracing::debug!("Session invalid, performing full re-authentication...");
     session.release_lock()?;
     drop(session);
 
@@ -329,7 +329,7 @@ where
 
     let mut session = shared_session.write().await;
     *session = new_auth.session;
-    tracing::info!("Re-authentication successful");
+    tracing::debug!("Re-authentication successful");
     Ok(())
 }
 
@@ -358,7 +358,7 @@ async fn wait_for_2fa_submit(cookie_dir: &Path, username: &str) {
             .and_then(|m| m.modified())
             .ok();
         if current_mtime != initial_mtime {
-            tracing::info!("Session file updated, retrying authentication");
+            tracing::debug!("Session file updated, retrying authentication");
             break;
         }
     }
@@ -406,7 +406,7 @@ where
                     if e.downcast_ref::<auth::error::AuthError>()
                         .is_some_and(auth::error::AuthError::is_two_factor_required) =>
                 {
-                    tracing::info!("Session not yet trusted, continuing to wait...");
+                    tracing::debug!("Session not yet trusted, continuing to wait...");
                     break; // Back to outer loop (wait_for_2fa_submit)
                 }
                 Err(e)
@@ -486,12 +486,12 @@ pub(crate) async fn resolve_libraries(
 ) -> anyhow::Result<Vec<icloud::photos::PhotoLibrary>> {
     match selection {
         config::LibrarySelection::All => {
-            tracing::info!("Using all available libraries");
+            tracing::debug!("Using all available libraries");
             photos_service.all_libraries().await
         }
         config::LibrarySelection::Single(name) => {
             if name != "PrimarySync" {
-                tracing::info!(library = %name, "Using non-default library");
+                tracing::debug!(library = %name, "Using non-default library");
             }
             Ok(vec![photos_service.get_library(name).await?.clone()])
         }
@@ -534,7 +534,7 @@ pub(crate) async fn resolve_albums(
         for name in exclude_albums {
             if let Some(album) = album_map.get(name.as_str()) {
                 let count = album.len().await.unwrap_or(0);
-                tracing::info!(album = name, count, "Pre-fetching excluded album asset IDs");
+                tracing::debug!(album = name, count, "Pre-fetching excluded album asset IDs");
                 let (stream, _token_rx) = album.photo_stream_with_token(None, Some(count), 1);
                 tokio::pin!(stream);
                 while let Some(Ok(asset)) = stream.next().await {
@@ -544,7 +544,7 @@ pub(crate) async fn resolve_albums(
                 tracing::warn!(album = name, "Excluded album not found, ignoring");
             }
         }
-        tracing::info!(count = exclude_ids.len(), "Collected excluded asset IDs");
+        tracing::debug!(count = exclude_ids.len(), "Collected excluded asset IDs");
         return Ok((vec![library.all()], exclude_ids));
     }
 
@@ -553,7 +553,7 @@ pub(crate) async fn resolve_albums(
     let mut matched = Vec::new();
     for name in album_names {
         if exclude_albums.iter().any(|e| e == name) {
-            tracing::info!(album = name, "Album excluded by --exclude-album");
+            tracing::debug!(album = name, "Album excluded by --exclude-album");
             continue;
         }
         if let Some(album) = album_map.remove(name.as_str()) {

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -782,6 +782,33 @@ mod tests {
         );
     }
 
+    // ── is_misdirected_request tests ──────────────────────────────────
+
+    #[test]
+    fn misdirected_request_detected_from_connection_error() {
+        let err = icloud::error::ICloudError::Connection(
+            "HTTP 421 for https://p60-ckdatabasews.icloud.com/...".to_string(),
+        );
+        assert!(is_misdirected_request(&err));
+    }
+
+    #[test]
+    fn non_421_connection_error_not_misdirected() {
+        let err = icloud::error::ICloudError::Connection(
+            "HTTP 500 for https://p60-ckdatabasews.icloud.com/...".to_string(),
+        );
+        assert!(!is_misdirected_request(&err));
+    }
+
+    #[test]
+    fn service_not_activated_not_misdirected() {
+        let err = icloud::error::ICloudError::ServiceNotActivated {
+            code: "ZONE_NOT_FOUND".to_string(),
+            reason: "zone not found".to_string(),
+        };
+        assert!(!is_misdirected_request(&err));
+    }
+
     #[tokio::test]
     async fn resolve_albums_same_album_in_both_yields_empty() {
         let mock = MockPhotosSession::new().ok(serde_json::json!({"records": [

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -383,6 +383,19 @@ where
     loop {
         wait_for_2fa_submit(cookie_dir, username).await;
 
+        // Invalidate the validation cache so authenticate() actually checks
+        // with Apple instead of returning stale cached data from before 2FA.
+        let sanitized: String = username
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        let cache_path = cookie_dir.join(format!("{sanitized}.cache"));
+        if cache_path.exists() {
+            if let Err(e) = tokio::fs::remove_file(&cache_path).await {
+                tracing::debug!(error = %e, "Could not remove validation cache");
+            }
+        }
+
         for attempt in 0..3 {
             if attempt > 0 {
                 tokio::time::sleep(std::time::Duration::from_secs(TWO_FA_POLL_SECS)).await;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -95,9 +95,21 @@ pub(crate) async fn init_photos_service(
         Err(_) => {}
     }
 
-    // ── Recovery strategy 1: fresh HTTP/2 connection pool ──────────────
-    // Cheap fix: drop old connections, keep auth state. Handles cases where
-    // the TCP connection was routed to the wrong CloudKit partition server.
+    // ── 421 recovery ─────────────────────────────────────────────────────
+    //
+    // A 421 Misdirected Request means Apple's CDN routed our HTTP/2
+    // connection to the wrong CloudKit partition server. Per RFC 9110,
+    // the correct client response is to retry on a new connection - NOT
+    // to re-authenticate. The session credentials are almost certainly
+    // fine; it's the TCP/TLS routing that's wrong.
+    //
+    // Strategy order:
+    //   1. Fresh connection pool (instant, free)
+    //   2. Backoff + fresh pools (handles transient CDN routing issues)
+    //   3. Full re-auth (last resort - only if the URL actually changed,
+    //      meaning Apple migrated the account to a different partition)
+
+    // ── Strategy 1: fresh HTTP/2 connection pool ─────────────────────
     tracing::warn!(
         url = %ckdatabasews_url,
         "Service returned 421 Misdirected Request, retrying with fresh connection pool"
@@ -121,17 +133,53 @@ pub(crate) async fn init_photos_service(
         Err(_) => {}
     }
 
-    // ── Recovery strategy 2: full re-authentication ────────────────────
-    // Expensive fix: clear session state, perform fresh SRP + 2FA login.
-    // Handles cases where stale session headers cause wrong partition routing.
+    // ── Strategy 2: exponential backoff with fresh pools ─────────────
+    // The routing issue may be transient (CDN propagation, partition
+    // migration in progress). Retry with fresh connections on each
+    // attempt, giving Apple's infrastructure time to settle.
+    const BACKOFF_SECS: &[u64] = &[10, 30, 60];
+    for (i, &delay) in BACKOFF_SECS.iter().enumerate() {
+        tracing::warn!(
+            attempt = i + 1,
+            max_attempts = BACKOFF_SECS.len(),
+            delay_secs = delay,
+            url = %ckdatabasews_url,
+            "421 persists, retrying after backoff with fresh connection pool"
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+
+        {
+            let mut session = shared_session.write().await;
+            session.reset_http_clients()?;
+        }
+
+        let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
+        match icloud::photos::PhotosService::new(
+            ckdatabasews_url.clone(),
+            session_box,
+            params.clone(),
+            api_retry_config,
+        )
+        .await
+        {
+            Ok(service) => return Ok((shared_session, service)),
+            Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
+            Err(_) => {}
+        }
+    }
+
+    // ── Strategy 3: re-authenticate (last resort) ────────────────────
+    // All pool resets and backoff failed. The most likely cause is that
+    // Apple migrated the account to a different CloudKit partition, so
+    // the ckdatabasews URL itself is stale. Re-authenticate to get a
+    // fresh URL.
     //
-    // Clear routing-related session state (session_token, session_id, scnt)
-    // so `authenticate()` falls through to fresh SRP instead of the validate
-    // shortcut. We preserve trust_token so SRP can include it in `trustTokens`,
+    // We preserve trust_token so SRP can include it in `trustTokens`,
     // letting Apple recognise this as a trusted device and skip 2FA.
     tracing::warn!(
         url = %ckdatabasews_url,
-        "Fresh connection pool did not resolve 421, performing full re-authentication"
+        "421 persists after {} backoff retries, performing full re-authentication",
+        BACKOFF_SECS.len()
     );
     {
         let session = shared_session.read().await;
@@ -203,46 +251,11 @@ pub(crate) async fn init_photos_service(
         Err(_) => {}
     }
 
-    // ── Recovery strategy 3: retry with exponential backoff ───────────
-    // Both strategies failed. Apple's partition routing may be transiently
-    // broken (account migration, infrastructure issue). Wait and retry
-    // with fresh connection pools on each attempt.
-    const BACKOFF_SECS: &[u64] = &[10, 30, 60];
-    for (i, &delay) in BACKOFF_SECS.iter().enumerate() {
-        tracing::warn!(
-            attempt = i + 1,
-            max_attempts = BACKOFF_SECS.len(),
-            delay_secs = delay,
-            url = %fresh_url,
-            "All recovery strategies failed, retrying after backoff"
-        );
-        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-
-        {
-            let mut session = shared_session.write().await;
-            session.reset_http_clients()?;
-        }
-
-        let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
-        match icloud::photos::PhotosService::new(
-            fresh_url.clone(),
-            session_box,
-            new_params.clone(),
-            api_retry_config,
-        )
-        .await
-        {
-            Ok(service) => return Ok((shared_session, service)),
-            Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
-            Err(_) => {}
-        }
-    }
-
     anyhow::bail!(
-        "421 Misdirected Request persists on {} after re-authentication and {} \
-         backoff retries.\n\n\
+        "421 Misdirected Request persists on {} after {} backoff retries and \
+         re-authentication.\n\n\
          If Advanced Data Protection (ADP) is enabled on this account, that's the\n\
-         cause -- ADP blocks the web API that kei uses. To fix, change both settings\n\
+         cause - ADP blocks the web API that kei uses. To fix, change both settings\n\
          on your iPhone/iPad:\n  \
          1. Disable ADP: Settings > Apple ID > iCloud > Advanced Data Protection\n  \
          2. Enable web access: Settings > Apple ID > iCloud > Access iCloud Data on the Web\n\n\

--- a/src/config.rs
+++ b/src/config.rs
@@ -958,7 +958,7 @@ pub(crate) fn persist_first_run_config(
         std::fs::set_permissions(config_path, std::fs::Permissions::from_mode(0o600))?;
     }
 
-    tracing::info!(path = %config_path.display(), "Saved configuration for future runs");
+    tracing::debug!(path = %config_path.display(), "Saved configuration for future runs");
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -958,7 +958,7 @@ pub(crate) fn persist_first_run_config(
         std::fs::set_permissions(config_path, std::fs::Permissions::from_mode(0o600))?;
     }
 
-    tracing::debug!(path = %config_path.display(), "Saved configuration for future runs");
+    tracing::info!(path = %config_path.display(), "Saved configuration for future runs");
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,6 +194,7 @@ pub struct Config {
     // Optional paths
     pub pid_file: Option<PathBuf>,
     pub notification_script: Option<PathBuf>,
+    pub report_json: Option<PathBuf>,
 
     // 8-byte primitives
     pub watch_with_interval: Option<u64>,
@@ -662,6 +663,9 @@ impl Config {
             .or_else(|| toml_notif.and_then(|n| n.script.clone()))
             .map(|s| expand_tilde(&s));
 
+        // JSON report
+        let report_json = sync.report_json;
+
         if skip_videos && skip_photos && live_photo_mode == LivePhotoMode::Skip {
             tracing::warn!(
                 "All media types are being skipped (--skip-videos, --skip-photos, \
@@ -686,6 +690,7 @@ impl Config {
             skip_created_after,
             pid_file,
             notification_script,
+            report_json,
             watch_with_interval,
             retry_delay_secs,
             recent,

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -109,7 +109,7 @@ pub(super) async fn download_file<C: DownloadClient>(
     retry_config: &RetryConfig,
     temp_suffix: &str,
     opts: DownloadOpts,
-) -> Result<(), DownloadError> {
+) -> Result<u64, DownloadError> {
     let part_path =
         temp_download_path(download_path, checksum, temp_suffix).map_err(DownloadError::Other)?;
 
@@ -152,7 +152,7 @@ async fn attempt_download<C: DownloadClient>(
     part_path: &Path,
     skip_rename: bool,
     expected_size: Option<u64>,
-) -> Result<(), DownloadError> {
+) -> Result<u64, DownloadError> {
     let path_str = download_path.display().to_string();
 
     let resume_offset = match fs::metadata(part_path).await {
@@ -340,7 +340,7 @@ async fn attempt_download<C: DownloadClient>(
         rename_part_to_final(part_path, download_path).await?;
     }
 
-    Ok(())
+    Ok(bytes_written)
 }
 
 /// Rename a `.part` file to its final destination, handling the case where
@@ -1394,7 +1394,7 @@ mod tests {
         fail_count: u32,
         fail_status: u16,
         max_retries: u32,
-    ) -> (Result<(), DownloadError>, u32, PathBuf, TempDir) {
+    ) -> (Result<u64, DownloadError>, u32, PathBuf, TempDir) {
         let jpeg_body = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
         let client = RetryingStubClient::new(fail_count, fail_status, jpeg_body);
         let dir = TempDir::new().unwrap();
@@ -1569,7 +1569,7 @@ mod tests {
             filename: &str,
             checksum: &str,
             max_retries: u32,
-        ) -> (Result<(), DownloadError>, PathBuf, TempDir) {
+        ) -> (Result<u64, DownloadError>, PathBuf, TempDir) {
             let dir = TempDir::new().unwrap();
             let download_path = dir.path().join(filename);
             let config = RetryConfig {

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -20,6 +20,16 @@ use crate::types::{
 use super::paths;
 use super::DownloadConfig;
 
+/// Reason an asset was filtered out during content/metadata filtering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FilterReason {
+    ExcludedAlbum,
+    MediaType,
+    LivePhoto,
+    DateRange,
+    Filename,
+}
+
 /// Case-insensitive glob matching options for filename exclusion patterns.
 const GLOB_CASE_INSENSITIVE: glob::MatchOptions = glob::MatchOptions {
     case_sensitive: false,
@@ -165,41 +175,42 @@ fn apply_raw_policy(versions: &VersionsMap, policy: RawTreatmentPolicy) -> Cow<'
     Cow::Owned(swapped)
 }
 
-/// Returns `true` if this asset should be skipped by content/metadata filters.
+/// Returns the reason this asset should be skipped by content/metadata
+/// filters, or `None` if the asset passes all filters.
 ///
 /// Callers must invoke this before `extract_skip_candidates` or
 /// `filter_asset_to_tasks` to avoid redundant evaluation.
 pub(super) fn is_asset_filtered(
     asset: &crate::icloud::photos::PhotoAsset,
     config: &DownloadConfig,
-) -> bool {
+) -> Option<FilterReason> {
     if config.exclude_asset_ids.contains(asset.id()) {
         tracing::debug!(asset_id = %asset.id(), "Skipping (excluded album asset)");
-        return true;
+        return Some(FilterReason::ExcludedAlbum);
     }
     if config.skip_videos && asset.item_type() == Some(AssetItemType::Movie) {
         tracing::debug!(asset_id = %asset.id(), "Skipping video (skip_videos enabled)");
-        return true;
+        return Some(FilterReason::MediaType);
     }
     if config.skip_photos && asset.item_type() == Some(AssetItemType::Image) {
         tracing::debug!(asset_id = %asset.id(), "Skipping photo (skip_photos enabled)");
-        return true;
+        return Some(FilterReason::MediaType);
     }
     if config.live_photo_mode == LivePhotoMode::Skip && asset.is_live_photo() {
         tracing::debug!(asset_id = %asset.id(), "Skipping live photo (live_photo_mode=skip)");
-        return true;
+        return Some(FilterReason::LivePhoto);
     }
     let created_utc = asset.created();
     if let Some(before) = &config.skip_created_before {
         if created_utc < *before {
             tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (before date range)");
-            return true;
+            return Some(FilterReason::DateRange);
         }
     }
     if let Some(after) = &config.skip_created_after {
         if created_utc > *after {
             tracing::debug!(asset_id = %asset.id(), date = %created_utc, "Skipping (after date range)");
-            return true;
+            return Some(FilterReason::DateRange);
         }
     }
     // Only check filename exclusion when the asset has a real filename.
@@ -212,11 +223,11 @@ pub(super) fn is_asset_filtered(
                 .any(|p| p.matches_with(filename, GLOB_CASE_INSENSITIVE))
             {
                 tracing::debug!(asset_id = %asset.id(), filename, "Skipping (filename_exclude match)");
-                return true;
+                return Some(FilterReason::Filename);
             }
         }
     }
-    false
+    None
 }
 
 /// Lightweight pre-check: extract (`version_size`, checksum) pairs for an asset
@@ -763,7 +774,10 @@ mod tests {
             .build();
         let mut config = test_config();
         config.skip_videos = true;
-        assert!(is_asset_filtered(&asset, &config));
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::MediaType)
+        );
     }
 
     #[test]
@@ -787,7 +801,10 @@ mod tests {
         let asset = TestPhotoAsset::new("TEST_1").build();
         let mut config = test_config();
         config.skip_photos = true;
-        assert!(is_asset_filtered(&asset, &config));
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::MediaType)
+        );
     }
 
     #[test]
@@ -1329,7 +1346,10 @@ mod tests {
             .build();
         let mut config = test_config();
         config.skip_videos = true;
-        assert!(is_asset_filtered(&asset, &config));
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::MediaType)
+        );
     }
 
     #[test]
@@ -1337,7 +1357,10 @@ mod tests {
         let asset = TestPhotoAsset::new("TEST_1").build();
         let mut config = test_config();
         config.skip_photos = true;
-        assert!(is_asset_filtered(&asset, &config));
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::MediaType)
+        );
     }
 
     #[test]
@@ -1356,8 +1379,9 @@ mod tests {
         let asset = test_live_photo_asset();
         let mut config = test_config();
         config.live_photo_mode = LivePhotoMode::Skip;
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::LivePhoto),
             "Skip mode should exclude live photos entirely"
         );
     }
@@ -1396,7 +1420,10 @@ mod tests {
                 .unwrap()
                 .into(),
         );
-        assert!(is_asset_filtered(&asset, &config));
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::DateRange)
+        );
     }
 
     #[test]
@@ -1409,7 +1436,10 @@ mod tests {
                 .unwrap()
                 .into(),
         );
-        assert!(is_asset_filtered(&asset, &config));
+        assert_eq!(
+            is_asset_filtered(&asset, &config),
+            Some(FilterReason::DateRange)
+        );
     }
 
     #[test]
@@ -1975,8 +2005,9 @@ mod tests {
                 .unwrap()
                 .into(),
         );
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::DateRange),
             "Asset before the date window should be skipped"
         );
     }
@@ -1997,8 +2028,9 @@ mod tests {
                 .unwrap()
                 .into(),
         );
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::DateRange),
             "Asset after the date window should be skipped"
         );
     }
@@ -2173,8 +2205,9 @@ mod tests {
                 .unwrap()
                 .and_utc(),
         );
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::DateRange),
             "Asset created in 2020 should be excluded by skip_created_before=2024"
         );
     }
@@ -2194,8 +2227,9 @@ mod tests {
                 .unwrap()
                 .and_utc(),
         );
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::DateRange),
             "Asset created in 2025 should be excluded by skip_created_after=2023"
         );
     }
@@ -2220,8 +2254,9 @@ mod tests {
         let asset = test_live_photo_asset();
         let mut config = test_config();
         config.live_photo_mode = LivePhotoMode::Skip;
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::LivePhoto),
             "Skip mode should produce no tasks for live photos"
         );
     }
@@ -2244,8 +2279,9 @@ mod tests {
             .build();
         let mut config = test_config();
         config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::Filename),
             "*.AAE pattern should exclude AAE files"
         );
     }
@@ -2255,8 +2291,9 @@ mod tests {
         let asset = TestPhotoAsset::new("EXCL_2").filename("Photo.aae").build();
         let mut config = test_config();
         config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::Filename),
             "Pattern matching should be case-insensitive"
         );
     }
@@ -2283,8 +2320,9 @@ mod tests {
         let mut ids = FxHashSet::default();
         ids.insert("EXCLUDED_1".to_string());
         config.exclude_asset_ids = Arc::new(ids);
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::ExcludedAlbum),
             "Asset in exclude set should be filtered"
         );
     }
@@ -2311,8 +2349,9 @@ mod tests {
         let mut ids = FxHashSet::default();
         ids.insert("SKIP_EXCL_1".to_string());
         config.exclude_asset_ids = Arc::new(ids);
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::ExcludedAlbum),
             "is_asset_filtered should return true for excluded assets"
         );
     }
@@ -2324,8 +2363,9 @@ mod tests {
         let asset = TestPhotoAsset::new("TEST_1").filename("photo.AAE").build();
         let mut config = test_config();
         config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::Filename),
             "filename_exclude should filter via is_asset_filtered"
         );
     }
@@ -2346,8 +2386,9 @@ mod tests {
         let asset = TestPhotoAsset::new("TEST_1").filename("photo.aae").build();
         let mut config = test_config();
         config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::Filename),
             "filename_exclude should be case-insensitive"
         );
     }
@@ -2530,8 +2571,9 @@ mod tests {
         excluded.insert("EXCLUDED_1".to_string());
         config.exclude_asset_ids = Arc::new(excluded);
 
-        assert!(
+        assert_eq!(
             is_asset_filtered(&asset, &config),
+            Some(FilterReason::ExcludedAlbum),
             "asset in exclude_asset_ids should be filtered"
         );
     }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -743,7 +743,7 @@ async fn cleanup_orphan_part_files(config: &DownloadConfig) {
     .unwrap_or(0);
 
     if cleaned > 0 {
-        tracing::debug!(count = cleaned, "Cleaned up orphaned .part files");
+        tracing::info!(count = cleaned, "Cleaned up orphaned .part files");
     }
 }
 
@@ -1268,7 +1268,7 @@ async fn download_photos_incremental(
     }
 
     let task_count = tasks.len();
-    tracing::debug!(
+    tracing::info!(
         count = task_count,
         "Downloading files from incremental sync"
     );

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -743,7 +743,7 @@ async fn cleanup_orphan_part_files(config: &DownloadConfig) {
     .unwrap_or(0);
 
     if cleaned > 0 {
-        tracing::info!(count = cleaned, "Cleaned up orphaned .part files");
+        tracing::debug!(count = cleaned, "Cleaned up orphaned .part files");
     }
 }
 
@@ -763,10 +763,10 @@ pub async fn download_photos_with_sync(
         match db.prepare_for_retry().await {
             Ok((failed, stale, total_pending)) => {
                 if failed > 0 {
-                    tracing::info!(count = failed, "Reset failed assets for retry");
+                    tracing::debug!(count = failed, "Reset failed assets for retry");
                 }
                 if stale > 0 {
-                    tracing::info!(
+                    tracing::debug!(
                         count = stale,
                         "Cleared stale attempt counts on pending assets"
                     );
@@ -796,7 +796,7 @@ pub async fn download_photos_with_sync(
         // pending assets from previous syncs. Fall back to full so they get
         // retried. Once everything is downloaded, incremental resumes.
         SyncMode::Incremental { .. } if total_pending > 0 => {
-            tracing::info!(
+            tracing::debug!(
                 pending = total_pending,
                 "Pending assets require full enumeration, skipping incremental sync"
             );
@@ -1094,7 +1094,7 @@ async fn download_photos_incremental(
         }
     }
 
-    tracing::info!(
+    tracing::debug!(
         created = created_count,
         soft_deleted = soft_deleted_count,
         hard_deleted = hard_deleted_count,
@@ -1120,7 +1120,7 @@ async fn download_photos_incremental(
     if let Some(recent) = config.recent {
         let limit = recent as usize;
         if downloadable_assets.len() > limit {
-            tracing::info!(
+            tracing::debug!(
                 total = downloadable_assets.len(),
                 limit,
                 "Capping incremental assets to --recent limit"
@@ -1129,7 +1129,7 @@ async fn download_photos_incremental(
         }
     }
 
-    tracing::info!(
+    tracing::debug!(
         count = downloadable_assets.len(),
         "Assets to download from incremental sync"
     );
@@ -1229,7 +1229,7 @@ async fn download_photos_incremental(
     }
 
     if skip_breakdown.by_state > 0 {
-        tracing::info!(
+        tracing::debug!(
             skipped = skip_breakdown.by_state,
             "Skipped already-downloaded assets (state DB)"
         );
@@ -1268,7 +1268,7 @@ async fn download_photos_incremental(
     }
 
     let task_count = tasks.len();
-    tracing::info!(
+    tracing::debug!(
         count = task_count,
         "Downloading files from incremental sync"
     );

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -11,8 +11,8 @@ pub mod paths;
 pub(crate) mod pipeline;
 
 use pipeline::{
-    build_download_outcome, format_duration, run_download_pass, stream_and_download_from_stream,
-    PassConfig, StreamingResult, AUTH_ERROR_THRESHOLD,
+    build_download_outcome, format_duration, log_sync_summary, run_download_pass,
+    stream_and_download_from_stream, PassConfig, StreamingResult, AUTH_ERROR_THRESHOLD,
 };
 
 pub(crate) use filter::determine_media_type;
@@ -73,6 +73,56 @@ pub struct SyncResult {
     /// The new zone-level syncToken, if one was captured during this sync.
     /// Store this for the next incremental sync.
     pub sync_token: Option<String>,
+    /// Accumulated statistics from this sync run.
+    pub stats: SyncStats,
+}
+
+/// Accumulated statistics from a sync run, used for JSON reports and notifications.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct SyncStats {
+    pub assets_seen: u64,
+    pub downloaded: usize,
+    pub failed: usize,
+    pub skipped: SkipBreakdown,
+    pub bytes_downloaded: u64,
+    pub disk_bytes_written: u64,
+    pub exif_failures: usize,
+    pub state_write_failures: usize,
+    pub enumeration_errors: usize,
+    pub elapsed_secs: f64,
+    pub interrupted: bool,
+}
+
+/// Per-reason breakdown of skipped assets.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct SkipBreakdown {
+    pub by_state: usize,
+    pub on_disk: usize,
+    pub by_media_type: usize,
+    pub by_date_range: usize,
+    pub by_live_photo: usize,
+    pub by_filename: usize,
+    pub by_excluded_album: usize,
+    pub ampm_variant: usize,
+    pub duplicates: usize,
+    pub retry_exhausted: usize,
+    pub retry_only: usize,
+}
+
+impl SkipBreakdown {
+    pub fn total(&self) -> usize {
+        self.by_state
+            + self.on_disk
+            + self.by_media_type
+            + self.by_date_range
+            + self.by_live_photo
+            + self.by_filename
+            + self.by_excluded_album
+            + self.ampm_variant
+            + self.duplicates
+            + self.retry_exhausted
+            + self.retry_only
+    }
 }
 
 /// Truncate a `DateTime<Utc>` to midnight so that relative date intervals
@@ -606,7 +656,7 @@ async fn build_download_tasks(
         let assets = album_result?;
 
         for asset in &assets {
-            if filter::is_asset_filtered(asset, config) {
+            if filter::is_asset_filtered(asset, config).is_some() {
                 continue;
             }
             pre_ensure_asset_dir(&mut dir_cache, asset, config).await;
@@ -964,7 +1014,7 @@ async fn download_photos_full_with_token(
     }
 
     // Build the outcome using the same logic as download_photos
-    let outcome = build_download_outcome(
+    let (outcome, stats) = build_download_outcome(
         download_client,
         albums,
         config,
@@ -977,6 +1027,7 @@ async fn download_photos_full_with_token(
     Ok(SyncResult {
         outcome,
         sync_token,
+        stats,
     })
 }
 
@@ -1052,11 +1103,16 @@ async fn download_photos_incremental(
     );
 
     if downloadable_assets.is_empty() {
+        let stats = SyncStats {
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            ..SyncStats::default()
+        };
         tracing::info!("No new photos to download from incremental sync");
         tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
         return Ok(SyncResult {
             outcome: DownloadOutcome::Success,
             sync_token,
+            stats,
         });
     }
 
@@ -1091,7 +1147,7 @@ async fn download_photos_incremental(
     let mut tasks: Vec<DownloadTask> = Vec::new();
     let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
     let mut dir_cache = paths::DirCache::new();
-    let mut skipped_by_state = 0usize;
+    let mut skip_breakdown = SkipBreakdown::default();
     let mut album_configs: FxHashMap<Arc<str>, Arc<DownloadConfig>> = FxHashMap::default();
 
     // In {album} mode, assets in multiple albums are processed once per album,
@@ -1106,7 +1162,14 @@ async fn download_photos_incremental(
             config
         };
 
-        if filter::is_asset_filtered(asset, effective_config) {
+        if let Some(reason) = filter::is_asset_filtered(asset, effective_config) {
+            match reason {
+                filter::FilterReason::ExcludedAlbum => skip_breakdown.by_excluded_album += 1,
+                filter::FilterReason::MediaType => skip_breakdown.by_media_type += 1,
+                filter::FilterReason::LivePhoto => skip_breakdown.by_live_photo += 1,
+                filter::FilterReason::DateRange => skip_breakdown.by_date_range += 1,
+                filter::FilterReason::Filename => skip_breakdown.by_filename += 1,
+            }
             continue;
         }
 
@@ -1121,7 +1184,7 @@ async fn download_photos_incremental(
                 )
             })
         {
-            skipped_by_state += 1;
+            skip_breakdown.by_state += 1;
             continue;
         }
 
@@ -1159,22 +1222,31 @@ async fn download_photos_incremental(
             }
         }
 
+        if asset_tasks.is_empty() {
+            skip_breakdown.on_disk += 1;
+        }
         tasks.extend(asset_tasks);
     }
 
-    if skipped_by_state > 0 {
+    if skip_breakdown.by_state > 0 {
         tracing::info!(
-            skipped = skipped_by_state,
+            skipped = skip_breakdown.by_state,
             "Skipped already-downloaded assets (state DB)"
         );
     }
 
     if tasks.is_empty() {
+        let stats = SyncStats {
+            skipped: skip_breakdown,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            ..SyncStats::default()
+        };
         tracing::info!("All incremental assets already downloaded or filtered");
         tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
         return Ok(SyncResult {
             outcome: DownloadOutcome::Success,
             sync_token,
+            stats,
         });
     }
 
@@ -1182,10 +1254,16 @@ async fn download_photos_incremental(
         for task in &tasks {
             println!("{}", task.download_path.display());
         }
+        let stats = SyncStats {
+            skipped: skip_breakdown,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            ..SyncStats::default()
+        };
         // Don't advance the sync token — this is a read-only operation.
         return Ok(SyncResult {
             outcome: DownloadOutcome::Success,
             sync_token: None,
+            stats,
         });
     }
 
@@ -1211,25 +1289,30 @@ async fn download_photos_incremental(
     let failed = pass_result.failed.len();
     let succeeded = task_count - failed;
 
-    tracing::info!("── Incremental Sync Summary ──");
-    if pass_result.exif_failures > 0 || pass_result.state_write_failures > 0 {
-        tracing::info!(
-            downloaded = succeeded,
-            exif_failures = pass_result.exif_failures,
-            state_write_failures = pass_result.state_write_failures,
-            failed,
-            total = task_count,
-            "  sync results"
-        );
-    } else {
-        tracing::info!(
-            downloaded = succeeded,
-            failed,
-            total = task_count,
-            "  sync results"
-        );
+    // Log failed downloads before the summary
+    if failed > 0 {
+        for task in &pass_result.failed {
+            tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), "Download failed");
+        }
     }
-    tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
+
+    let stats = SyncStats {
+        assets_seen: 0, // incremental doesn't have total library count
+        downloaded: succeeded,
+        failed,
+        skipped: skip_breakdown,
+        bytes_downloaded: pass_result.bytes_downloaded,
+        disk_bytes_written: pass_result.disk_bytes_written,
+        exif_failures: pass_result.exif_failures,
+        state_write_failures: pass_result.state_write_failures,
+        enumeration_errors: 0,
+        elapsed_secs: started.elapsed().as_secs_f64(),
+        interrupted: pass_result.auth_errors >= AUTH_ERROR_THRESHOLD,
+    };
+    log_sync_summary(
+        "\u{2500}\u{2500} Incremental Sync Summary \u{2500}\u{2500}",
+        &stats,
+    );
 
     if pass_result.auth_errors >= AUTH_ERROR_THRESHOLD {
         return Ok(SyncResult {
@@ -1237,26 +1320,23 @@ async fn download_photos_incremental(
                 auth_error_count: pass_result.auth_errors,
             },
             sync_token,
+            stats,
         });
     }
 
-    let outcome = if failed > 0
-        || pass_result.exif_failures > 0
-        || pass_result.state_write_failures > 0
-    {
-        for task in &pass_result.failed {
-            tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), "Download failed");
-        }
-        DownloadOutcome::PartialFailure {
-            failed_count: failed + pass_result.exif_failures + pass_result.state_write_failures,
-        }
-    } else {
-        DownloadOutcome::Success
-    };
+    let outcome =
+        if failed > 0 || pass_result.exif_failures > 0 || pass_result.state_write_failures > 0 {
+            DownloadOutcome::PartialFailure {
+                failed_count: failed + pass_result.exif_failures + pass_result.state_write_failures,
+            }
+        } else {
+            DownloadOutcome::Success
+        };
 
     Ok(SyncResult {
         outcome,
         sync_token,
+        stats,
     })
 }
 
@@ -1402,6 +1482,7 @@ mod tests {
         let result = SyncResult {
             outcome: DownloadOutcome::PartialFailure { failed_count: 3 },
             sync_token: Some("tok".to_string()),
+            stats: SyncStats::default(),
         };
         match result.outcome {
             DownloadOutcome::PartialFailure { failed_count } => {
@@ -1418,6 +1499,7 @@ mod tests {
                 auth_error_count: 5,
             },
             sync_token: None,
+            stats: SyncStats::default(),
         };
         match result.outcome {
             DownloadOutcome::SessionExpired { auth_error_count } => {
@@ -1713,6 +1795,7 @@ mod tests {
             skip_created_after: None,
             pid_file: None,
             notification_script: None,
+            report_json: None,
             watch_with_interval: None,
             retry_delay_secs: 5,
             recent: dl_config.recent,

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -158,7 +158,7 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
     if pending.is_empty() {
         return 0;
     }
-    tracing::info!(count = pending.len(), "Retrying deferred state writes");
+    tracing::debug!(count = pending.len(), "Retrying deferred state writes");
     let mut failures = 0;
     for write in pending {
         let mut succeeded = false;
@@ -213,7 +213,7 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
             "Some state writes could not be saved"
         );
     } else {
-        tracing::info!(count = pending.len(), "All deferred state writes recovered");
+        tracing::debug!(count = pending.len(), "All deferred state writes recovered");
     }
     failures
 }
@@ -410,13 +410,13 @@ where
         let mut trust = stored_hash.as_deref() == Some(&config_hash);
         if !trust {
             if stored_hash.is_some() {
-                tracing::info!("Download config changed since last sync, verifying all files");
+                tracing::debug!("Download config changed since last sync, verifying all files");
                 // Clear stored sync tokens so the next cycle/run falls back to
                 // full enumeration, picking up assets that the old incremental
                 // token would have missed under the new filter settings.
                 match db.delete_metadata_by_prefix("sync_token:").await {
                     Ok(n) if n > 0 => {
-                        tracing::info!(cleared = n, "Cleared stale sync tokens");
+                        tracing::debug!(cleared = n, "Cleared stale sync tokens");
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Failed to clear sync tokens");
@@ -743,7 +743,7 @@ where
         let total_skipped = skips.total();
         if total_skipped > 0 {
             producer_pb.suspend(|| {
-                tracing::info!(
+                tracing::debug!(
                     state = skips.by_state,
                     on_disk = skips.on_disk,
                     ampm_variant = skips.ampm_variant,
@@ -1079,7 +1079,7 @@ pub(super) async fn build_download_outcome(
     );
 
     let fresh_tasks = super::build_download_tasks(albums, config, shutdown_token.clone()).await?;
-    tracing::info!(
+    tracing::debug!(
         count = fresh_tasks.len(),
         "  Re-fetched tasks with fresh URLs"
     );

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -410,7 +410,7 @@ where
         let mut trust = stored_hash.as_deref() == Some(&config_hash);
         if !trust {
             if stored_hash.is_some() {
-                tracing::debug!("Download config changed since last sync, verifying all files");
+                tracing::info!("Download config changed since last sync, verifying all files");
                 // Clear stored sync tokens so the next cycle/run falls back to
                 // full enumeration, picking up assets that the old incremental
                 // token would have missed under the new filter settings.

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -24,7 +24,7 @@ use crate::state::{AssetRecord, StateDb, SyncRunStats};
 use super::error::DownloadError;
 use super::filter::{
     determine_media_type, extract_skip_candidates, filter_asset_to_tasks, is_asset_filtered,
-    pre_ensure_asset_dir, DownloadTask, NormalizedPath,
+    pre_ensure_asset_dir, DownloadTask, FilterReason, NormalizedPath,
 };
 use super::{paths, DownloadConfig, DownloadContext, DownloadOutcome};
 
@@ -52,7 +52,11 @@ pub(super) struct ProducerSkipSummary {
     pub(super) by_state: usize,
     pub(super) on_disk: usize,
     pub(super) ampm_variant: usize,
-    pub(super) by_filter: usize,
+    pub(super) by_media_type: usize,
+    pub(super) by_date_range: usize,
+    pub(super) by_live_photo: usize,
+    pub(super) by_filename: usize,
+    pub(super) by_excluded_album: usize,
     pub(super) duplicates: usize,
     pub(super) retry_exhausted: usize,
     pub(super) retry_only: usize,
@@ -63,7 +67,11 @@ impl ProducerSkipSummary {
         self.by_state
             + self.on_disk
             + self.ampm_variant
-            + self.by_filter
+            + self.by_media_type
+            + self.by_date_range
+            + self.by_live_photo
+            + self.by_filename
+            + self.by_excluded_album
             + self.duplicates
             + self.retry_exhausted
             + self.retry_only
@@ -75,10 +83,32 @@ impl std::ops::AddAssign for ProducerSkipSummary {
         self.by_state += rhs.by_state;
         self.on_disk += rhs.on_disk;
         self.ampm_variant += rhs.ampm_variant;
-        self.by_filter += rhs.by_filter;
+        self.by_media_type += rhs.by_media_type;
+        self.by_date_range += rhs.by_date_range;
+        self.by_live_photo += rhs.by_live_photo;
+        self.by_filename += rhs.by_filename;
+        self.by_excluded_album += rhs.by_excluded_album;
         self.duplicates += rhs.duplicates;
         self.retry_exhausted += rhs.retry_exhausted;
         self.retry_only += rhs.retry_only;
+    }
+}
+
+impl From<ProducerSkipSummary> for super::SkipBreakdown {
+    fn from(s: ProducerSkipSummary) -> Self {
+        Self {
+            by_state: s.by_state,
+            on_disk: s.on_disk,
+            by_media_type: s.by_media_type,
+            by_date_range: s.by_date_range,
+            by_live_photo: s.by_live_photo,
+            by_filename: s.by_filename,
+            by_excluded_album: s.by_excluded_album,
+            ampm_variant: s.ampm_variant,
+            duplicates: s.duplicates,
+            retry_exhausted: s.retry_exhausted,
+            retry_only: s.retry_only,
+        }
     }
 }
 
@@ -93,6 +123,8 @@ pub(super) struct StreamingResult {
     pub(super) enumeration_errors: usize,
     pub(super) assets_seen: u64,
     pub(super) skip_summary: ProducerSkipSummary,
+    pub(super) bytes_downloaded: u64,
+    pub(super) disk_bytes_written: u64,
 }
 
 /// Threshold of auth errors before aborting the download pass for re-authentication.
@@ -240,6 +272,8 @@ pub(super) struct PassResult {
     pub(super) failed: Vec<DownloadTask>,
     pub(super) auth_errors: usize,
     pub(super) state_write_failures: usize,
+    pub(super) bytes_downloaded: u64,
+    pub(super) disk_bytes_written: u64,
 }
 
 /// Streaming download pipeline that consumes a pre-built combined stream.
@@ -280,7 +314,7 @@ where
             }
             match result {
                 Ok(asset) => {
-                    if is_asset_filtered(&asset, config) {
+                    if is_asset_filtered(&asset, config).is_some() {
                         continue;
                     }
                     let candidates = extract_skip_candidates(&asset, config);
@@ -327,7 +361,7 @@ where
             }
             match result {
                 Ok(asset) => {
-                    if is_asset_filtered(&asset, config) {
+                    if is_asset_filtered(&asset, config).is_some() {
                         continue;
                     }
                     pre_ensure_asset_dir(&mut dir_cache, &asset, config).await;
@@ -455,6 +489,8 @@ where
     let mut failed: Vec<DownloadTask> = Vec::new();
     let mut auth_errors = 0usize;
     let mut pending_state_writes: Vec<PendingStateWrite> = Vec::new();
+    let mut bytes_downloaded_total: u64 = 0;
+    let mut disk_bytes_total: u64 = 0;
 
     let (task_tx, task_rx) = mpsc::channel::<DownloadTask>(concurrency * 2);
 
@@ -492,8 +528,14 @@ where
 
                     assets_seen_producer.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-                    if is_asset_filtered(&asset, config) {
-                        skips.by_filter += 1;
+                    if let Some(reason) = is_asset_filtered(&asset, config) {
+                        match reason {
+                            FilterReason::ExcludedAlbum => skips.by_excluded_album += 1,
+                            FilterReason::MediaType => skips.by_media_type += 1,
+                            FilterReason::LivePhoto => skips.by_live_photo += 1,
+                            FilterReason::DateRange => skips.by_date_range += 1,
+                            FilterReason::Filename => skips.by_filename += 1,
+                        }
                         producer_pb.inc(1);
                         continue;
                     }
@@ -532,7 +574,7 @@ where
                                 tracing::debug!(error = %e, asset_id = asset.id(), "Failed to touch last_seen for on-disk asset");
                             }
                         }
-                        skips.by_filter += 1;
+                        skips.on_disk += 1;
                         producer_pb.inc(1);
                     } else {
                         let mut disposition = AssetDisposition::Unresolved;
@@ -705,7 +747,11 @@ where
                     state = skips.by_state,
                     on_disk = skips.on_disk,
                     ampm_variant = skips.ampm_variant,
-                    filtered = skips.by_filter,
+                    media_type = skips.by_media_type,
+                    date_range = skips.by_date_range,
+                    live_photo = skips.by_live_photo,
+                    filename = skips.by_filename,
+                    excluded_album = skips.by_excluded_album,
                     duplicates = skips.duplicates,
                     retry_exhausted = skips.retry_exhausted,
                     retry_only = skips.retry_only,
@@ -770,8 +816,10 @@ where
             .to_string();
         pb.set_message(filename);
         match result {
-            Ok((exif_ok, local_checksum, download_checksum)) => {
+            Ok((exif_ok, local_checksum, download_checksum, bytes_dl, disk_bytes)) => {
                 downloaded += 1;
+                bytes_downloaded_total += bytes_dl;
+                disk_bytes_total += disk_bytes;
                 if !exif_ok {
                     exif_failures += 1;
                 }
@@ -911,6 +959,8 @@ where
         enumeration_errors: enum_errors.load(std::sync::atomic::Ordering::Relaxed),
         assets_seen: assets_seen_count,
         skip_summary: producer_skips,
+        bytes_downloaded: bytes_downloaded_total,
+        disk_bytes_written: disk_bytes_total,
     })
 }
 
@@ -924,24 +974,45 @@ pub(super) async fn build_download_outcome(
     streaming_result: StreamingResult,
     started: Instant,
     shutdown_token: CancellationToken,
-) -> Result<DownloadOutcome> {
+) -> Result<(DownloadOutcome, super::SyncStats)> {
     let downloaded = streaming_result.downloaded;
     let mut exif_failures = streaming_result.exif_failures;
     let failed_tasks = streaming_result.failed;
     let auth_errors = streaming_result.auth_errors;
     let mut state_write_failures = streaming_result.state_write_failures;
     let enumeration_errors = streaming_result.enumeration_errors;
-    // Exclude duplicates: they're outside the API's unique-asset count
-    // and would inflate the user-facing total beyond what the API reported.
-    let skipped = streaming_result.skip_summary.total() - streaming_result.skip_summary.duplicates;
+    let skip_breakdown: super::SkipBreakdown = streaming_result.skip_summary.into();
 
     if auth_errors >= AUTH_ERROR_THRESHOLD {
-        return Ok(DownloadOutcome::SessionExpired {
-            auth_error_count: auth_errors,
-        });
+        let stats = super::SyncStats {
+            assets_seen: streaming_result.assets_seen,
+            downloaded,
+            failed: failed_tasks.len(),
+            skipped: skip_breakdown,
+            bytes_downloaded: streaming_result.bytes_downloaded,
+            disk_bytes_written: streaming_result.disk_bytes_written,
+            exif_failures,
+            state_write_failures,
+            enumeration_errors,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: true,
+        };
+        return Ok((
+            DownloadOutcome::SessionExpired {
+                auth_error_count: auth_errors,
+            },
+            stats,
+        ));
     }
 
     if downloaded == 0 && failed_tasks.is_empty() {
+        let stats = super::SyncStats {
+            assets_seen: streaming_result.assets_seen,
+            skipped: skip_breakdown,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: shutdown_token.is_cancelled(),
+            ..super::SyncStats::default()
+        };
         if config.dry_run {
             tracing::info!("── Dry Run Summary ──");
             tracing::info!("  0 files would be downloaded");
@@ -949,10 +1020,18 @@ pub(super) async fn build_download_outcome(
         } else {
             tracing::info!("No new photos to download");
         }
-        return Ok(DownloadOutcome::Success);
+        return Ok((DownloadOutcome::Success, stats));
     }
 
     if config.dry_run {
+        let stats = super::SyncStats {
+            assets_seen: streaming_result.assets_seen,
+            downloaded,
+            skipped: skip_breakdown,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: shutdown_token.is_cancelled(),
+            ..super::SyncStats::default()
+        };
         tracing::info!("── Dry Run Summary ──");
         if shutdown_token.is_cancelled() {
             tracing::info!(scanned = downloaded, "  Interrupted before shutdown");
@@ -961,40 +1040,33 @@ pub(super) async fn build_download_outcome(
         }
         tracing::info!(destination = %config.directory.display(), "  destination");
         tracing::info!(concurrency = config.concurrent_downloads, "  concurrency");
-        return Ok(DownloadOutcome::Success);
+        return Ok((DownloadOutcome::Success, stats));
     }
 
-    let total = downloaded + failed_tasks.len();
-
     if failed_tasks.is_empty() {
-        tracing::info!("── Summary ──");
-        if exif_failures > 0 || state_write_failures > 0 || enumeration_errors > 0 {
-            tracing::info!(
-                downloaded = total,
-                skipped,
-                exif_failures,
-                state_write_failures,
-                enumeration_errors,
-                failed = 0,
-                total = total + skipped,
-                "  sync results"
-            );
-        } else {
-            tracing::info!(
-                downloaded = total,
-                skipped,
-                failed = 0,
-                total = total + skipped,
-                "  sync results"
-            );
-        }
-        tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
+        let stats = super::SyncStats {
+            assets_seen: streaming_result.assets_seen,
+            downloaded,
+            failed: 0,
+            skipped: skip_breakdown,
+            bytes_downloaded: streaming_result.bytes_downloaded,
+            disk_bytes_written: streaming_result.disk_bytes_written,
+            exif_failures,
+            state_write_failures,
+            enumeration_errors,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: shutdown_token.is_cancelled(),
+        };
+        log_sync_summary("\u{2500}\u{2500} Summary \u{2500}\u{2500}", &stats);
         if state_write_failures > 0 || enumeration_errors > 0 || exif_failures > 0 {
-            return Ok(DownloadOutcome::PartialFailure {
-                failed_count: state_write_failures + enumeration_errors + exif_failures,
-            });
+            return Ok((
+                DownloadOutcome::PartialFailure {
+                    failed_count: state_write_failures + enumeration_errors + exif_failures,
+                },
+                stats,
+            ));
         }
-        return Ok(DownloadOutcome::Success);
+        return Ok((DownloadOutcome::Success, stats));
     }
 
     // Phase 2: cleanup pass with fresh CDN URLs
@@ -1020,7 +1092,7 @@ pub(super) async fn build_download_outcome(
         concurrency: cleanup_concurrency,
         no_progress_bar: config.no_progress_bar,
         temp_suffix: config.temp_suffix.clone(),
-        shutdown_token,
+        shutdown_token: shutdown_token.clone(),
         state_db: config.state_db.clone(),
     };
     let pass_result = run_download_pass(pass_config, fresh_tasks).await;
@@ -1032,48 +1104,65 @@ pub(super) async fn build_download_outcome(
     let total_auth_errors = auth_errors + phase2_auth_errors;
 
     if total_auth_errors >= AUTH_ERROR_THRESHOLD {
-        return Ok(DownloadOutcome::SessionExpired {
-            auth_error_count: total_auth_errors,
-        });
+        let stats = super::SyncStats {
+            assets_seen: streaming_result.assets_seen,
+            downloaded,
+            failed: remaining_failed.len(),
+            skipped: skip_breakdown,
+            bytes_downloaded: streaming_result.bytes_downloaded + pass_result.bytes_downloaded,
+            disk_bytes_written: streaming_result.disk_bytes_written
+                + pass_result.disk_bytes_written,
+            exif_failures,
+            state_write_failures,
+            enumeration_errors,
+            elapsed_secs: started.elapsed().as_secs_f64(),
+            interrupted: true,
+        };
+        return Ok((
+            DownloadOutcome::SessionExpired {
+                auth_error_count: total_auth_errors,
+            },
+            stats,
+        ));
     }
 
     let failed = remaining_failed.len();
     let phase2_succeeded = phase2_task_count - failed;
     let succeeded = downloaded + phase2_succeeded;
-    let final_total = succeeded + failed;
-    tracing::info!("── Summary ──");
-    if exif_failures > 0 || state_write_failures > 0 {
-        tracing::info!(
-            downloaded = succeeded,
-            skipped,
-            exif_failures,
-            state_write_failures,
-            failed,
-            total = final_total + skipped,
-            "  sync results"
-        );
-    } else {
-        tracing::info!(
-            downloaded = succeeded,
-            skipped,
-            failed,
-            total = final_total + skipped,
-            "  sync results"
-        );
-    }
-    tracing::info!(elapsed = %format_duration(started.elapsed()), "  completed");
 
+    // Log failed downloads before the summary
     let total_failures = failed + state_write_failures + exif_failures;
     if total_failures > 0 {
         for task in &remaining_failed {
             tracing::error!(asset_id = %task.asset_id, path = %task.download_path.display(), "Download failed");
         }
-        return Ok(DownloadOutcome::PartialFailure {
-            failed_count: total_failures,
-        });
     }
 
-    Ok(DownloadOutcome::Success)
+    let stats = super::SyncStats {
+        assets_seen: streaming_result.assets_seen,
+        downloaded: succeeded,
+        failed,
+        skipped: skip_breakdown,
+        bytes_downloaded: streaming_result.bytes_downloaded + pass_result.bytes_downloaded,
+        disk_bytes_written: streaming_result.disk_bytes_written + pass_result.disk_bytes_written,
+        exif_failures,
+        state_write_failures,
+        enumeration_errors,
+        elapsed_secs: started.elapsed().as_secs_f64(),
+        interrupted: shutdown_token.is_cancelled(),
+    };
+    log_sync_summary("\u{2500}\u{2500} Summary \u{2500}\u{2500}", &stats);
+
+    if total_failures > 0 {
+        return Ok((
+            DownloadOutcome::PartialFailure {
+                failed_count: total_failures,
+            },
+            stats,
+        ));
+    }
+
+    Ok((DownloadOutcome::Success, stats))
 }
 
 /// Execute a download pass over the given tasks, returning any that failed.
@@ -1090,7 +1179,10 @@ pub(super) async fn run_download_pass(
     let concurrency = config.concurrency;
     let temp_suffix: Arc<str> = config.temp_suffix.into();
 
-    type DownloadResult = (DownloadTask, Result<(bool, String, Option<String>)>);
+    type DownloadResult = (
+        DownloadTask,
+        Result<(bool, String, Option<String>, u64, u64)>,
+    );
     let results: Vec<DownloadResult> = stream::iter(tasks)
         .take_while(|_| std::future::ready(!shutdown_token.is_cancelled()))
         .map(|task| {
@@ -1116,10 +1208,14 @@ pub(super) async fn run_download_pass(
     let mut auth_errors = 0usize;
     let mut exif_failures = 0usize;
     let mut pending_state_writes: Vec<PendingStateWrite> = Vec::new();
+    let mut bytes_downloaded_total: u64 = 0;
+    let mut disk_bytes_total: u64 = 0;
 
     for (task, result) in results {
         match &result {
-            Ok((exif_ok, local_checksum, download_checksum)) => {
+            Ok((exif_ok, local_checksum, download_checksum, bytes_dl, disk_bytes)) => {
+                bytes_downloaded_total += bytes_dl;
+                disk_bytes_total += disk_bytes;
                 if !*exif_ok {
                     exif_failures += 1;
                 }
@@ -1196,6 +1292,8 @@ pub(super) async fn run_download_pass(
         failed,
         auth_errors,
         state_write_failures,
+        bytes_downloaded: bytes_downloaded_total,
+        disk_bytes_written: disk_bytes_total,
     }
 }
 
@@ -1209,7 +1307,7 @@ async fn download_single_task(
     retry_config: &RetryConfig,
     set_exif: bool,
     temp_suffix: &str,
-) -> Result<(bool, String, Option<String>)> {
+) -> Result<(bool, String, Option<String>, u64, u64)> {
     if let Some(parent) = task.download_path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
@@ -1233,7 +1331,7 @@ async fn download_single_task(
         matches!(ext.to_ascii_lowercase().as_str(), "jpg" | "jpeg")
     };
 
-    Box::pin(super::file::download_file(
+    let bytes_downloaded = Box::pin(super::file::download_file(
         client,
         &task.url,
         &task.download_path,
@@ -1316,6 +1414,14 @@ async fn download_single_task(
         super::file::rename_part_to_final(part, &task.download_path).await?;
     }
 
+    let disk_bytes = match tokio::fs::metadata(&task.download_path).await {
+        Ok(meta) => meta.len(),
+        Err(e) => {
+            tracing::warn!(path = %task.download_path.display(), error = %e, "Could not stat downloaded file for size tracking");
+            0
+        }
+    };
+
     tracing::debug!(path = %task.download_path.display(), "Downloaded");
 
     // Compute SHA-256 of the final file for local storage and verification.
@@ -1327,7 +1433,13 @@ async fn download_single_task(
     // is verified by size matching (Content-Length + API size field) and
     // magic-byte validation during download instead.
 
-    Ok((exif_ok, local_checksum, download_checksum))
+    Ok((
+        exif_ok,
+        local_checksum,
+        download_checksum,
+        bytes_downloaded,
+        disk_bytes,
+    ))
 }
 
 pub(super) fn format_duration(d: Duration) -> String {
@@ -1343,6 +1455,130 @@ pub(super) fn format_duration(d: Duration) -> String {
     } else {
         format!("{secs}s")
     }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1} GiB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.1} MiB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1} KiB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Log a formatted summary of sync statistics.
+pub(super) fn log_sync_summary(title: &str, stats: &super::SyncStats) {
+    tracing::info!("{title}");
+
+    // Line 1: core counts
+    let skipped = stats.skipped.total() - stats.skipped.duplicates;
+    let total = stats.downloaded + stats.failed + skipped;
+    if skipped > 0 {
+        tracing::info!(
+            "  {downloaded} downloaded, {skipped} skipped, {failed} failed ({total} total)",
+            downloaded = stats.downloaded,
+            failed = stats.failed
+        );
+    } else {
+        tracing::info!(
+            "  {downloaded} downloaded, {failed} failed ({total} total)",
+            downloaded = stats.downloaded,
+            failed = stats.failed
+        );
+    }
+
+    // Line 2: error details (only if any)
+    if stats.exif_failures > 0 || stats.state_write_failures > 0 {
+        tracing::info!(
+            "  {} EXIF write failure(s), {} state write failure(s)",
+            stats.exif_failures,
+            stats.state_write_failures
+        );
+    }
+
+    // Line 3: skip breakdown (only if skips > 0)
+    if skipped > 0 {
+        let mut reasons = Vec::new();
+        if stats.skipped.by_state > 0 {
+            reasons.push(format!("{} already downloaded", stats.skipped.by_state));
+        }
+        if stats.skipped.on_disk > 0 {
+            reasons.push(format!("{} on disk", stats.skipped.on_disk));
+        }
+        if stats.skipped.by_media_type > 0 {
+            reasons.push(format!(
+                "{} filtered by media type",
+                stats.skipped.by_media_type
+            ));
+        }
+        if stats.skipped.by_date_range > 0 {
+            reasons.push(format!(
+                "{} filtered by date range",
+                stats.skipped.by_date_range
+            ));
+        }
+        if stats.skipped.by_live_photo > 0 {
+            reasons.push(format!(
+                "{} filtered (live photo)",
+                stats.skipped.by_live_photo
+            ));
+        }
+        if stats.skipped.by_filename > 0 {
+            reasons.push(format!(
+                "{} filtered by filename",
+                stats.skipped.by_filename
+            ));
+        }
+        if stats.skipped.by_excluded_album > 0 {
+            reasons.push(format!(
+                "{} excluded by album",
+                stats.skipped.by_excluded_album
+            ));
+        }
+        if stats.skipped.ampm_variant > 0 {
+            reasons.push(format!(
+                "{} live photo variants",
+                stats.skipped.ampm_variant
+            ));
+        }
+        if stats.skipped.retry_exhausted > 0 {
+            reasons.push(format!(
+                "{} retries exhausted",
+                stats.skipped.retry_exhausted
+            ));
+        }
+        if stats.skipped.retry_only > 0 {
+            reasons.push(format!(
+                "{} not failed (retry mode)",
+                stats.skipped.retry_only
+            ));
+        }
+        if !reasons.is_empty() {
+            tracing::info!("  Skipped: {}", reasons.join(", "));
+        }
+    }
+
+    // Line 4: transfer stats (only if bytes downloaded)
+    if stats.bytes_downloaded > 0 {
+        if stats.bytes_downloaded == stats.disk_bytes_written {
+            tracing::info!("  Transferred {}", format_bytes(stats.bytes_downloaded));
+        } else {
+            tracing::info!(
+                "  Transferred {}, {} written to disk",
+                format_bytes(stats.bytes_downloaded),
+                format_bytes(stats.disk_bytes_written)
+            );
+        }
+    }
+
+    // Line 5: elapsed
+    tracing::info!(
+        "  Completed in {}",
+        format_duration(Duration::from_secs_f64(stats.elapsed_secs))
+    );
 }
 
 /// Set the modification and access times of a file to the given Unix
@@ -1602,7 +1838,11 @@ mod tests {
             by_state: 10,
             on_disk: 5,
             ampm_variant: 2,
-            by_filter: 1,
+            by_media_type: 1,
+            by_date_range: 0,
+            by_live_photo: 0,
+            by_filename: 0,
+            by_excluded_album: 0,
             duplicates: 3,
             retry_exhausted: 4,
             retry_only: 0,
@@ -1616,7 +1856,11 @@ mod tests {
             by_state: 10,
             on_disk: 5,
             ampm_variant: 2,
-            by_filter: 1,
+            by_media_type: 1,
+            by_date_range: 0,
+            by_live_photo: 0,
+            by_filename: 0,
+            by_excluded_album: 0,
             duplicates: 3,
             retry_exhausted: 4,
             retry_only: 0,
@@ -1625,7 +1869,11 @@ mod tests {
             by_state: 1,
             on_disk: 2,
             ampm_variant: 3,
-            by_filter: 4,
+            by_media_type: 2,
+            by_date_range: 1,
+            by_live_photo: 1,
+            by_filename: 0,
+            by_excluded_album: 0,
             duplicates: 5,
             retry_exhausted: 6,
             retry_only: 7,
@@ -1634,7 +1882,11 @@ mod tests {
         assert_eq!(a.by_state, 11);
         assert_eq!(a.on_disk, 7);
         assert_eq!(a.ampm_variant, 5);
-        assert_eq!(a.by_filter, 5);
+        assert_eq!(a.by_media_type, 3);
+        assert_eq!(a.by_date_range, 1);
+        assert_eq!(a.by_live_photo, 1);
+        assert_eq!(a.by_filename, 0);
+        assert_eq!(a.by_excluded_album, 0);
         assert_eq!(a.duplicates, 8);
         assert_eq!(a.retry_exhausted, 10);
         assert_eq!(a.retry_only, 7);

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -399,7 +399,7 @@ impl PhotoAlbum {
                 raw.div_ceil(ps) * ps
             };
 
-            tracing::info!(
+            tracing::debug!(
                 fetchers = num_fetchers,
                 chunk_size = chunk_size_items,
                 total = total,

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -221,6 +221,13 @@ fn classify_api_error(e: &anyhow::Error) -> RetryAction {
             RetryAction::Abort
         };
     }
+    if let Some(http_err) = e.downcast_ref::<HttpStatusError>() {
+        return if http_err.status == 429 || http_err.status >= 500 {
+            RetryAction::Retry
+        } else {
+            RetryAction::Abort
+        };
+    }
     if let Some(reqwest_err) = e.downcast_ref::<reqwest::Error>() {
         if let Some(status) = reqwest_err.status() {
             if status.as_u16() == 429 || status.as_u16() >= 500 {
@@ -819,5 +826,41 @@ mod tests {
             !transient.should_fallback_to_full(),
             "UnexpectedZoneError should NOT trigger full fallback"
         );
+    }
+
+    #[test]
+    fn classify_http_status_error_retries_5xx() {
+        let err = anyhow::Error::new(HttpStatusError {
+            status: 503,
+            url: "https://example.com".to_string(),
+        });
+        assert!(matches!(classify_api_error(&err), RetryAction::Retry));
+    }
+
+    #[test]
+    fn classify_http_status_error_retries_429() {
+        let err = anyhow::Error::new(HttpStatusError {
+            status: 429,
+            url: "https://example.com".to_string(),
+        });
+        assert!(matches!(classify_api_error(&err), RetryAction::Retry));
+    }
+
+    #[test]
+    fn classify_http_status_error_aborts_4xx() {
+        let err = anyhow::Error::new(HttpStatusError {
+            status: 401,
+            url: "https://example.com".to_string(),
+        });
+        assert!(matches!(classify_api_error(&err), RetryAction::Abort));
+    }
+
+    #[test]
+    fn classify_http_status_error_aborts_403() {
+        let err = anyhow::Error::new(HttpStatusError {
+            status: 403,
+            url: "https://example.com".to_string(),
+        });
+        assert!(matches!(classify_api_error(&err), RetryAction::Abort));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,17 +328,17 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
     let config_required = config_explicitly_set && !can_auto_create;
     let mut toml_config = config::load_toml_config(&config_path, config_required)?;
 
-    // Resolve log level: CLI > TOML > default (warn)
+    // Resolve log level: CLI > TOML > default (info)
     let effective_log_level = cli
         .log_level
         .or_else(|| toml_config.as_ref().and_then(|t| t.log_level))
-        .unwrap_or(types::LogLevel::Warn);
+        .unwrap_or(types::LogLevel::Info);
 
     // Scope debug/info to the app crate so dependency crates stay quieter.
     // Users can override with RUST_LOG env var for full control.
     let filter = match effective_log_level {
         types::LogLevel::Debug => "kei=debug,info",
-        types::LogLevel::Info => "info",
+        types::LogLevel::Info => "kei=info",
         types::LogLevel::Warn => "warn",
         types::LogLevel::Error => "error",
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod icloud;
 mod migration;
 mod notifications;
 mod password;
+mod report;
 mod retry;
 mod setup;
 mod shutdown;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -30,6 +30,63 @@ impl Event {
     }
 }
 
+/// Sync statistics passed to notification scripts as environment variables.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SyncNotificationData {
+    pub assets_seen: u64,
+    pub downloaded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub bytes_downloaded: u64,
+    pub disk_bytes_written: u64,
+    pub elapsed_secs: f64,
+    pub interrupted: bool,
+    pub exif_failures: usize,
+    pub state_write_failures: usize,
+    pub enumeration_errors: usize,
+    // Skip breakdown
+    pub skipped_by_state: usize,
+    pub skipped_on_disk: usize,
+    pub skipped_by_media_type: usize,
+    pub skipped_by_date_range: usize,
+    pub skipped_by_live_photo: usize,
+    pub skipped_by_filename: usize,
+    pub skipped_by_excluded_album: usize,
+    pub skipped_live_photo_variant: usize,
+    pub skipped_duplicates: usize,
+    pub skipped_retry_exhausted: usize,
+    pub skipped_retry_only: usize,
+}
+
+impl From<&crate::download::SyncStats> for SyncNotificationData {
+    fn from(s: &crate::download::SyncStats) -> Self {
+        Self {
+            assets_seen: s.assets_seen,
+            downloaded: s.downloaded,
+            failed: s.failed,
+            skipped: s.skipped.total(),
+            bytes_downloaded: s.bytes_downloaded,
+            disk_bytes_written: s.disk_bytes_written,
+            elapsed_secs: s.elapsed_secs,
+            interrupted: s.interrupted,
+            exif_failures: s.exif_failures,
+            state_write_failures: s.state_write_failures,
+            enumeration_errors: s.enumeration_errors,
+            skipped_by_state: s.skipped.by_state,
+            skipped_on_disk: s.skipped.on_disk,
+            skipped_by_media_type: s.skipped.by_media_type,
+            skipped_by_date_range: s.skipped.by_date_range,
+            skipped_by_live_photo: s.skipped.by_live_photo,
+            skipped_by_filename: s.skipped.by_filename,
+            skipped_by_excluded_album: s.skipped.by_excluded_album,
+            skipped_live_photo_variant: s.skipped.ampm_variant,
+            skipped_duplicates: s.skipped.duplicates,
+            skipped_retry_exhausted: s.skipped.retry_exhausted,
+            skipped_retry_only: s.skipped.retry_only,
+        }
+    }
+}
+
 /// Notification dispatcher. Holds an optional script path.
 /// When no script is configured, all methods are no-ops.
 #[derive(Debug, Clone)]
@@ -47,7 +104,13 @@ impl Notifier {
 
     /// Fire the notification script with the given event.
     /// Fire-and-forget: spawns the script in a background task so it never blocks sync.
-    pub fn notify(&self, event: Event, message: &str, username: &str) {
+    pub fn notify(
+        &self,
+        event: Event,
+        message: &str,
+        username: &str,
+        data: Option<&SyncNotificationData>,
+    ) {
         let Some(script) = self.script.clone() else {
             return;
         };
@@ -63,11 +126,12 @@ impl Notifier {
         let event_str = event.as_str();
         let message = message.to_owned();
         let username = username.to_owned();
+        let data = data.cloned();
 
         tracing::debug!(event = event_str, "Firing notification script");
 
         tokio::spawn(async move {
-            match run_script(&script, event_str, &message, &username).await {
+            match run_script(&script, event_str, &message, &username, data.as_ref()).await {
                 Ok(status) if status.success() => {
                     tracing::debug!(event = event_str, "Notification script completed");
                 }
@@ -95,19 +159,67 @@ async fn run_script(
     event: &str,
     message: &str,
     username: &str,
+    data: Option<&SyncNotificationData>,
 ) -> anyhow::Result<std::process::ExitStatus> {
     // Execute via /bin/sh to avoid ETXTBSY ("Text file busy") races when
     // the script file was recently written or replaced (e.g. config reload,
     // `kei setup`, parallel tests). Scripts with shebangs work fine via sh.
-    let mut child = tokio::process::Command::new("/bin/sh")
-        .arg(script)
+    let mut cmd = tokio::process::Command::new("/bin/sh");
+    cmd.arg(script)
         .env("KEI_EVENT", event)
         .env("KEI_MESSAGE", message)
         .env("KEI_ICLOUD_USERNAME", username)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()?;
+        .stderr(std::process::Stdio::inherit());
+
+    if let Some(d) = data {
+        cmd.env("KEI_ASSETS_SEEN", d.assets_seen.to_string())
+            .env("KEI_DOWNLOADED", d.downloaded.to_string())
+            .env("KEI_FAILED", d.failed.to_string())
+            .env("KEI_SKIPPED", d.skipped.to_string())
+            .env("KEI_INTERRUPTED", d.interrupted.to_string())
+            .env("KEI_BYTES_DOWNLOADED", d.bytes_downloaded.to_string())
+            .env("KEI_DISK_BYTES", d.disk_bytes_written.to_string())
+            .env("KEI_ELAPSED_SECS", format!("{:.1}", d.elapsed_secs))
+            .env("KEI_EXIF_FAILURES", d.exif_failures.to_string())
+            .env(
+                "KEI_STATE_WRITE_FAILURES",
+                d.state_write_failures.to_string(),
+            )
+            .env("KEI_ENUMERATION_ERRORS", d.enumeration_errors.to_string())
+            .env("KEI_SKIPPED_BY_STATE", d.skipped_by_state.to_string())
+            .env("KEI_SKIPPED_ON_DISK", d.skipped_on_disk.to_string())
+            .env(
+                "KEI_SKIPPED_BY_MEDIA_TYPE",
+                d.skipped_by_media_type.to_string(),
+            )
+            .env(
+                "KEI_SKIPPED_BY_DATE_RANGE",
+                d.skipped_by_date_range.to_string(),
+            )
+            .env(
+                "KEI_SKIPPED_BY_LIVE_PHOTO",
+                d.skipped_by_live_photo.to_string(),
+            )
+            .env("KEI_SKIPPED_BY_FILENAME", d.skipped_by_filename.to_string())
+            .env(
+                "KEI_SKIPPED_BY_EXCLUDED_ALBUM",
+                d.skipped_by_excluded_album.to_string(),
+            )
+            .env(
+                "KEI_SKIPPED_LIVE_PHOTO_VARIANT",
+                d.skipped_live_photo_variant.to_string(),
+            )
+            .env("KEI_SKIPPED_DUPLICATES", d.skipped_duplicates.to_string())
+            .env(
+                "KEI_SKIPPED_RETRY_EXHAUSTED",
+                d.skipped_retry_exhausted.to_string(),
+            )
+            .env("KEI_SKIPPED_RETRY_ONLY", d.skipped_retry_only.to_string());
+    }
+
+    let mut child = cmd.spawn()?;
 
     if let Ok(result) = tokio::time::timeout(SCRIPT_TIMEOUT, child.wait()).await {
         Ok(result?)
@@ -143,7 +255,12 @@ mod tests {
     fn notify_with_nonexistent_script() {
         let notifier = Notifier::new(Some(PathBuf::from("/tmp/claude/nonexistent_notify.sh")));
         // Should not panic, just log a warning (script existence checked synchronously)
-        notifier.notify(Event::SyncComplete, "test message", "user@example.com");
+        notifier.notify(
+            Event::SyncComplete,
+            "test message",
+            "user@example.com",
+            None,
+        );
     }
 
     /// Write a shell script to a temp dir. No executable permission needed
@@ -161,7 +278,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let script = write_test_script(dir.path(), "success.sh", b"#!/bin/sh\nexit 0\n");
 
-        let status = run_script(&script, "test_event", "msg", "user")
+        let status = run_script(&script, "test_event", "msg", "user", None)
             .await
             .unwrap();
         assert!(status.success());
@@ -173,7 +290,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let script = write_test_script(dir.path(), "fail.sh", b"#!/bin/sh\nexit 1\n");
 
-        let status = run_script(&script, "test_event", "msg", "user")
+        let status = run_script(&script, "test_event", "msg", "user", None)
             .await
             .unwrap();
         assert!(!status.success());
@@ -191,7 +308,12 @@ mod tests {
         let script_path = write_test_script(dir.path(), "test_notify.sh", body.as_bytes());
 
         let notifier = Notifier::new(Some(script_path.clone()));
-        notifier.notify(Event::TwoFaRequired, "Need 2FA code", "test@example.com");
+        notifier.notify(
+            Event::TwoFaRequired,
+            "Need 2FA code",
+            "test@example.com",
+            None,
+        );
 
         // Wait for the spawned background task to complete (poll instead of fixed sleep)
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
@@ -208,5 +330,74 @@ mod tests {
 
         let output = std::fs::read_to_string(&output_path).unwrap();
         assert_eq!(output.trim(), "2fa_required|Need 2FA code|test@example.com");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn notify_with_sync_data_sets_extended_env_vars() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("test_data_output.txt");
+        let body = format!(
+            "#!/bin/sh\necho \"$KEI_DOWNLOADED|$KEI_FAILED|$KEI_SKIPPED|$KEI_BYTES_DOWNLOADED|$KEI_SKIPPED_BY_STATE\" > {}\n",
+            output_path.display()
+        );
+        let script_path = write_test_script(dir.path(), "test_data.sh", body.as_bytes());
+
+        let data = SyncNotificationData {
+            downloaded: 42,
+            failed: 3,
+            skipped: 100,
+            bytes_downloaded: 1_500_000,
+            skipped_by_state: 80,
+            ..SyncNotificationData::default()
+        };
+
+        let notifier = Notifier::new(Some(script_path));
+        notifier.notify(Event::SyncComplete, "test", "user@example.com", Some(&data));
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if output_path.exists() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "notification script did not produce output"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let output = std::fs::read_to_string(&output_path).unwrap();
+        assert_eq!(output.trim(), "42|3|100|1500000|80");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn notify_without_data_omits_extended_vars() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("test_no_data.txt");
+        let body = format!(
+            "#!/bin/sh\necho \"${{KEI_DOWNLOADED:-unset}}|${{KEI_FAILED:-unset}}\" > {}\n",
+            output_path.display()
+        );
+        let script_path = write_test_script(dir.path(), "test_no_data.sh", body.as_bytes());
+
+        let notifier = Notifier::new(Some(script_path));
+        notifier.notify(Event::SyncComplete, "test", "user@example.com", None);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if output_path.exists() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "notification script did not produce output"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let output = std::fs::read_to_string(&output_path).unwrap();
+        assert_eq!(output.trim(), "unset|unset");
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,189 @@
+//! JSON sync report generation.
+//!
+//! Writes a structured JSON summary after each sync cycle for machine consumption
+//! (monitoring tools, Home Assistant, webhooks).
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::download::SyncStats;
+
+/// Top-level JSON report written after each sync cycle.
+#[derive(Debug, Serialize)]
+pub(crate) struct SyncReport {
+    /// Schema version for forward compatibility.
+    pub version: &'static str,
+    /// kei binary version.
+    pub kei_version: &'static str,
+    /// ISO 8601 timestamp of when the report was generated.
+    pub timestamp: String,
+    /// Sync outcome: "success", "partial_failure", or "session_expired".
+    pub status: String,
+    /// CLI/config options the sync was invoked with.
+    pub options: RunOptions,
+    /// Accumulated sync statistics.
+    pub stats: SyncStats,
+}
+
+/// User-facing options captured from the resolved Config. No secrets.
+#[derive(Debug, Serialize)]
+pub(crate) struct RunOptions {
+    pub username: String,
+    pub directory: PathBuf,
+    pub folder_structure: String,
+    pub size: String,
+    pub live_photo_mode: String,
+    pub live_photo_size: String,
+    pub file_match_policy: String,
+    pub albums: Vec<String>,
+    pub library: String,
+    pub skip_videos: bool,
+    pub skip_photos: bool,
+    pub set_exif_datetime: bool,
+    pub threads_num: u16,
+    pub no_incremental: bool,
+    pub dry_run: bool,
+}
+
+impl RunOptions {
+    /// Build from the resolved Config. Only includes user-facing settings.
+    pub(crate) fn from_config(config: &crate::config::Config) -> Self {
+        Self {
+            username: config.username.clone(),
+            directory: config.directory.clone(),
+            folder_structure: config.folder_structure.clone(),
+            size: format!("{:?}", config.size).to_lowercase(),
+            live_photo_mode: format!("{:?}", config.live_photo_mode).to_lowercase(),
+            live_photo_size: format!("{:?}", config.live_photo_size).to_lowercase(),
+            file_match_policy: format!("{:?}", config.file_match_policy).to_lowercase(),
+            albums: config.albums.clone(),
+            library: format!("{:?}", config.library).to_lowercase(),
+            skip_videos: config.skip_videos,
+            skip_photos: config.skip_photos,
+            set_exif_datetime: config.set_exif_datetime,
+            threads_num: config.threads_num,
+            no_incremental: config.no_incremental,
+            dry_run: config.dry_run,
+        }
+    }
+}
+
+/// Write a JSON report to the given path atomically (temp file + rename).
+pub(crate) fn write_report(path: &Path, report: &SyncReport) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(report)?;
+
+    // Write to a temp file in the same directory, then rename for atomicity.
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let temp_path = parent.join(format!(".kei-report-{}.tmp", std::process::id()));
+
+    std::fs::write(&temp_path, json.as_bytes())?;
+    std::fs::rename(&temp_path, path).or_else(|_| {
+        // Cross-device rename fallback: copy + remove
+        std::fs::copy(&temp_path, path)?;
+        std::fs::remove_file(&temp_path).ok();
+        Ok::<(), std::io::Error>(())
+    })?;
+
+    tracing::debug!(path = %path.display(), "Wrote JSON report");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::download::SkipBreakdown;
+
+    #[test]
+    fn report_serialization_roundtrip() {
+        let report = SyncReport {
+            version: "1",
+            kei_version: "0.7.12",
+            timestamp: "2026-04-15T12:00:00Z".to_string(),
+            status: "success".to_string(),
+            options: RunOptions {
+                username: "user@example.com".to_string(),
+                directory: PathBuf::from("/photos"),
+                folder_structure: "{:%Y/%m/%d}".to_string(),
+                size: "original".to_string(),
+                live_photo_mode: "original".to_string(),
+                live_photo_size: "original".to_string(),
+                file_match_policy: "name-size-dedup".to_string(),
+                albums: vec!["Favorites".to_string()],
+                library: "personal".to_string(),
+                skip_videos: false,
+                skip_photos: false,
+                set_exif_datetime: true,
+                threads_num: 4,
+                no_incremental: false,
+                dry_run: false,
+            },
+            stats: SyncStats {
+                assets_seen: 400,
+                downloaded: 50,
+                failed: 2,
+                skipped: SkipBreakdown {
+                    by_state: 300,
+                    on_disk: 30,
+                    by_media_type: 10,
+                    by_date_range: 5,
+                    ..SkipBreakdown::default()
+                },
+                bytes_downloaded: 1_200_000_000,
+                disk_bytes_written: 1_300_000_000,
+                elapsed_secs: 263.5,
+                ..SyncStats::default()
+            },
+        };
+
+        let json = serde_json::to_string_pretty(&report).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+
+        assert_eq!(parsed["version"], "1");
+        assert_eq!(parsed["status"], "success");
+        assert_eq!(parsed["stats"]["downloaded"], 50);
+        assert_eq!(parsed["stats"]["skipped"]["by_state"], 300);
+        assert_eq!(parsed["options"]["username"], "user@example.com");
+        assert!(parsed["options"]["set_exif_datetime"]
+            .as_bool()
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn write_report_creates_valid_json_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("report.json");
+
+        let report = SyncReport {
+            version: "1",
+            kei_version: "0.7.12",
+            timestamp: "2026-04-15T12:00:00Z".to_string(),
+            status: "success".to_string(),
+            options: RunOptions {
+                username: "test@example.com".to_string(),
+                directory: PathBuf::from("/tmp/photos"),
+                folder_structure: "{:%Y/%m/%d}".to_string(),
+                size: "original".to_string(),
+                live_photo_mode: "original".to_string(),
+                live_photo_size: "original".to_string(),
+                file_match_policy: "name-size-dedup".to_string(),
+                albums: vec![],
+                library: "personal".to_string(),
+                skip_videos: false,
+                skip_photos: false,
+                set_exif_datetime: false,
+                threads_num: 3,
+                no_incremental: false,
+                dry_run: false,
+            },
+            stats: SyncStats::default(),
+        };
+
+        write_report(&path, &report).expect("write_report");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+        assert_eq!(parsed["version"], "1");
+        assert_eq!(parsed["options"]["username"], "test@example.com");
+    }
+}

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -140,7 +140,7 @@ fn migrate_to_version(conn: &Connection, version: i32) -> Result<(), StateError>
         }
     }
     set_schema_version(conn, version)?;
-    tracing::debug!(version, "Migrated database schema");
+    tracing::info!(version, "Migrated database schema");
     Ok(())
 }
 

--- a/src/state/schema.rs
+++ b/src/state/schema.rs
@@ -140,7 +140,7 @@ fn migrate_to_version(conn: &Connection, version: i32) -> Result<(), StateError>
         }
     }
     set_schema_version(conn, version)?;
-    tracing::info!(version, "Migrated database schema");
+    tracing::debug!(version, "Migrated database schema");
     Ok(())
 }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -478,7 +478,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 .await
                 {
                     Ok(()) => {
-                        tracing::debug!("Re-auth successful, resuming download...");
+                        tracing::info!("Re-auth successful, resuming download...");
                         continue; // Restart entire cycle
                     }
                     Err(e)
@@ -676,7 +676,7 @@ async fn run_cycle(
                 let stored_hash = db.get_metadata("enum_config_hash").await.unwrap_or(None);
                 if stored_hash.as_deref() != Some(&config_hash) {
                     if stored_hash.is_some() {
-                        tracing::debug!(
+                        tracing::info!(
                             "Download config changed since last sync, clearing sync tokens"
                         );
                         match db.delete_metadata_by_prefix("sync_token:").await {
@@ -750,7 +750,7 @@ async fn run_cycle(
                 }
             }
         } else if sync_result.sync_token.is_some() {
-            tracing::debug!(
+            tracing::info!(
                 zone = %lib_state.zone_name,
                 "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
             );

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -249,7 +249,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 
     // Resolve the selected library/libraries
     let libraries = resolve_libraries(&config.library, &mut photos_service).await?;
-    tracing::info!(
+    tracing::debug!(
         count = libraries.len(),
         zones = %libraries.iter().map(|l| l.zone_name().to_string()).collect::<Vec<_>>().join(", "),
         "Resolved libraries"
@@ -275,11 +275,11 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 if is_retry_failed {
                     match db.reset_failed().await {
                         Ok(0) => {
-                            tracing::info!("No failed assets to retry");
+                            tracing::debug!("No failed assets to retry");
                             return Ok(());
                         }
                         Ok(count) => {
-                            tracing::info!(count, "Reset failed assets to pending");
+                            tracing::debug!(count, "Reset failed assets to pending");
                         }
                         Err(e) => {
                             tracing::warn!("Failed to reset failed assets: {e}");
@@ -311,7 +311,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 }
             }
             if cleared_ok {
-                tracing::info!("Cleared stored sync tokens");
+                tracing::debug!("Cleared stored sync tokens");
             }
         }
     }
@@ -478,7 +478,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 .await
                 {
                     Ok(()) => {
-                        tracing::info!("Re-auth successful, resuming download...");
+                        tracing::debug!("Re-auth successful, resuming download...");
                         continue; // Restart entire cycle
                     }
                     Err(e)
@@ -676,12 +676,12 @@ async fn run_cycle(
                 let stored_hash = db.get_metadata("enum_config_hash").await.unwrap_or(None);
                 if stored_hash.as_deref() != Some(&config_hash) {
                     if stored_hash.is_some() {
-                        tracing::info!(
+                        tracing::debug!(
                             "Download config changed since last sync, clearing sync tokens"
                         );
                         match db.delete_metadata_by_prefix("sync_token:").await {
                             Ok(n) if n > 0 => {
-                                tracing::info!(cleared = n, "Cleared stale sync tokens");
+                                tracing::debug!(cleared = n, "Cleared stale sync tokens");
                             }
                             Err(e) => {
                                 tracing::warn!(
@@ -745,12 +745,12 @@ async fn run_cycle(
                     if let Err(e) = db.set_metadata(&lib_state.sync_token_key, token).await {
                         tracing::warn!(error = %e, "Failed to store sync token");
                     } else {
-                        tracing::info!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
+                        tracing::debug!(zone = %lib_state.zone_name, "Stored sync token for next incremental sync");
                     }
                 }
             }
         } else if sync_result.sync_token.is_some() {
-            tracing::info!(
+            tracing::debug!(
                 zone = %lib_state.zone_name,
                 "Sync token NOT advanced (incomplete sync -- will replay changes next cycle)"
             );
@@ -872,12 +872,12 @@ async fn determine_sync_mode(
 ) -> download::SyncMode {
     if is_retry_failed || no_incremental {
         if no_incremental && library_count == 1 {
-            tracing::info!(
+            tracing::debug!(
                 "Incremental sync disabled via --no-incremental, performing full enumeration"
             );
         }
         if is_retry_failed {
-            tracing::info!(
+            tracing::debug!(
                 "Retry-failed requires full enumeration to find previously-failed assets"
             );
         }
@@ -885,13 +885,13 @@ async fn determine_sync_mode(
     } else if let Some(db) = state_db {
         match db.get_metadata(sync_token_key).await {
             Ok(Some(ref token)) if !token.is_empty() => {
-                tracing::info!(zone = %zone_name, "Stored sync token found, using incremental sync");
+                tracing::debug!(zone = %zone_name, "Stored sync token found, using incremental sync");
                 download::SyncMode::Incremental {
                     zone_sync_token: token.clone(),
                 }
             }
             Ok(_) => {
-                tracing::info!(zone = %zone_name, "No sync token found, performing full enumeration");
+                tracing::debug!(zone = %zone_name, "No sync token found, performing full enumeration");
                 download::SyncMode::Full
             }
             Err(e) => {

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -195,7 +195,12 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 u = config.username
             );
             tracing::warn!(message = %msg, "2FA required");
-            notifier.notify(notifications::Event::TwoFaRequired, &msg, &config.username);
+            notifier.notify(
+                notifications::Event::TwoFaRequired,
+                &msg,
+                &config.username,
+                None,
+            );
 
             wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
                 auth::authenticate(
@@ -428,6 +433,28 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             }
             health.write(&config.cookie_directory);
 
+            // Write JSON report if configured
+            if let Some(report_path) = &config.report_json {
+                let status = if cycle_result.session_expired {
+                    "session_expired"
+                } else if cycle_result.failed_count > 0 {
+                    "partial_failure"
+                } else {
+                    "success"
+                };
+                let report = crate::report::SyncReport {
+                    version: "1",
+                    kei_version: env!("CARGO_PKG_VERSION"),
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    status: status.to_string(),
+                    options: crate::report::RunOptions::from_config(&config),
+                    stats: cycle_result.stats.clone(),
+                };
+                if let Err(e) = crate::report::write_report(report_path, &report) {
+                    tracing::warn!(error = %e, path = %report_path.display(), "Failed to write JSON report");
+                }
+            }
+
             // Handle aggregate outcome across all libraries
             if cycle_result.session_expired {
                 reauth_attempts += 1;
@@ -472,6 +499,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                             notifications::Event::TwoFaRequired,
                             &msg,
                             &config.username,
+                            None,
                         );
                         if !is_watch_mode {
                             return Err(e);
@@ -494,15 +522,18 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                             notifications::Event::SessionExpired,
                             &format!("Re-authentication failed: {e}"),
                             &config.username,
+                            None,
                         );
                         return Err(e);
                     }
                 }
             } else if cycle_result.failed_count > 0 {
+                let data = notifications::SyncNotificationData::from(&cycle_result.stats);
                 notifier.notify(
                     notifications::Event::SyncFailed,
                     &format!("{} downloads failed", cycle_result.failed_count),
                     &config.username,
+                    Some(&data),
                 );
                 if is_watch_mode {
                     tracing::warn!(
@@ -516,10 +547,12 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             } else {
                 reauth_attempts = 0;
                 last_cycle_failed_count = 0;
+                let data = notifications::SyncNotificationData::from(&cycle_result.stats);
                 notifier.notify(
                     notifications::Event::SyncComplete,
                     "Sync completed successfully",
                     &config.username,
+                    Some(&data),
                 );
             }
         }
@@ -601,6 +634,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
 struct CycleResult {
     failed_count: usize,
     session_expired: bool,
+    stats: download::SyncStats,
 }
 
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.
@@ -618,6 +652,7 @@ async fn run_cycle(
 ) -> anyhow::Result<CycleResult> {
     let mut cycle_failed_count = 0usize;
     let mut cycle_session_expired = false;
+    let mut cycle_stats = download::SyncStats::default();
 
     for lib_state in library_states {
         if shutdown_token.is_cancelled() {
@@ -721,6 +756,29 @@ async fn run_cycle(
             );
         }
 
+        // Accumulate stats across libraries
+        cycle_stats.assets_seen += sync_result.stats.assets_seen;
+        cycle_stats.downloaded += sync_result.stats.downloaded;
+        cycle_stats.failed += sync_result.stats.failed;
+        cycle_stats.bytes_downloaded += sync_result.stats.bytes_downloaded;
+        cycle_stats.disk_bytes_written += sync_result.stats.disk_bytes_written;
+        cycle_stats.exif_failures += sync_result.stats.exif_failures;
+        cycle_stats.state_write_failures += sync_result.stats.state_write_failures;
+        cycle_stats.enumeration_errors += sync_result.stats.enumeration_errors;
+        cycle_stats.elapsed_secs += sync_result.stats.elapsed_secs;
+        cycle_stats.interrupted = cycle_stats.interrupted || sync_result.stats.interrupted;
+        cycle_stats.skipped.by_state += sync_result.stats.skipped.by_state;
+        cycle_stats.skipped.on_disk += sync_result.stats.skipped.on_disk;
+        cycle_stats.skipped.by_media_type += sync_result.stats.skipped.by_media_type;
+        cycle_stats.skipped.by_date_range += sync_result.stats.skipped.by_date_range;
+        cycle_stats.skipped.by_live_photo += sync_result.stats.skipped.by_live_photo;
+        cycle_stats.skipped.by_filename += sync_result.stats.skipped.by_filename;
+        cycle_stats.skipped.by_excluded_album += sync_result.stats.skipped.by_excluded_album;
+        cycle_stats.skipped.ampm_variant += sync_result.stats.skipped.ampm_variant;
+        cycle_stats.skipped.duplicates += sync_result.stats.skipped.duplicates;
+        cycle_stats.skipped.retry_exhausted += sync_result.stats.skipped.retry_exhausted;
+        cycle_stats.skipped.retry_only += sync_result.stats.skipped.retry_only;
+
         match sync_result.outcome {
             download::DownloadOutcome::Success => {}
             download::DownloadOutcome::SessionExpired { auth_error_count } => {
@@ -741,6 +799,7 @@ async fn run_cycle(
     Ok(CycleResult {
         failed_count: cycle_failed_count,
         session_expired: cycle_session_expired,
+        stats: cycle_stats,
     })
 }
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -275,7 +275,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 if is_retry_failed {
                     match db.reset_failed().await {
                         Ok(0) => {
-                            tracing::debug!("No failed assets to retry");
+                            tracing::info!("No failed assets to retry");
                             return Ok(());
                         }
                         Ok(count) => {

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2159,7 +2159,7 @@ fn exit_1_for_missing_username_on_sync() {
 #[test]
 fn log_level_default_info() {
     let dir = tempfile::tempdir().unwrap();
-    // sync with username + directory will fail at auth. Check stderr for WARN.
+    // sync with username + directory will fail at auth. Check stderr for INFO.
     let out = clean_cmd()
         .args([
             "sync",
@@ -2175,10 +2175,18 @@ fn log_level_default_info() {
         .get_output()
         .clone();
     let stderr = String::from_utf8_lossy(&out.stderr);
-    // Default level is WARN; INFO-level messages like "Starting kei" should not appear.
+    // Default level is INFO; "Starting kei" should appear but DEBUG should not.
     assert!(
-        !stderr.contains("INFO") && !stderr.contains("info"),
-        "default log level should suppress INFO-level messages, stderr: {stderr}"
+        stderr.contains("Starting kei"),
+        "default log level should show INFO-level messages like 'Starting kei', stderr: {stderr}"
+    );
+    let has_debug = stderr.lines().any(|line| {
+        let lower = line.to_lowercase();
+        lower.contains(" debug ") && !line.starts_with("Error:")
+    });
+    assert!(
+        !has_debug,
+        "default log level should suppress DEBUG-level messages, stderr: {stderr}"
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1160,3 +1160,22 @@ fn submit_code_fails_without_username() {
         .failure()
         .stderr(predicate::str::contains("error").or(predicate::str::contains("required")));
 }
+
+// ── --report-json ────────────────────────────────────────────────────
+
+#[test]
+fn report_json_flag_accepted() {
+    common::cmd()
+        .args(["sync", "--report-json", "/tmp/report.json", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn report_json_visible_in_help() {
+    common::cmd()
+        .args(["sync", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--report-json"));
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -101,7 +101,14 @@ fn require_creds() -> (String, String) {
 pub fn cookie_dir() -> PathBuf {
     init_env();
     let dir = if let Ok(dir) = std::env::var("ICLOUD_TEST_COOKIE_DIR") {
-        PathBuf::from(dir)
+        // Expand ~ since not all shells do it for env vars (e.g. fish)
+        if let Some(rest) = dir.strip_prefix("~/") {
+            dirs::home_dir()
+                .expect("could not determine home directory")
+                .join(rest)
+        } else {
+            PathBuf::from(dir)
+        }
     } else {
         let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         manifest.join(".test-cookies")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -119,23 +119,30 @@ pub fn cookie_dir() -> PathBuf {
 fn ensure_session(username: &str, password: &str, cookie_dir: &Path) {
     static ENSURED: OnceLock<()> = OnceLock::new();
     ENSURED.get_or_init(|| {
-        // Skip SRP if session file is fresh (< 1 hour old). This avoids
-        // burning rate-limit budget on every test run when cookies are valid.
+        // Skip SRP if session file is fresh AND the cookie file contains
+        // the WEBAUTH-TOKEN cookie (set only after 2FA trust is established).
+        // Without this check, a session that lost trust (e.g., after a 421
+        // storm) would be considered "fresh" but fail with 2FA required.
         let sanitized: String = username
             .chars()
             .filter(|c| c.is_ascii_alphanumeric())
             .collect();
         let session_file = cookie_dir.join(format!("{sanitized}.session"));
-        if let Ok(meta) = std::fs::metadata(&session_file) {
-            let is_fresh = meta
-                .modified()
-                .ok()
-                .and_then(|m| m.elapsed().ok())
-                .is_some_and(|age| age < std::time::Duration::from_secs(48 * 3600));
-            if is_fresh {
-                eprintln!("Session file is fresh, skipping SRP validation.");
-                return;
-            }
+        let cookie_file = cookie_dir.join(&sanitized);
+        let session_fresh = std::fs::metadata(&session_file)
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|m| m.elapsed().ok())
+            .is_some_and(|age| age < std::time::Duration::from_secs(48 * 3600));
+        let has_trust_cookie = std::fs::read_to_string(&cookie_file)
+            .ok()
+            .is_some_and(|c| c.contains("X-APPLE-WEBAUTH-TOKEN"));
+        if session_fresh && has_trust_cookie {
+            eprintln!("Session file is fresh and trusted, skipping SRP validation.");
+            return;
+        }
+        if session_fresh && !has_trust_cookie {
+            eprintln!("Session file is fresh but missing trust cookie, re-validating...");
         }
 
         eprintln!("Validating authentication session (login)...");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -161,14 +161,38 @@ fn ensure_session(username: &str, password: &str, cookie_dir: &Path) {
             .expect("failed to run login session validation");
 
         if output.status.success() {
-            eprintln!("Session OK.");
-            return;
+            // Verify the login actually established trust (not just SRP success
+            // without 2FA completion).
+            let has_token = std::fs::read_to_string(&cookie_file)
+                .ok()
+                .is_some_and(|c| c.contains("X-APPLE-WEBAUTH-TOKEN"));
+            if has_token {
+                eprintln!("Session OK.");
+                return;
+            }
+            eprintln!(
+                "Login succeeded but session is not trusted (missing X-APPLE-WEBAUTH-TOKEN).\n\
+                 Complete 2FA first: kei login get-code --username {username} --data-dir {}\n\
+                 Or set ICLOUD_TEST_COOKIE_DIR to a directory with a trusted session.",
+                cookie_dir.display()
+            );
+            std::process::exit(1);
         }
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains(RATE_LIMIT_MARKER) {
             RATE_LIMITED.store(true, Ordering::SeqCst);
             eprintln!("\n*** ABORTING: Apple 503 rate limit during session validation ***");
+            std::process::exit(1);
+        }
+
+        if stderr.contains("2FA") || stderr.contains("Two-factor") {
+            eprintln!(
+                "\n*** ABORTING: 2FA required but not available in test mode ***\n\
+                 Complete 2FA first: kei login get-code --username {username} --data-dir {}\n\
+                 Or set ICLOUD_TEST_COOKIE_DIR to a directory with a trusted session.",
+                cookie_dir.display()
+            );
             std::process::exit(1);
         }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -100,11 +100,14 @@ fn require_creds() -> (String, String) {
 #[allow(dead_code)]
 pub fn cookie_dir() -> PathBuf {
     init_env();
-    if let Ok(dir) = std::env::var("ICLOUD_TEST_COOKIE_DIR") {
-        return PathBuf::from(dir);
-    }
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest.join(".test-cookies")
+    let dir = if let Ok(dir) = std::env::var("ICLOUD_TEST_COOKIE_DIR") {
+        PathBuf::from(dir)
+    } else {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest.join(".test-cookies")
+    };
+    std::fs::create_dir_all(&dir).expect("create cookie dir");
+    dir
 }
 
 /// Run `--auth-only` once to ensure the session cookies are fresh.

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -129,8 +129,10 @@ fn retry_failed_cmd(
 }
 
 fn db_file_count(dir: &Path) -> usize {
-    std::fs::read_dir(dir)
-        .expect("read dir")
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.path()

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -653,7 +653,7 @@ fn reset_sync_token_forces_full_enumeration() {
 
         // Second sync should do full enumeration (no stored token)
         let output = sync_cmd(&username, &password, &cookie_dir, download_dir.path(), 2)
-            .args(["--log-level", "info"])
+            .args(["--log-level", "debug"])
             .timeout(Duration::from_secs(TIMEOUT_SYNC))
             .output()
             .unwrap();

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1055,7 +1055,7 @@ fn sync_incremental_second_run_skips_download() {
                 download_dir.path().to_str().unwrap(),
                 "--no-progress-bar",
                 "--log-level",
-                "info",
+                "debug",
             ])
             .timeout(Duration::from_secs(TIMEOUT_SECS))
             .output()


### PR DESCRIPTION
Closes #195. Closes #196. Closes #197. Closes #198. Closes #212. Closes #217.

## Summary

- `--report-json <path>` writes a structured JSON file after each sync cycle with schema version, CLI options, stats, and per-reason skip breakdown. In watch mode, each cycle overwrites the same file.
- Bytes downloaded and disk bytes written are now tracked through the download pipeline. `attempt_download` returns its byte count (already computed locally, was just discarded), and `fs::metadata` on the final file captures post-EXIF on-disk size.
- `is_asset_filtered` returns `Option<FilterReason>` instead of `bool`. Skip reasons are broken out into media type, date range, live photo, filename, and excluded album - both in the summary log and in the JSON report.
- Notification scripts get 21 new `KEI_*` env vars (core counts, transfer stats, error details, full skip breakdown). Absent for non-sync events (2FA, session expired), so existing scripts don't break.
- Summary log is now plain English instead of structured key=value tracing fields.

## 421 resilience (#217)

Reordered the 421 Misdirected Request recovery in two layers:

**Auth layer (`authenticate`):** When both `/validate` and `/accountLogin` return 421, fall back to cached auth data (no time limit) instead of SRP. A 421 is a routing error, not a credentials error - the session is likely still valid. CloudKit will discover any real auth failures downstream. This prevents unnecessary 2FA prompts in Docker/headless setups.

**CloudKit layer (`init_photos_service`):** Moved backoff retries with fresh connection pools *before* re-auth (was: pool reset -> re-auth -> backoff; now: pool reset -> backoff -> re-auth). Re-auth is the last resort since it can trigger 2FA and may not even fix a routing issue.

## What didn't change

No download logic, verification, EXIF handling, state DB schema, or file operations were modified. The byte counting captures values that were already computed and discarded. The only new I/O in the download path is one `fs::metadata` call after a successful rename.

## New summary format

```
── Summary ──
  50 downloaded, 350 skipped, 0 failed (400 total)
  Skipped: 300 already downloaded, 30 on disk, 15 filtered by media type, 5 filtered by date range
  Transferred 1.2 GiB, 1.3 GiB written to disk
  Completed in 4m 23s
```

Lines are conditional - skip breakdown only appears when there are skips, transfer line collapses when bandwidth equals disk bytes, error line only appears when relevant.

## Test plan

- [x] `cargo clippy --all-targets -D warnings` - zero warnings
- [x] 1,396 tests pass (1200 unit, 101 behavioral, 95 CLI)
- [x] New tests: report serialization roundtrip, atomic file write, notification env var presence, backward compat (data=None omits new vars), CLI flag parsing
- [ ] Live download against iCloud to verify summary format with real data