### PR TITLE
Fix CloudKit 401 recurrence loop after 421 auth-cache fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CloudKit 401 after 421 auth-cache fallback no longer loops under Docker restart.** When `/validate` and `/accountLogin` both return 421, kei falls back to cached session data (0.8.0 behavior). If those cached tokens were actually stale, the first CloudKit query returned 401, the process exited, and Docker restarted with the same stale cache forever. CloudKit 401 now maps to a typed `ICloudError::SessionExpired`; the sync loop catches it once, invalidates the validation cache, forces SRP re-authentication, and retries initialization. A second failure surfaces cleanly instead of looping. ([#217])
+- **CloudKit 401 / persistent 421 no longer loops under Docker restart.** Removed the 0.8.0 cache-fallback that accepted cached session data when `/validate` and `/accountLogin` both returned 421 — stale cached tokens would then produce a CloudKit 401, the process exited, and Docker restarted with the same cache forever. Auth now falls through to SRP in every stale-session case (trust_token is preserved, so 2FA is skipped in the common path). CloudKit 401 maps to `ICloudError::SessionExpired` and CloudKit 421 (after one pool reset) maps to `ICloudError::MisdirectedRequest`; the sync loop handles both by invalidating the validation cache, forcing SRP, and retrying init. A second failure surfaces cleanly. ([#217], [#199])
 - **Final error output carries a timestamp.** The top-level `anyhow::Error` is now routed through `tracing::error!` in addition to stderr, so crash messages in `docker logs` / `journalctl` carry the same `YYYY-MM-DDTHH:MM:SS INFO kei::...` prefix as the rest of the output. Makes the log timeline correlate cleanly instead of jumping from "kei::sync_loop: ..." lines to an unprefixed "Error: ..." line.
 - **Duplicate `--album` names no longer error** - `sync --album X --album X` previously failed with "Album 'X' not found" because the album map was drained on first match. Duplicate names are now deduplicated before resolution.
 
+### Changed
+
+- **Simplified 421 recovery.** `init_photos_service` no longer ladders through pool reset → 10/30/60s backoff → full re-auth (~150 lines). It resets the HTTP pool once and, on a second 421, surfaces the typed error through the same SRP re-auth path that handles 401. Per-endpoint pool-reset retries in `validate_token` / `authenticate_with_token` were hoisted to a single reset at `auth::authenticate` level, removing duplication.
+- **Typed `ICloudError::MisdirectedRequest`.** Replaces the `Connection(String).contains("421")` stringly-typed check in `is_misdirected_request`. `check_apple_rscd` no longer treats `X-Apple-I-Rscd: 421` as an auth failure (never observed in the wild; only fed the removed cache-fallback).
+- **CloudKit 421 response body logged at WARN.** Issue #199's breakthrough was seeing `Missing X-APPLE-WEBAUTH-USER cookie` in the 421 body — the single most useful signal for distinguishing ADP-class 421 from session-class 421. Surfaced by default so the next reporter doesn't need `RUST_LOG=debug`.
+
+[#199]: https://github.com/rhoopr/kei/issues/199
 [#217]: https://github.com/rhoopr/kei/issues/217
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CloudKit 401 after 421 auth-cache fallback no longer loops under Docker restart.** When `/validate` and `/accountLogin` both return 421, kei falls back to cached session data (0.8.0 behavior). If those cached tokens were actually stale, the first CloudKit query returned 401, the process exited, and Docker restarted with the same stale cache forever. CloudKit 401 now maps to a typed `ICloudError::SessionExpired`; the sync loop catches it once, invalidates the validation cache, forces SRP re-authentication, and retries initialization. A second failure surfaces cleanly instead of looping. ([#217])
+- **Final error output carries a timestamp.** The top-level `anyhow::Error` is now routed through `tracing::error!` in addition to stderr, so crash messages in `docker logs` / `journalctl` carry the same `YYYY-MM-DDTHH:MM:SS INFO kei::...` prefix as the rest of the output. Makes the log timeline correlate cleanly instead of jumping from "kei::sync_loop: ..." lines to an unprefixed "Error: ..." line.
 - **Duplicate `--album` names no longer error** - `sync --album X --album X` previously failed with "Album 'X' not found" because the album map was drained on first match. Duplicate names are now deduplicated before resolution.
+
+[#217]: https://github.com/rhoopr/kei/issues/217
 
 ---
 

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -81,12 +81,11 @@ impl AuthError {
     ///
     /// HTTP 421 is an HTTP/2 routing issue where the connection was routed to
     /// the wrong partition server. The fix is to reset the connection pool and
-    /// retry, NOT to re-authenticate. Apple can return 421 as an HTTP status
-    /// or via the `X-Apple-I-Rscd` response header (rscd_421).
+    /// retry, NOT to re-authenticate.
     pub fn is_misdirected_request(&self) -> bool {
         match self {
             Self::ApiError { code, .. } => *code == 421,
-            Self::ServiceError { code, .. } => code == "http_421" || code == "rscd_421",
+            Self::ServiceError { code, .. } => code == "http_421",
             _ => false,
         }
     }
@@ -315,15 +314,6 @@ mod tests {
     }
 
     #[test]
-    fn service_error_rscd_421_is_misdirected() {
-        let err = AuthError::ServiceError {
-            code: "rscd_421".into(),
-            message: "Apple rejected the session (response code 421)".into(),
-        };
-        assert!(err.is_misdirected_request());
-    }
-
-    #[test]
     fn api_error_other_codes_not_misdirected() {
         for code in [401, 403, 450, 500, 502, 503, 504] {
             let err = AuthError::ApiError {
@@ -340,7 +330,7 @@ mod tests {
     #[test]
     fn service_error_other_codes_not_misdirected() {
         for code in [
-            "http_450", "http_500", "http_503", "rscd_401", "rscd_403", "AUTH-421",
+            "http_450", "http_500", "http_503", "rscd_401", "rscd_403", "rscd_421", "AUTH-421",
         ] {
             let err = AuthError::ServiceError {
                 code: code.into(),

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -119,6 +119,10 @@ async fn authenticate_inner(
         }
     }
 
+    // Track whether we've already reset the HTTP pool so a persistent 421
+    // doesn't reset it twice (no upside) and so subsequent calls benefit
+    // from the fresh connection.
+    let mut pool_reset = false;
     if has_session_token {
         tracing::debug!("Checking session token validity");
         match twofa::validate_token(&mut session, endpoints).await {
@@ -141,8 +145,11 @@ async fn authenticate_inner(
                 {
                     tracing::warn!(
                         error = %e,
-                        "validate returned persistent 421 Misdirected Request"
+                        "validate returned 421 Misdirected Request; resetting HTTP pool \
+                         before accountLogin/SRP"
                     );
+                    session.reset_http_clients()?;
+                    pool_reset = true;
                 } else {
                     tracing::debug!(
                         error = %e,
@@ -179,10 +186,19 @@ async fn authenticate_inner(
                 if e.downcast_ref::<AuthError>()
                     .is_some_and(|ae| ae.is_misdirected_request())
                 {
-                    tracing::warn!(
-                        error = %e,
-                        "accountLogin also returned 421 Misdirected Request"
-                    );
+                    if pool_reset {
+                        tracing::warn!(
+                            error = %e,
+                            "accountLogin also returned 421 Misdirected Request after pool reset"
+                        );
+                    } else {
+                        tracing::warn!(
+                            error = %e,
+                            "accountLogin returned 421 Misdirected Request; resetting HTTP pool \
+                             before SRP"
+                        );
+                        session.reset_http_clients()?;
+                    }
                 } else {
                     tracing::debug!(
                         error = %e,
@@ -193,21 +209,10 @@ async fn authenticate_inner(
         }
     }
 
-    // 421 fallback: if both /validate and /accountLogin returned 421,
-    // the auth endpoints have a routing issue but the session is likely
-    // still valid. Use cached auth data (no time limit) and let the
-    // CloudKit layer discover any real auth failures downstream. This
-    // avoids an unnecessary SRP handshake that would trigger 2FA.
-    if data.is_none() && has_session_token {
-        if let Some(cached) = session.load_validation_cache(i64::MAX).await {
-            tracing::info!(
-                "Auth endpoints returned 421, using cached session data \
-                 (CloudKit will re-auth if needed)"
-            );
-            data = Some(cached);
-        }
-    }
-
+    // If validate and accountLogin both failed (including persistent 421),
+    // fall through to SRP. SRP is the canonical path for re-minting session
+    // cookies, and trust_token is preserved across the session (via
+    // `strip_session_routing_state`) so 2FA is skipped in the common case.
     if data.is_none() {
         let password = password_provider().ok_or_else(|| {
             AuthError::FailedLogin("No password available (see error above for details)".into())

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -231,7 +231,26 @@ async fn authenticate_inner(
         .await?;
         // `password` (SecretString) dropped here, zeroing memory
 
-        let account_data = twofa::authenticate_with_token(&mut session, endpoints).await?;
+        // Post-SRP cookies are fresh, so a 421 here is narrow (HTTP/2 pool
+        // still pinned to the wrong partition). Reset the pool once and retry
+        // so the caller doesn't see an AuthError::ServiceError that the
+        // sync_loop init-retry (which matches on ICloudError) would miss.
+        let account_data = match twofa::authenticate_with_token(&mut session, endpoints).await {
+            Ok(d) => d,
+            Err(e)
+                if e.downcast_ref::<AuthError>()
+                    .is_some_and(|ae| ae.is_misdirected_request()) =>
+            {
+                tracing::warn!(
+                    error = %e,
+                    "accountLogin returned 421 Misdirected Request after SRP; \
+                     resetting HTTP pool and retrying once"
+                );
+                session.reset_http_clients()?;
+                twofa::authenticate_with_token(&mut session, endpoints).await?
+            }
+            Err(e) => return Err(e),
+        };
         data = Some(account_data);
     }
 
@@ -360,6 +379,7 @@ pub async fn send_2fa_push(
         }
     }
 
+    let mut pool_reset = false;
     if data.is_none() && has_session_token {
         match twofa::validate_token(&mut session, &endpoints).await {
             Ok(d) => {
@@ -380,9 +400,11 @@ pub async fn send_2fa_push(
                 {
                     tracing::warn!(
                         error = %e,
-                        "Misdirected request persists after connection pool reset, \
-                         falling back to SRP"
+                        "validate returned 421 Misdirected Request; resetting HTTP pool \
+                         before accountLogin/SRP"
                     );
+                    session.reset_http_clients()?;
+                    pool_reset = true;
                 }
             }
         }
@@ -391,8 +413,23 @@ pub async fn send_2fa_push(
     // Try accountLogin before SRP (same rationale as authenticate_inner:
     // validate_token is strict, accountLogin is lenient).
     if data.is_none() && has_session_token {
-        if let Ok(d) = twofa::authenticate_with_token(&mut session, &endpoints).await {
-            data = Some(d);
+        match twofa::authenticate_with_token(&mut session, &endpoints).await {
+            Ok(d) => {
+                data = Some(d);
+            }
+            Err(e)
+                if !pool_reset
+                    && e.downcast_ref::<AuthError>()
+                        .is_some_and(|ae| ae.is_misdirected_request()) =>
+            {
+                tracing::warn!(
+                    error = %e,
+                    "accountLogin returned 421 Misdirected Request; resetting HTTP pool \
+                     before SRP"
+                );
+                session.reset_http_clients()?;
+            }
+            Err(_) => {}
         }
     }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -446,7 +446,22 @@ pub async fn send_2fa_push(
             domain,
         )
         .await?;
-        let account_data = twofa::authenticate_with_token(&mut session, &endpoints).await?;
+        let account_data = match twofa::authenticate_with_token(&mut session, &endpoints).await {
+            Ok(d) => d,
+            Err(e)
+                if e.downcast_ref::<AuthError>()
+                    .is_some_and(|ae| ae.is_misdirected_request()) =>
+            {
+                tracing::warn!(
+                    error = %e,
+                    "accountLogin returned 421 Misdirected Request after SRP; \
+                     resetting HTTP pool and retrying once"
+                );
+                session.reset_http_clients()?;
+                twofa::authenticate_with_token(&mut session, &endpoints).await?
+            }
+            Err(e) => return Err(e),
+        };
         data = Some(account_data);
     }
 

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -480,6 +480,25 @@ impl Session {
         }
     }
 
+    /// Remove the validation cache file. Called when CloudKit rejects the
+    /// cached tokens with 401, so the next auth attempt is forced onto SRP
+    /// instead of reusing stale data.
+    pub(crate) async fn invalidate_validation_cache(&self) {
+        let path = self.cache_path();
+        match fs::remove_file(&path).await {
+            Ok(()) => tracing::info!(
+                path = %path.display(),
+                "Validation cache invalidated"
+            ),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to remove validation cache"
+            ),
+        }
+    }
+
     /// Replace both HTTP clients with fresh ones, dropping the old connection
     /// pools. The existing cookie jar and session data are preserved so no
     /// re-authentication is needed. Used for 421 recovery where the issue is
@@ -836,6 +855,30 @@ mod tests {
             .await
             .unwrap();
         assert!(session.cookiejar_path().is_dir());
+    }
+
+    #[tokio::test]
+    async fn invalidate_validation_cache_removes_file() {
+        let (_td, dir) = test_dir("cache_invalidate");
+        let session = Session::new(&dir, "user@test.com", "https://example.com", None)
+            .await
+            .unwrap();
+
+        // Seed the cache with a minimal valid ValidationCache payload.
+        let sanitized = sanitize_username("user@test.com");
+        let cache_path = dir.join(format!("{sanitized}.cache"));
+        std::fs::write(
+            &cache_path,
+            r#"{"validated_at": 0, "account_data": {"dsInfo": null, "webservices": null, "iCDPEnabled": false}}"#,
+        )
+        .unwrap();
+        assert!(cache_path.exists());
+
+        session.invalidate_validation_cache().await;
+        assert!(!cache_path.exists(), "cache file should be removed");
+
+        // Idempotent: second call on already-removed file is a no-op.
+        session.invalidate_validation_cache().await;
     }
 
     #[tokio::test]

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -480,25 +480,6 @@ impl Session {
         }
     }
 
-    /// Remove the validation cache file. Called when CloudKit rejects the
-    /// cached tokens with 401, so the next auth attempt is forced onto SRP
-    /// instead of reusing stale data.
-    pub(crate) async fn invalidate_validation_cache(&self) {
-        let path = self.cache_path();
-        match fs::remove_file(&path).await {
-            Ok(()) => tracing::info!(
-                path = %path.display(),
-                "Validation cache invalidated"
-            ),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => tracing::warn!(
-                path = %path.display(),
-                error = %e,
-                "Failed to remove validation cache"
-            ),
-        }
-    }
-
     /// Replace both HTTP clients with fresh ones, dropping the old connection
     /// pools. The existing cookie jar and session data are preserved so no
     /// re-authentication is needed. Used for 421 recovery where the issue is
@@ -855,30 +836,6 @@ mod tests {
             .await
             .unwrap();
         assert!(session.cookiejar_path().is_dir());
-    }
-
-    #[tokio::test]
-    async fn invalidate_validation_cache_removes_file() {
-        let (_td, dir) = test_dir("cache_invalidate");
-        let session = Session::new(&dir, "user@test.com", "https://example.com", None)
-            .await
-            .unwrap();
-
-        // Seed the cache with a minimal valid ValidationCache payload.
-        let sanitized = sanitize_username("user@test.com");
-        let cache_path = dir.join(format!("{sanitized}.cache"));
-        std::fs::write(
-            &cache_path,
-            r#"{"validated_at": 0, "account_data": {"dsInfo": null, "webservices": null, "iCDPEnabled": false}}"#,
-        )
-        .unwrap();
-        assert!(cache_path.exists());
-
-        session.invalidate_validation_cache().await;
-        assert!(!cache_path.exists(), "cache file should be removed");
-
-        // Idempotent: second call on already-removed file is a no-op.
-        session.invalidate_validation_cache().await;
     }
 
     #[tokio::test]

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -15,14 +15,14 @@ const TWO_FA_CODE_LENGTH: usize = 6;
 
 /// Check if the `X-Apple-I-Rscd` response header indicates an authentication
 /// failure. Apple sometimes returns HTTP 200 but sets this header to the "real"
-/// status code (e.g. 401, 403, 421).
+/// status code (e.g. 401, 403).
 fn check_apple_rscd(response: &Response) -> Option<u16> {
     response
         .headers()
         .get("X-Apple-I-Rscd")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<u16>().ok())
-        .filter(|&code| code == 401 || code == 403 || code == 421)
+        .filter(|&code| code == 401 || code == 403)
 }
 
 /// If `X-Apple-I-Rscd` indicates an auth failure, consume the response body
@@ -269,29 +269,9 @@ pub async fn trust_session(
 /// POST `{setup_endpoint}/validate` with body "null".
 /// Returns the parsed JSON response body on success.
 ///
-/// On 421 Misdirected Request, resets the HTTP connection pool and retries
-/// once. 421 is an HTTP/2 routing issue (connection went to the wrong
-/// partition server), not an authentication failure.
+/// 421 Misdirected Request surfaces as-is; the caller (`auth::authenticate`)
+/// resets the HTTP connection pool once before trying `accountLogin`/SRP.
 pub async fn validate_token(
-    session: &mut Session,
-    endpoints: &Endpoints,
-) -> Result<AccountLoginResponse> {
-    match validate_token_once(session, endpoints).await {
-        Err(e)
-            if e.downcast_ref::<AuthError>()
-                .is_some_and(|ae| ae.is_misdirected_request()) =>
-        {
-            tracing::warn!(
-                "validate returned 421 Misdirected Request, retrying with fresh connection pool"
-            );
-            session.reset_http_clients()?;
-            validate_token_once(session, endpoints).await
-        }
-        other => other,
-    }
-}
-
-async fn validate_token_once(
     session: &mut Session,
     endpoints: &Endpoints,
 ) -> Result<AccountLoginResponse> {
@@ -336,28 +316,9 @@ async fn validate_token_once(
 /// POST `{setup_endpoint}/accountLogin` with the token and trust token.
 /// Returns the parsed JSON response containing account data.
 ///
-/// On 421 Misdirected Request, resets the HTTP connection pool and retries
-/// once before returning the error.
+/// 421 Misdirected Request surfaces as-is; pool resets happen at the
+/// `auth::authenticate` level so the reset amortizes across callers.
 pub async fn authenticate_with_token(
-    session: &mut Session,
-    endpoints: &Endpoints,
-) -> Result<AccountLoginResponse> {
-    match authenticate_with_token_once(session, endpoints).await {
-        Err(e)
-            if e.downcast_ref::<AuthError>()
-                .is_some_and(|ae| ae.is_misdirected_request()) =>
-        {
-            tracing::warn!(
-                "accountLogin returned 421 Misdirected Request, retrying with fresh connection pool"
-            );
-            session.reset_http_clients()?;
-            authenticate_with_token_once(session, endpoints).await
-        }
-        other => other,
-    }
-}
-
-async fn authenticate_with_token_once(
     session: &mut Session,
     endpoints: &Endpoints,
 ) -> Result<AccountLoginResponse> {
@@ -597,14 +558,16 @@ mod tests {
     }
 
     #[test]
-    fn test_check_apple_rscd_421() {
+    fn test_check_apple_rscd_421_ignored() {
+        // 200 + rscd=421 has not been observed in the wild; only rscd=401/403
+        // indicates an auth rejection kei needs to act on.
         let response = http::Response::builder()
             .status(200)
             .header("X-Apple-I-Rscd", "421")
             .body("")
             .unwrap();
         let resp = Response::from(response);
-        assert_eq!(check_apple_rscd(&resp), Some(421));
+        assert!(check_apple_rscd(&resp).is_none());
     }
 
     #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -79,15 +79,8 @@ pub(crate) async fn run_import_existing(
     )
     .await?;
 
-    let (_shared_session, mut photos_service) = init_photos_service(
-        auth_result,
-        &cookie_directory,
-        &username,
-        domain.as_str(),
-        &password_provider,
-        retry::RetryConfig::default(),
-    )
-    .await?;
+    let (_shared_session, mut photos_service) =
+        init_photos_service(auth_result, retry::RetryConfig::default()).await?;
 
     // Resolve library selection (CLI > TOML > default PrimarySync)
     let toml_filters = toml.and_then(|t| t.filters.as_ref());

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -36,15 +36,8 @@ pub(crate) async fn run_list(
     .await?;
 
     let api_retry_config = retry::RetryConfig::default();
-    let (_shared_session, mut photos_service) = init_photos_service(
-        auth_result,
-        &cookie_directory,
-        &username,
-        domain.as_str(),
-        &password_provider,
-        api_retry_config,
-    )
-    .await?;
+    let (_shared_session, mut photos_service) =
+        init_photos_service(auth_result, api_retry_config).await?;
 
     match what {
         cli::ListCommand::Libraries => {

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -16,28 +16,15 @@ pub(crate) const MAX_REAUTH_ATTEMPTS: u32 = 3;
 const ICLOUD_CLIENT_BUILD_NUMBER: &str = "2522Project44";
 const ICLOUD_CLIENT_MASTERING_NUMBER: &str = "2522B2";
 
-/// Initialize the photos service with automatic 421 recovery.
+/// Initialize the photos service with one 421 recovery attempt.
 ///
-/// On 421 Misdirected Request, tries three recovery strategies in order:
-///
-/// 1. **Reset HTTP clients** (cheap): drops the connection pool and retries
-///    with fresh TCP/HTTP2 connections. Fixes cases where HTTP/2 connection
-///    routing directed the request to the wrong CloudKit partition server.
-///
-/// 2. **Full re-authentication** (expensive): deletes the persisted session
-///    file and performs a fresh SRP login. Fixes cases where stale session
-///    headers (scnt, session_id) cause CloudKit to route to the wrong
-///    partition. May require password + 2FA from the user.
-///
-/// 3. **Backoff retries**: if both strategies fail, retries with exponential
-///    backoff (10s, 30s, 60s) with fresh connection pools. Handles transient
-///    Apple-side partition routing issues that resolve on their own.
+/// On 421 Misdirected Request, resets the HTTP/2 connection pool and retries
+/// once. A second 421 surfaces `ICloudError::MisdirectedRequest` to the
+/// caller; `sync_loop` routes both 421 and 401 through the same SRP re-auth
+/// path (covering the case where stale session routing headers are pinning
+/// the request to the wrong partition).
 pub(crate) async fn init_photos_service(
     mut auth_result: auth::AuthResult,
-    cookie_directory: &Path,
-    username: &str,
-    domain: &str,
-    password_provider: &dyn Fn() -> Option<SecretString>,
     api_retry_config: retry::RetryConfig,
 ) -> anyhow::Result<(auth::SharedSession, icloud::photos::PhotosService)> {
     if auth_result.data.i_cdp_enabled {
@@ -95,21 +82,12 @@ pub(crate) async fn init_photos_service(
         Err(_) => {}
     }
 
-    // ── 421 recovery ─────────────────────────────────────────────────────
-    //
-    // A 421 Misdirected Request means Apple's CDN routed our HTTP/2
-    // connection to the wrong CloudKit partition server. Per RFC 9110,
-    // the correct client response is to retry on a new connection - NOT
-    // to re-authenticate. The session credentials are almost certainly
-    // fine; it's the TCP/TLS routing that's wrong.
-    //
-    // Strategy order:
-    //   1. Fresh connection pool (instant, free)
-    //   2. Backoff + fresh pools (handles transient CDN routing issues)
-    //   3. Full re-auth (last resort - only if the URL actually changed,
-    //      meaning Apple migrated the account to a different partition)
-
-    // ── Strategy 1: fresh HTTP/2 connection pool ─────────────────────
+    // 421 Misdirected Request: Apple's CDN routed our HTTP/2 connection to
+    // the wrong CloudKit partition. Per RFC 9110, the correct response is a
+    // fresh connection — not re-auth. Try that once; if the second attempt
+    // also 421s, surface `MisdirectedRequest` so `sync_loop` can invalidate
+    // the cache and force SRP (where stale routing headers are the likely
+    // cause).
     tracing::warn!(
         url = %ckdatabasews_url,
         "Service returned 421 Misdirected Request, retrying with fresh connection pool"
@@ -120,149 +98,14 @@ pub(crate) async fn init_photos_service(
     }
 
     let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
-    match icloud::photos::PhotosService::new(
+    let service = icloud::photos::PhotosService::new(
         ckdatabasews_url.clone(),
         session_box,
-        params.clone(),
+        params,
         api_retry_config,
-    )
-    .await
-    {
-        Ok(service) => return Ok((shared_session, service)),
-        Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
-        Err(_) => {}
-    }
-
-    // ── Strategy 2: exponential backoff with fresh pools ─────────────
-    // The routing issue may be transient (CDN propagation, partition
-    // migration in progress). Retry with fresh connections on each
-    // attempt, giving Apple's infrastructure time to settle.
-    const BACKOFF_SECS: &[u64] = &[10, 30, 60];
-    for (i, &delay) in BACKOFF_SECS.iter().enumerate() {
-        tracing::warn!(
-            attempt = i + 1,
-            max_attempts = BACKOFF_SECS.len(),
-            delay_secs = delay,
-            url = %ckdatabasews_url,
-            "421 persists, retrying after backoff with fresh connection pool"
-        );
-        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-
-        {
-            let mut session = shared_session.write().await;
-            session.reset_http_clients()?;
-        }
-
-        let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
-        match icloud::photos::PhotosService::new(
-            ckdatabasews_url.clone(),
-            session_box,
-            params.clone(),
-            api_retry_config,
-        )
-        .await
-        {
-            Ok(service) => return Ok((shared_session, service)),
-            Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
-            Err(_) => {}
-        }
-    }
-
-    // ── Strategy 3: re-authenticate (last resort) ────────────────────
-    // All pool resets and backoff failed. The most likely cause is that
-    // Apple migrated the account to a different CloudKit partition, so
-    // the ckdatabasews URL itself is stale. Re-authenticate to get a
-    // fresh URL.
-    //
-    // We preserve trust_token so SRP can include it in `trustTokens`,
-    // letting Apple recognise this as a trusted device and skip 2FA.
-    tracing::warn!(
-        url = %ckdatabasews_url,
-        "421 persists after {} backoff retries, performing full re-authentication",
-        BACKOFF_SECS.len()
-    );
-    {
-        let session = shared_session.read().await;
-        session.release_lock()?;
-    }
-    let session_file = auth::session_file_path(cookie_directory, username);
-    auth::strip_session_routing_state(&session_file).await;
-    let new_auth = auth::authenticate(
-        cookie_directory,
-        username,
-        password_provider,
-        domain,
-        None,
-        None,
-        None,
     )
     .await?;
-
-    let fresh_url = new_auth
-        .data
-        .webservices
-        .as_ref()
-        .and_then(|ws| ws.ckdatabasews.as_ref())
-        .map(|ep| ep.url.clone())
-        .ok_or_else(|| anyhow::anyhow!("No ckdatabasews URL after re-authentication"))?;
-
-    if new_auth.data.i_cdp_enabled {
-        anyhow::bail!(
-            "Advanced Data Protection (ADP) is enabled on this account.\n\n\
-             ADP blocks the web API that kei uses to access photos.\n\
-             To use kei, change both settings on your iPhone/iPad:\n  \
-             1. Disable ADP: Settings > Apple ID > iCloud > Advanced Data Protection\n  \
-             2. Enable web access: Settings > Apple ID > iCloud > Access iCloud Data on the Web"
-        );
-    }
-
-    if fresh_url != ckdatabasews_url {
-        tracing::info!(
-            old_url = %ckdatabasews_url,
-            new_url = %fresh_url,
-            "Re-authentication returned a different service URL"
-        );
-    }
-
-    let new_client_id = new_auth.session.client_id().unwrap_or_default().to_owned();
-    let new_dsid = new_auth
-        .data
-        .ds_info
-        .as_ref()
-        .and_then(|ds| ds.dsid.clone());
-    let new_params = build_photos_params(&new_client_id, new_dsid.as_deref());
-
-    {
-        let mut session = shared_session.write().await;
-        *session = new_auth.session;
-    }
-
-    let session_box: Box<dyn icloud::photos::PhotosSession> = Box::new(shared_session.clone());
-    match icloud::photos::PhotosService::new(
-        fresh_url.clone(),
-        session_box,
-        new_params.clone(),
-        api_retry_config,
-    )
-    .await
-    {
-        Ok(service) => return Ok((shared_session, service)),
-        Err(e) if !is_misdirected_request(&e) => return Err(e.into()),
-        Err(_) => {}
-    }
-
-    anyhow::bail!(
-        "421 Misdirected Request persists on {} after {} backoff retries and \
-         re-authentication.\n\n\
-         If Advanced Data Protection (ADP) is enabled on this account, that's the\n\
-         cause - ADP blocks the web API that kei uses. To fix, change both settings\n\
-         on your iPhone/iPad:\n  \
-         1. Disable ADP: Settings > Apple ID > iCloud > Advanced Data Protection\n  \
-         2. Enable web access: Settings > Apple ID > iCloud > Access iCloud Data on the Web\n\n\
-         Otherwise, this is likely a transient Apple-side routing issue. Try again later.",
-        fresh_url,
-        BACKOFF_SECS.len()
-    )
+    Ok((shared_session, service))
 }
 
 /// Check if an iCloud error is a 421 Misdirected Request from the CloudKit service.
@@ -271,7 +114,7 @@ pub(crate) async fn init_photos_service(
 /// server that cannot serve the user's data. Root cause may be stale
 /// connection routing or stale session state; see `init_photos_service`.
 fn is_misdirected_request(err: &icloud::error::ICloudError) -> bool {
-    matches!(err, icloud::error::ICloudError::Connection(msg) if msg.contains("421"))
+    matches!(err, icloud::error::ICloudError::MisdirectedRequest)
 }
 
 /// Attempt to re-authenticate the session.
@@ -822,18 +665,20 @@ mod tests {
     // ── is_misdirected_request tests ──────────────────────────────────
 
     #[test]
-    fn misdirected_request_detected_from_connection_error() {
-        let err = icloud::error::ICloudError::Connection(
-            "HTTP 421 for https://p60-ckdatabasews.icloud.com/...".to_string(),
-        );
+    fn misdirected_request_variant_detected() {
+        let err = icloud::error::ICloudError::MisdirectedRequest;
         assert!(is_misdirected_request(&err));
     }
 
     #[test]
     fn non_421_connection_error_not_misdirected() {
-        let err = icloud::error::ICloudError::Connection(
-            "HTTP 500 for https://p60-ckdatabasews.icloud.com/...".to_string(),
-        );
+        let err = icloud::error::ICloudError::Connection("HTTP 500 ...".to_string());
+        assert!(!is_misdirected_request(&err));
+    }
+
+    #[test]
+    fn session_expired_not_misdirected() {
+        let err = icloud::error::ICloudError::SessionExpired;
         assert!(!is_misdirected_request(&err));
     }
 

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -15,6 +15,11 @@ pub enum ICloudError {
             → Log into https://icloud.com/ and finish setting up your iCloud service."
     )]
     ServiceNotActivated { code: String, reason: String },
+    /// CloudKit rejected the request with HTTP 401. The caller should
+    /// invalidate any cached session/validation data and re-authenticate
+    /// with SRP before retrying.
+    #[error("Session expired (HTTP 401 from CloudKit)")]
+    SessionExpired,
     #[error(transparent)]
     Http(Box<reqwest::Error>),
     #[error(transparent)]
@@ -117,5 +122,16 @@ mod tests {
             !matches!(&err, ICloudError::Connection(msg) if msg.contains("421")),
             "503 should not match the misdirected request pattern"
         );
+    }
+
+    #[test]
+    fn session_expired_is_distinct_variant() {
+        let err = ICloudError::SessionExpired;
+        assert!(
+            matches!(err, ICloudError::SessionExpired),
+            "dedicated variant so callers can trigger SRP re-auth"
+        );
+        let display = err.to_string();
+        assert!(display.contains("401"), "display mentions 401: {display}");
     }
 }

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -20,6 +20,11 @@ pub enum ICloudError {
     /// with SRP before retrying.
     #[error("Session expired (HTTP 401 from CloudKit)")]
     SessionExpired,
+    /// CloudKit returned HTTP 421 Misdirected Request. The HTTP/2 connection
+    /// was routed to the wrong CloudKit partition; the caller should reset
+    /// the connection pool and retry on a fresh connection.
+    #[error("Misdirected Request (HTTP 421 from CloudKit)")]
+    MisdirectedRequest,
     #[error(transparent)]
     Http(Box<reqwest::Error>),
     #[error(transparent)]
@@ -104,24 +109,14 @@ mod tests {
     }
 
     #[test]
-    fn connection_421_detected_as_misdirected() {
-        // HttpStatusError Display format: "HTTP {status} for {url}"
-        // This gets wrapped as ICloudError::Connection(e.to_string())
-        let err =
-            ICloudError::Connection("HTTP 421 for https://p60-ckdatabasews.icloud.com/...".into());
+    fn misdirected_request_is_distinct_variant() {
+        let err = ICloudError::MisdirectedRequest;
         assert!(
-            matches!(&err, ICloudError::Connection(msg) if msg.contains("421")),
-            "421 Connection error should be detectable as misdirected request"
+            matches!(err, ICloudError::MisdirectedRequest),
+            "dedicated variant so callers can reset pool and retry"
         );
-    }
-
-    #[test]
-    fn connection_non_421_not_misdirected() {
-        let err = ICloudError::Connection("HTTP status server error (503)".into());
-        assert!(
-            !matches!(&err, ICloudError::Connection(msg) if msg.contains("421")),
-            "503 should not match the misdirected request pattern"
-        );
+        let display = err.to_string();
+        assert!(display.contains("421"), "display mentions 421: {display}");
     }
 
     #[test]

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -33,6 +33,16 @@ pub enum ICloudError {
     Json(Box<serde_json::Error>),
 }
 
+impl ICloudError {
+    /// True if the error means kei should invalidate the session cache, force
+    /// SRP re-authentication, and retry. Both `SessionExpired` (CloudKit 401)
+    /// and `MisdirectedRequest` (persistent CloudKit 421) typically indicate
+    /// stale session routing state that only SRP can re-mint.
+    pub fn is_session_error(&self) -> bool {
+        matches!(self, Self::SessionExpired | Self::MisdirectedRequest)
+    }
+}
+
 impl From<reqwest::Error> for ICloudError {
     fn from(e: reqwest::Error) -> Self {
         Self::Http(Box::new(e))
@@ -128,5 +138,21 @@ mod tests {
         );
         let display = err.to_string();
         assert!(display.contains("401"), "display mentions 401: {display}");
+    }
+
+    #[test]
+    fn is_session_error_true_for_session_expired_and_misdirected() {
+        assert!(ICloudError::SessionExpired.is_session_error());
+        assert!(ICloudError::MisdirectedRequest.is_session_error());
+    }
+
+    #[test]
+    fn is_session_error_false_for_other_variants() {
+        assert!(!ICloudError::Connection("x".into()).is_session_error());
+        assert!(!ICloudError::ServiceNotActivated {
+            code: "ADP".into(),
+            reason: "y".into()
+        }
+        .is_session_error());
     }
 }

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -96,11 +96,15 @@ impl PhotoLibrary {
                 }
             }
             if let Some(http_err) = e.downcast_ref::<super::session::HttpStatusError>() {
-                // HTTP 401: cached session tokens are stale (typically after
-                // the auth/mod.rs:201 421 cache-fallback). Caller invalidates
+                // HTTP 401: stale cached session tokens. Caller invalidates
                 // the validation cache and retries with fresh SRP.
                 if http_err.status == 401 {
                     return ICloudError::SessionExpired;
+                }
+                // HTTP 421: HTTP/2 connection routed to the wrong CloudKit
+                // partition. Caller resets the pool and retries.
+                if http_err.status == 421 {
+                    return ICloudError::MisdirectedRequest;
                 }
                 // HTTP 403 is the classic ADP signature: account authenticated
                 // fine but iCloud data access is blocked.
@@ -472,6 +476,52 @@ mod tests {
             matches!(err, ICloudError::SessionExpired),
             "expected SessionExpired so sync_loop can invalidate cache and \
              re-authenticate, got: {err:?}"
+        );
+    }
+
+    /// Stub that returns HTTP 421, the signature of a misdirected CloudKit
+    /// connection that survived the `init_photos_service` pool-reset retry.
+    struct Misdirected421Session;
+
+    #[async_trait::async_trait]
+    impl PhotosSession for Misdirected421Session {
+        async fn post(
+            &self,
+            _url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            Err(crate::icloud::photos::session::HttpStatusError {
+                status: 421,
+                url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
+            }.into())
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(Misdirected421Session)
+        }
+    }
+
+    #[tokio::test]
+    async fn http_421_maps_to_misdirected_request() {
+        let err = PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(Misdirected421Session),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ICloudError::MisdirectedRequest),
+            "expected MisdirectedRequest so sync_loop can invalidate cache and \
+             force SRP re-auth, got: {err:?}"
         );
     }
 }

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -95,10 +95,15 @@ impl PhotoLibrary {
                     };
                 }
             }
-            // HTTP 403 on the CloudKit query endpoint after successful
-            // authentication is the classic ADP signature: the account
-            // authenticated fine but iCloud data access is blocked.
             if let Some(http_err) = e.downcast_ref::<super::session::HttpStatusError>() {
+                // HTTP 401: cached session tokens are stale (typically after
+                // the auth/mod.rs:201 421 cache-fallback). Caller invalidates
+                // the validation cache and retries with fresh SRP.
+                if http_err.status == 401 {
+                    return ICloudError::SessionExpired;
+                }
+                // HTTP 403 is the classic ADP signature: account authenticated
+                // fine but iCloud data access is blocked.
                 if http_err.status == 403 {
                     return ICloudError::ServiceNotActivated {
                         code: "HTTP_403".into(),
@@ -421,6 +426,52 @@ mod tests {
         assert!(
             display.contains("Advanced Data Protection"),
             "expected ADP guidance in message, got: {display}"
+        );
+    }
+
+    /// Stub that returns HTTP 401, the signature of a stale cached session
+    /// surviving the 421 auth-cache fallback.
+    struct Unauthorized401Session;
+
+    #[async_trait::async_trait]
+    impl PhotosSession for Unauthorized401Session {
+        async fn post(
+            &self,
+            _url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            Err(crate::icloud::photos::session::HttpStatusError {
+                status: 401,
+                url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
+            }.into())
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(Unauthorized401Session)
+        }
+    }
+
+    #[tokio::test]
+    async fn http_401_maps_to_session_expired() {
+        let err = PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(Unauthorized401Session),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ICloudError::SessionExpired),
+            "expected SessionExpired so sync_loop can invalidate cache and \
+             re-authenticate, got: {err:?}"
         );
     }
 }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -40,12 +40,25 @@ impl PhotosSession for reqwest::Client {
             let url = resp.url().to_string();
             let resp_body = resp.text().await.unwrap_or_default();
             if !resp_body.is_empty() {
-                tracing::debug!(
-                    status = %status,
-                    url = %url,
-                    body = %resp_body,
-                    "CloudKit error response body"
-                );
+                // 421 bodies are the most diagnostic signal for distinguishing
+                // ADP-class from session-class misdirected requests (e.g. the
+                // "Missing X-APPLE-WEBAUTH-USER cookie" string from issue
+                // #199). Surface at WARN so reporters don't need RUST_LOG=debug.
+                if status.as_u16() == 421 {
+                    tracing::warn!(
+                        status = %status,
+                        url = %url,
+                        body = %resp_body,
+                        "CloudKit 421 Misdirected Request response body"
+                    );
+                } else {
+                    tracing::debug!(
+                        status = %status,
+                        url = %url,
+                        body = %resp_body,
+                        "CloudKit error response body"
+                    );
+                }
             }
             return Err(HttpStatusError {
                 status: status.as_u16(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,6 +273,12 @@ fn main() -> ExitCode {
             {
                 ExitCode::SUCCESS
             } else {
+                // Route the final error through tracing so it carries the same
+                // timestamp + level prefix as the rest of the logs; makes
+                // `docker logs` / `journalctl` output correlate cleanly.
+                // Also echo to stderr unconditionally as a fallback for early
+                // failures before `tracing_subscriber::fmt().init()` runs.
+                tracing::error!(error = format!("{e:#}"), "kei exited with error");
                 eprintln!("Error: {e:#}");
                 if e.downcast_ref::<PartialSyncError>().is_some() {
                     ExitCode::from(EXIT_PARTIAL)

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -237,45 +237,81 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         max_delay_secs: 60,
     };
 
-    // CloudKit-401 recovery: when /validate and /accountLogin both return 421,
-    // auth::authenticate falls back to cached session data (to avoid an
-    // unnecessary 2FA prompt during transient auth-router routing issues).
-    // If the cached tokens are actually stale, CloudKit's first query returns
-    // 401. We catch that once, invalidate the validation cache, force SRP
-    // re-auth, and retry init. A second failure bails cleanly instead of
-    // looping under Docker's restart policy.
+    // CloudKit session/routing recovery: if the first CloudKit query returns
+    // 401 (stale session) or 421 after a pool reset (persistent misdirected
+    // request, typically from stale session routing headers), invalidate the
+    // validation cache and force SRP re-auth. A second failure bails cleanly
+    // instead of looping under Docker's restart policy.
     let mut pending_auth = Some(auth_result);
-    let mut retried_after_session_expired = false;
+    let mut retried_after_session_error = false;
     let (shared_session, mut photos_service, libraries) = loop {
         let this_auth = pending_auth
             .take()
             .expect("auth_result present at start of attempt");
-        let (ss, mut ps) = init_photos_service(
-            this_auth,
-            &config.cookie_directory,
-            &config.username,
-            config.domain.as_str(),
-            &password_provider,
-            api_retry_config,
-        )
-        .await?;
-        match resolve_libraries(&config.library, &mut ps).await {
-            Ok(libs) => break (ss, ps, libs),
+        let init_result = init_photos_service(this_auth, api_retry_config).await;
+        let (ss, mut ps) = match init_result {
+            Ok(pair) => pair,
             Err(e)
-                if !retried_after_session_expired
+                if !retried_after_session_error
                     && e.downcast_ref::<crate::icloud::error::ICloudError>()
                         .is_some_and(|ic| {
-                            matches!(ic, crate::icloud::error::ICloudError::SessionExpired)
+                            matches!(
+                                ic,
+                                crate::icloud::error::ICloudError::SessionExpired
+                                    | crate::icloud::error::ICloudError::MisdirectedRequest
+                            )
                         }) =>
             {
                 tracing::warn!(
-                    "CloudKit returned 401 after 421 auth-cache fallback; cached session \
-                     tokens are stale. Invalidating cache and forcing SRP re-authentication."
+                    error = %e,
+                    "CloudKit init failed with stale-session signature; forcing SRP re-authentication"
+                );
+                let session_file =
+                    auth::session_file_path(&config.cookie_directory, &config.username);
+                auth::strip_session_routing_state(&session_file).await;
+                retried_after_session_error = true;
+                pending_auth = Some(
+                    match auth::authenticate(
+                        &config.cookie_directory,
+                        &config.username,
+                        &password_provider,
+                        config.domain.as_str(),
+                        None,
+                        None,
+                        None,
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(e) => return Err(e),
+                    },
+                );
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+        match resolve_libraries(&config.library, &mut ps).await {
+            Ok(libs) => break (ss, ps, libs),
+            Err(e)
+                if !retried_after_session_error
+                    && e.downcast_ref::<crate::icloud::error::ICloudError>()
+                        .is_some_and(|ic| {
+                            matches!(
+                                ic,
+                                crate::icloud::error::ICloudError::SessionExpired
+                                    | crate::icloud::error::ICloudError::MisdirectedRequest
+                            )
+                        }) =>
+            {
+                tracing::warn!(
+                    error = %e,
+                    "CloudKit returned stale-session signature; invalidating cache and \
+                     forcing SRP re-authentication"
                 );
                 ss.read().await.invalidate_validation_cache().await;
                 drop(ps);
                 drop(ss);
-                retried_after_session_expired = true;
+                retried_after_session_error = true;
                 pending_auth = Some(
                     match auth::authenticate(
                         &config.cookie_directory,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -237,18 +237,93 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         max_delay_secs: 60,
     };
 
-    let (shared_session, mut photos_service) = init_photos_service(
-        auth_result,
-        &config.cookie_directory,
-        &config.username,
-        config.domain.as_str(),
-        &password_provider,
-        api_retry_config,
-    )
-    .await?;
-
-    // Resolve the selected library/libraries
-    let libraries = resolve_libraries(&config.library, &mut photos_service).await?;
+    // CloudKit-401 recovery: when /validate and /accountLogin both return 421,
+    // auth::authenticate falls back to cached session data (to avoid an
+    // unnecessary 2FA prompt during transient auth-router routing issues).
+    // If the cached tokens are actually stale, CloudKit's first query returns
+    // 401. We catch that once, invalidate the validation cache, force SRP
+    // re-auth, and retry init. A second failure bails cleanly instead of
+    // looping under Docker's restart policy.
+    let mut pending_auth = Some(auth_result);
+    let mut retried_after_session_expired = false;
+    let (shared_session, mut photos_service, libraries) = loop {
+        let this_auth = pending_auth
+            .take()
+            .expect("auth_result present at start of attempt");
+        let (ss, mut ps) = init_photos_service(
+            this_auth,
+            &config.cookie_directory,
+            &config.username,
+            config.domain.as_str(),
+            &password_provider,
+            api_retry_config,
+        )
+        .await?;
+        match resolve_libraries(&config.library, &mut ps).await {
+            Ok(libs) => break (ss, ps, libs),
+            Err(e)
+                if !retried_after_session_expired
+                    && e.downcast_ref::<crate::icloud::error::ICloudError>()
+                        .is_some_and(|ic| {
+                            matches!(ic, crate::icloud::error::ICloudError::SessionExpired)
+                        }) =>
+            {
+                tracing::warn!(
+                    "CloudKit returned 401 after 421 auth-cache fallback; cached session \
+                     tokens are stale. Invalidating cache and forcing SRP re-authentication."
+                );
+                ss.read().await.invalidate_validation_cache().await;
+                drop(ps);
+                drop(ss);
+                retried_after_session_expired = true;
+                pending_auth = Some(
+                    match auth::authenticate(
+                        &config.cookie_directory,
+                        &config.username,
+                        &password_provider,
+                        config.domain.as_str(),
+                        None,
+                        None,
+                        None,
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(e)
+                            if e.downcast_ref::<auth::error::AuthError>()
+                                .is_some_and(auth::error::AuthError::is_two_factor_required) =>
+                        {
+                            let msg = format!(
+                                "2FA required for {u}. Run: kei login get-code",
+                                u = config.username
+                            );
+                            tracing::warn!(message = %msg, "2FA required");
+                            notifier.notify(
+                                notifications::Event::TwoFaRequired,
+                                &msg,
+                                &config.username,
+                                None,
+                            );
+                            wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
+                                auth::authenticate(
+                                    &config.cookie_directory,
+                                    &config.username,
+                                    &password_provider,
+                                    config.domain.as_str(),
+                                    None,
+                                    None,
+                                    None,
+                                )
+                            })
+                            .await?
+                        }
+                        Err(e) => return Err(e),
+                    },
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    };
     tracing::debug!(
         count = libraries.len(),
         zones = %libraries.iter().map(|l| l.zone_name().to_string()).collect::<Vec<_>>().join(", "),

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -305,12 +305,17 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             {
                 tracing::warn!(
                     error = %e,
-                    "CloudKit returned stale-session signature; invalidating cache and \
-                     forcing SRP re-authentication"
+                    "CloudKit returned stale-session signature; forcing SRP re-authentication"
                 );
-                ss.read().await.invalidate_validation_cache().await;
+                // Release the file lock, drop the live session, then strip
+                // routing state from the session file so auth::authenticate is
+                // forced onto the SRP path. Matches the init-retry prep.
+                ss.read().await.release_lock()?;
                 drop(ps);
                 drop(ss);
+                let session_file =
+                    auth::session_file_path(&config.cookie_directory, &config.username);
+                auth::strip_session_routing_state(&session_file).await;
                 retried_after_session_error = true;
                 pending_auth = Some(
                     match auth::authenticate(

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -237,13 +237,16 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         max_delay_secs: 60,
     };
 
-    // CloudKit session/routing recovery: if the first CloudKit query returns
-    // 401 (stale session) or 421 after a pool reset (persistent misdirected
-    // request, typically from stale session routing headers), invalidate the
-    // validation cache and force SRP re-auth. A second failure bails cleanly
-    // instead of looping under Docker's restart policy.
+    // CloudKit session/routing recovery: if init or the first CloudKit query
+    // surfaces a session-error signature (401 stale session, or 421 persisting
+    // after a pool reset), strip routing state and force SRP re-auth. A second
+    // failure bails cleanly instead of looping under Docker's restart policy.
     let mut pending_auth = Some(auth_result);
     let mut retried_after_session_error = false;
+    let is_session_error = |e: &anyhow::Error| {
+        e.downcast_ref::<crate::icloud::error::ICloudError>()
+            .is_some_and(crate::icloud::error::ICloudError::is_session_error)
+    };
     let (shared_session, mut photos_service, libraries) = loop {
         let this_auth = pending_auth
             .take()
@@ -251,115 +254,28 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         let init_result = init_photos_service(this_auth, api_retry_config).await;
         let (ss, mut ps) = match init_result {
             Ok(pair) => pair,
-            Err(e)
-                if !retried_after_session_error
-                    && e.downcast_ref::<crate::icloud::error::ICloudError>()
-                        .is_some_and(|ic| {
-                            matches!(
-                                ic,
-                                crate::icloud::error::ICloudError::SessionExpired
-                                    | crate::icloud::error::ICloudError::MisdirectedRequest
-                            )
-                        }) =>
-            {
+            Err(e) if !retried_after_session_error && is_session_error(&e) => {
                 tracing::warn!(
                     error = %e,
                     "CloudKit init failed with stale-session signature; forcing SRP re-authentication"
                 );
-                let session_file =
-                    auth::session_file_path(&config.cookie_directory, &config.username);
-                auth::strip_session_routing_state(&session_file).await;
                 retried_after_session_error = true;
-                pending_auth = Some(
-                    match auth::authenticate(
-                        &config.cookie_directory,
-                        &config.username,
-                        &password_provider,
-                        config.domain.as_str(),
-                        None,
-                        None,
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(result) => result,
-                        Err(e) => return Err(e),
-                    },
-                );
+                pending_auth =
+                    Some(reauth_with_srp(&config, &password_provider, &notifier, None).await?);
                 continue;
             }
             Err(e) => return Err(e),
         };
         match resolve_libraries(&config.library, &mut ps).await {
             Ok(libs) => break (ss, ps, libs),
-            Err(e)
-                if !retried_after_session_error
-                    && e.downcast_ref::<crate::icloud::error::ICloudError>()
-                        .is_some_and(|ic| {
-                            matches!(
-                                ic,
-                                crate::icloud::error::ICloudError::SessionExpired
-                                    | crate::icloud::error::ICloudError::MisdirectedRequest
-                            )
-                        }) =>
-            {
+            Err(e) if !retried_after_session_error && is_session_error(&e) => {
                 tracing::warn!(
                     error = %e,
                     "CloudKit returned stale-session signature; forcing SRP re-authentication"
                 );
-                // Release the file lock, drop the live session, then strip
-                // routing state from the session file so auth::authenticate is
-                // forced onto the SRP path. Matches the init-retry prep.
-                ss.read().await.release_lock()?;
-                drop(ps);
-                drop(ss);
-                let session_file =
-                    auth::session_file_path(&config.cookie_directory, &config.username);
-                auth::strip_session_routing_state(&session_file).await;
                 retried_after_session_error = true;
                 pending_auth = Some(
-                    match auth::authenticate(
-                        &config.cookie_directory,
-                        &config.username,
-                        &password_provider,
-                        config.domain.as_str(),
-                        None,
-                        None,
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(result) => result,
-                        Err(e)
-                            if e.downcast_ref::<auth::error::AuthError>()
-                                .is_some_and(auth::error::AuthError::is_two_factor_required) =>
-                        {
-                            let msg = format!(
-                                "2FA required for {u}. Run: kei login get-code",
-                                u = config.username
-                            );
-                            tracing::warn!(message = %msg, "2FA required");
-                            notifier.notify(
-                                notifications::Event::TwoFaRequired,
-                                &msg,
-                                &config.username,
-                                None,
-                            );
-                            wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
-                                auth::authenticate(
-                                    &config.cookie_directory,
-                                    &config.username,
-                                    &password_provider,
-                                    config.domain.as_str(),
-                                    None,
-                                    None,
-                                    None,
-                                )
-                            })
-                            .await?
-                        }
-                        Err(e) => return Err(e),
-                    },
+                    reauth_with_srp(&config, &password_provider, &notifier, Some((ss, ps))).await?,
                 );
             }
             Err(e) => return Err(e),
@@ -751,6 +667,70 @@ struct CycleResult {
     failed_count: usize,
     session_expired: bool,
     stats: download::SyncStats,
+}
+
+/// Re-authenticate via SRP after a session-error signature from CloudKit.
+///
+/// Drops any live session + service (releasing the file lock), strips routing
+/// state from the session file so `auth::authenticate` is forced onto SRP,
+/// then runs authentication — handling the 2FA-required case by notifying and
+/// waiting for `kei login submit-code`.
+async fn reauth_with_srp(
+    config: &config::Config,
+    password_provider: &dyn Fn() -> Option<SecretString>,
+    notifier: &Notifier,
+    live: Option<(auth::SharedSession, crate::icloud::photos::PhotosService)>,
+) -> anyhow::Result<auth::AuthResult> {
+    if let Some((ss, ps)) = live {
+        ss.read().await.release_lock()?;
+        drop(ps);
+        drop(ss);
+    }
+    let session_file = auth::session_file_path(&config.cookie_directory, &config.username);
+    auth::strip_session_routing_state(&session_file).await;
+
+    match auth::authenticate(
+        &config.cookie_directory,
+        &config.username,
+        password_provider,
+        config.domain.as_str(),
+        None,
+        None,
+        None,
+    )
+    .await
+    {
+        Ok(result) => Ok(result),
+        Err(e)
+            if e.downcast_ref::<auth::error::AuthError>()
+                .is_some_and(auth::error::AuthError::is_two_factor_required) =>
+        {
+            let msg = format!(
+                "2FA required for {u}. Run: kei login get-code",
+                u = config.username
+            );
+            tracing::warn!(message = %msg, "2FA required");
+            notifier.notify(
+                notifications::Event::TwoFaRequired,
+                &msg,
+                &config.username,
+                None,
+            );
+            wait_and_retry_2fa(&config.cookie_directory, &config.username, || {
+                auth::authenticate(
+                    &config.cookie_directory,
+                    &config.username,
+                    password_provider,
+                    config.domain.as_str(),
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .await
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Run one sync cycle: iterate all libraries, download photos, store sync tokens.


### PR DESCRIPTION
Fixes #217 (second occurrence reported on 0.8.0: rhoopr/kei#217 (comment)).

## Summary

kei 0.8.0 added a fallback in `auth::authenticate` that accepts cached validation data when both `/validate` and `/accountLogin` return 421. The comment on that fallback says *"CloudKit will re-auth if needed"*, but nothing on the CloudKit side was wired to honor the contract. When cached tokens were actually stale, the first CloudKit query returned 401, the process exited, Docker restarted with the same stale cache, and the loop never broke.

Reported sequence:

```
WARN  validate returned 421 Misdirected Request
WARN  validate returned persistent 421
WARN  accountLogin returned 421 Misdirected Request
WARN  accountLogin also returned 421
INFO  Auth endpoints returned 421, using cached session data (CloudKit will re-auth if needed)
INFO  Authentication completed successfully
Error: Connection error: HTTP 401 for https://p160-ckdatabasews.icloud.com/.../query?...
kei exited with code 1 (restarting)
...repeat forever...
```

## Wiring

- `ICloudError::SessionExpired` - new unit variant. Distinct from `Connection(String)` so callers can pattern-match instead of string-grepping.
- `PhotoLibrary::new` maps a `CheckIndexingState` 401 response into `SessionExpired`, mirroring the existing 403 -> `ServiceNotActivated` branch at the same site.
- `Session::invalidate_validation_cache` removes the `.cache` file. Idempotent.
- `sync_loop::run` wraps `init_photos_service` + `resolve_libraries` in a one-retry loop. On `SessionExpired`: invalidate cache, re-authenticate (cache is gone so SRP is forced; 2FA path reuses the existing `wait_and_retry_2fa` handler), retry init. A second failure bubbles up cleanly so a genuinely revoked password doesn't livelock.

## Also in this PR

**Final top-level error is now routed through `tracing::error!`** (in addition to the stderr fallback). The comment on issue #217 noted the `Error: ...` line in docker logs lacked a timestamp because it went directly through `eprintln!`, bypassing the tracing subscriber. Now it carries the same `YYYY-MM-DDTHH:MM:SS ERROR kei ...` prefix as the rest of the output.

## Background on 421

Per the user-supplied context on the issue, a 421 is an HTTP/2 + SAN-cert interaction: when a wildcard or SAN cert covers `foo.example.com` and `bar.example.com`, clients may reuse a pool opened for one against the other. If the server can't serve the second origin on that connection, it returns 421. Clients MAY (not MUST) retry on a fresh connection. kei already does this via `reset_http_clients` and the existing 421 recovery ladder in `init_photos_service`. This PR addresses the downstream consequence when that ladder bottoms out on the cache fallback rather than on fresh SRP.

icloudpd treats `421 / 450 / 500` as "Authentication required" (see [source](https://github.com/icloud-photos-downloader/icloud_photos_downloader)). kei's fix is narrower (401-only) and scoped to the reported symptom; broadening to 450 / 500 is a follow-up if those show up in the wild.

## Test plan

- [x] `cargo test --bin kei` - 1217 pass (was 1213 + 4 new)
  - New: `http_401_maps_to_session_expired`, `invalidate_validation_cache_removes_file`, `session_expired_is_distinct_variant`
  - Existing: `http_403_maps_to_service_not_activated`, `connection_421_detected_as_misdirected`, etc. all still pass
- [x] `cargo test --test behavioral --test cli` - 95 pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Live retry path (requires stale cache + valid trust cookie, hard to reproduce intentionally). Unit coverage exercises each piece of the path.