### PR TITLE
feat: add Prometheus metrics and /healthz HTTP endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +718,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dunce"
@@ -1394,6 +1446,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "axum",
  "base64",
  "bytes",
  "chrono",
@@ -1416,6 +1469,7 @@ dependencies = [
  "num-bigint",
  "pbkdf2",
  "predicates",
+ "prometheus-client",
  "rand 0.10.0",
  "reqwest",
  "rpassword",
@@ -1538,6 +1592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1620,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1684,6 +1753,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "password-hash"
@@ -1827,6 +1919,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1985,6 +2100,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -2248,6 +2372,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sd-notify"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Metrics / observability
+prometheus-client = "0.22"
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
+
 # Progress / UI
 indicatif = "0.18"
 rpassword = "7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,10 @@ COPY --from=builder /kei /usr/local/bin/kei
 
 VOLUME ["/config", "/photos"]
 
+# Prometheus metrics + /healthz endpoint (opt-in via --metrics-port / KEI_METRICS_PORT).
+# The port below is a documentation hint only; the actual port is user-configured.
+EXPOSE 9090
+
 HEALTHCHECK --interval=60s --timeout=5s --start-period=15m --retries=3 \
   CMD test -f /config/health.json \
    && test "$(jq -r '.consecutive_failures' /config/health.json)" -lt 5 \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,6 +195,12 @@ pub struct SyncArgs {
     #[arg(long, env = "KEI_REPORT_JSON")]
     pub report_json: Option<std::path::PathBuf>,
 
+    /// Expose a Prometheus /metrics endpoint on this port (e.g. 9090).
+    /// Also serves a /healthz JSON endpoint on the same port.
+    /// When not set, no HTTP server is started.
+    #[arg(long, env = "KEI_METRICS_PORT", value_parser = clap::value_parser!(u16).range(1..))]
+    pub metrics_port: Option<u16>,
+
     /// After successful auth, persist the password to the credential store
     /// (OS keyring or encrypted file).
     #[arg(long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub(crate) struct TomlConfig {
     pub photos: Option<TomlPhotos>,
     pub watch: Option<TomlWatch>,
     pub notifications: Option<TomlNotifications>,
+    pub metrics: Option<TomlMetrics>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -92,6 +93,12 @@ pub(crate) struct TomlWatch {
     pub interval: Option<u64>,
     pub notify_systemd: Option<bool>,
     pub pid_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlMetrics {
+    pub port: Option<u16>,
 }
 
 /// Load a TOML config file. Returns `Ok(None)` if the file doesn't exist
@@ -206,6 +213,7 @@ pub struct Config {
 
     // 2-byte primitives
     pub threads_num: u16,
+    pub metrics_port: Option<u16>,
 
     // 1-byte enums
     pub size: VersionSize,
@@ -481,6 +489,7 @@ impl Config {
         let toml_filters = toml.as_ref().and_then(|t| t.filters.as_ref());
         let toml_photos = toml.as_ref().and_then(|t| t.photos.as_ref());
         let toml_watch = toml.as_ref().and_then(|t| t.watch.as_ref());
+        let toml_metrics = toml.as_ref().and_then(|t| t.metrics.as_ref());
 
         // Download
         let directory = sync
@@ -666,6 +675,11 @@ impl Config {
         // JSON report
         let report_json = sync.report_json;
 
+        // Prometheus metrics port — CLI takes precedence over TOML.
+        let metrics_port = sync
+            .metrics_port
+            .or_else(|| toml_metrics.and_then(|m| m.port));
+
         if skip_videos && skip_photos && live_photo_mode == LivePhotoMode::Skip {
             tracing::warn!(
                 "All media types are being skipped (--skip-videos, --skip-photos, \
@@ -691,6 +705,7 @@ impl Config {
             pid_file,
             notification_script,
             report_json,
+            metrics_port,
             watch_with_interval,
             retry_delay_secs,
             recent,
@@ -868,6 +883,9 @@ impl Config {
                 .map(|s| TomlNotifications {
                     script: Some(s.display().to_string()),
                 }),
+            metrics: self
+                .metrics_port
+                .map(|port| TomlMetrics { port: Some(port) }),
         }
     }
 }
@@ -936,6 +954,7 @@ pub(crate) fn persist_first_run_config(
         photos: None,
         watch: None,
         notifications: None,
+        metrics: None,
     };
 
     // Don't write if there's nothing meaningful to persist
@@ -1909,6 +1928,69 @@ mod tests {
         assert_eq!(w.interval, Some(1800));
         assert_eq!(w.notify_systemd, Some(true));
         assert_eq!(w.pid_file.as_deref(), Some("/run/test.pid"));
+    }
+
+    #[test]
+    fn test_toml_metrics_port_parsed() {
+        let toml_str = r#"
+            [metrics]
+            port = 9090
+        "#;
+        let config: TomlConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.metrics.unwrap().port, Some(9090));
+    }
+
+    #[test]
+    fn test_toml_metrics_port_resolves_in_config() {
+        let toml_str = r#"
+            [auth]
+            username = "user@example.com"
+            [download]
+            directory = "/photos"
+            [metrics]
+            port = 9090
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let config = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(config.metrics_port, Some(9090));
+    }
+
+    #[test]
+    fn test_cli_metrics_port_overrides_toml() {
+        let toml_str = r#"
+            [auth]
+            username = "user@example.com"
+            [download]
+            directory = "/photos"
+            [metrics]
+            port = 9090
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let mut sync = default_sync();
+        sync.metrics_port = Some(8080);
+        let config =
+            Config::build(&default_globals(), default_password(), sync, Some(toml)).unwrap();
+        assert_eq!(config.metrics_port, Some(8080));
+    }
+
+    #[test]
+    fn test_toml_metrics_unknown_field_rejected() {
+        let toml_str = r#"
+            [metrics]
+            port = 9090
+            unknown_field = true
+        "#;
+        let result: Result<TomlConfig, _> = toml::from_str(toml_str);
+        assert!(
+            result.is_err(),
+            "unknown fields in [metrics] should be rejected"
+        );
     }
 
     // ── TOML file loading from disk ────────────────────────────────
@@ -3164,6 +3246,7 @@ mod tests {
             photos: None,
             watch: None,
             notifications: None,
+            metrics: None,
         };
         let result = resolve_data_dir(None, None, Some(&toml), Path::new("/config/config.toml"));
         assert_eq!(result, PathBuf::from("/toml/data"));
@@ -3187,6 +3270,7 @@ mod tests {
             photos: None,
             watch: None,
             notifications: None,
+            metrics: None,
         };
         let result = resolve_data_dir(None, None, Some(&toml), Path::new("/config/config.toml"));
         assert_eq!(result, PathBuf::from("/toml/cookies"));
@@ -3209,6 +3293,7 @@ mod tests {
             photos: None,
             watch: None,
             notifications: None,
+            metrics: None,
         };
         let result = resolve_data_dir(
             Some("/cli/data"),

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1796,6 +1796,7 @@ mod tests {
             pid_file: None,
             notification_script: None,
             report_json: None,
+            metrics_port: None,
             watch_with_interval: None,
             retry_delay_secs: 5,
             recent: dl_config.recent,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod credential;
 mod download;
 mod health;
 mod icloud;
+mod metrics;
 mod migration;
 mod notifications;
 mod password;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,759 @@
+//! Prometheus metrics and HTTP observability server.
+//!
+//! When `--metrics-port` is provided, spawns an axum HTTP server that serves:
+//! - `GET /metrics` — Prometheus text format
+//! - `GET /healthz`  — JSON health status (same data as `health.json`)
+//!
+//! Metrics are updated after every sync cycle by calling [`MetricsHandle::update`].
+//! On skipped cycles (no changes detected), call [`MetricsHandle::update_health_only`]
+//! to refresh the health gauges without clobbering cycle counters or duration.
+//! All counters are cumulative across cycles (they never reset while the process
+//! is running), matching Prometheus conventions.
+
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use prometheus_client::encoding::text::encode;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::download::SyncStats;
+use crate::health::HealthStatus;
+
+// ── Label types ──────────────────────────────────────────────────────────────
+
+/// Label set for the `kei_sync_skipped_total` counter family.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
+struct SkipLabels {
+    reason: &'static str,
+}
+
+// ── State shared between the HTTP handlers and the sync loop ─────────────────
+
+/// Health snapshot read by the /healthz handler. The registry is immutable
+/// after construction so it lives directly on MetricsHandle behind an Arc,
+/// letting /metrics encode without taking the lock.
+struct Inner {
+    health_snapshot: Option<HealthStatus>,
+}
+
+/// Cheap-to-clone handle passed to the sync loop and into axum state.
+#[derive(Clone)]
+pub(crate) struct MetricsHandle {
+    /// Prometheus registry — immutable after new(), so no lock needed for reads.
+    registry: Arc<Registry>,
+    /// Protects the /healthz snapshot only.
+    inner: Arc<Mutex<Inner>>,
+    // Metric handles use atomics internally; no lock needed for updates.
+    assets_seen: Counter,
+    downloaded: Counter,
+    failed: Counter,
+    skipped: Family<SkipLabels, Counter>,
+    bytes_downloaded: Counter,
+    disk_bytes_written: Counter,
+    exif_failures: Counter,
+    state_write_failures: Counter,
+    enumeration_errors: Counter,
+    session_expirations: Counter,
+    cycle_duration_seconds: Gauge<f64, AtomicU64>,
+    consecutive_failures: Gauge,
+    last_success_timestamp: Gauge<f64, AtomicU64>,
+    interrupted_cycles: Counter,
+}
+
+impl MetricsHandle {
+    /// Build the registry and register all metrics.
+    pub(crate) fn new() -> Self {
+        let mut registry = Registry::default();
+
+        let assets_seen = Counter::default();
+        registry.register(
+            "kei_sync_assets_seen",
+            "Total number of assets enumerated from iCloud across all sync cycles",
+            assets_seen.clone(),
+        );
+
+        let downloaded = Counter::default();
+        registry.register(
+            "kei_sync_downloaded",
+            "Total number of assets successfully downloaded",
+            downloaded.clone(),
+        );
+
+        let failed = Counter::default();
+        registry.register(
+            "kei_sync_failed",
+            "Total number of asset download failures",
+            failed.clone(),
+        );
+
+        let skipped: Family<SkipLabels, Counter> = Family::default();
+        registry.register(
+            "kei_sync_skipped",
+            "Total number of assets skipped, by reason",
+            skipped.clone(),
+        );
+
+        let bytes_downloaded = Counter::default();
+        registry.register(
+            "kei_sync_bytes_downloaded",
+            "Total bytes received over the network",
+            bytes_downloaded.clone(),
+        );
+
+        let disk_bytes_written = Counter::default();
+        registry.register(
+            "kei_sync_disk_bytes_written",
+            "Total bytes written to disk",
+            disk_bytes_written.clone(),
+        );
+
+        let exif_failures = Counter::default();
+        registry.register(
+            "kei_sync_exif_failures",
+            "Total number of EXIF stamping failures",
+            exif_failures.clone(),
+        );
+
+        let state_write_failures = Counter::default();
+        registry.register(
+            "kei_sync_state_write_failures",
+            "Total number of SQLite state write failures",
+            state_write_failures.clone(),
+        );
+
+        let enumeration_errors = Counter::default();
+        registry.register(
+            "kei_sync_enumeration_errors",
+            "Total number of iCloud API enumeration errors",
+            enumeration_errors.clone(),
+        );
+
+        let session_expirations = Counter::default();
+        registry.register(
+            "kei_sync_session_expirations",
+            "Total number of sync cycles aborted due to an expired iCloud session",
+            session_expirations.clone(),
+        );
+
+        let cycle_duration_seconds: Gauge<f64, AtomicU64> = Gauge::default();
+        registry.register(
+            "kei_sync_cycle_duration_seconds",
+            "Wall-clock duration of the most recent sync cycle in seconds",
+            cycle_duration_seconds.clone(),
+        );
+
+        let consecutive_failures: Gauge = Gauge::default();
+        registry.register(
+            "kei_health_consecutive_failures",
+            "Number of consecutive sync cycle failures",
+            consecutive_failures.clone(),
+        );
+
+        let last_success_timestamp: Gauge<f64, AtomicU64> = Gauge::default();
+        registry.register(
+            "kei_health_last_success_timestamp_seconds",
+            "Unix timestamp of the last successful sync cycle (0 if never succeeded)",
+            last_success_timestamp.clone(),
+        );
+
+        let interrupted_cycles = Counter::default();
+        registry.register(
+            "kei_sync_interrupted_cycles",
+            "Total number of sync cycles interrupted by a shutdown signal",
+            interrupted_cycles.clone(),
+        );
+
+        Self {
+            registry: Arc::new(registry),
+            inner: Arc::new(Mutex::new(Inner {
+                health_snapshot: None,
+            })),
+            assets_seen,
+            downloaded,
+            failed,
+            skipped,
+            bytes_downloaded,
+            disk_bytes_written,
+            exif_failures,
+            state_write_failures,
+            enumeration_errors,
+            session_expirations,
+            cycle_duration_seconds,
+            consecutive_failures,
+            last_success_timestamp,
+            interrupted_cycles,
+        }
+    }
+
+    /// Update all metrics from the latest completed sync cycle.
+    ///
+    /// Counters are incremented by this cycle's values; gauges are set to the
+    /// latest value. Call this after every cycle that actually ran.
+    pub(crate) async fn update(&self, stats: &SyncStats, health: &HealthStatus) {
+        // Counters — increment by this cycle's values.
+        self.assets_seen.inc_by(stats.assets_seen);
+        self.downloaded.inc_by(stats.downloaded as u64);
+        self.failed.inc_by(stats.failed as u64);
+        self.bytes_downloaded.inc_by(stats.bytes_downloaded);
+        self.disk_bytes_written.inc_by(stats.disk_bytes_written);
+        self.exif_failures.inc_by(stats.exif_failures as u64);
+        self.state_write_failures
+            .inc_by(stats.state_write_failures as u64);
+        self.enumeration_errors
+            .inc_by(stats.enumeration_errors as u64);
+
+        if stats.interrupted {
+            self.interrupted_cycles.inc();
+        }
+
+        // Skip breakdown counters with reason labels.
+        self.inc_skip("by_state", stats.skipped.by_state);
+        self.inc_skip("on_disk", stats.skipped.on_disk);
+        self.inc_skip("by_media_type", stats.skipped.by_media_type);
+        self.inc_skip("by_date_range", stats.skipped.by_date_range);
+        self.inc_skip("by_live_photo", stats.skipped.by_live_photo);
+        self.inc_skip("by_filename", stats.skipped.by_filename);
+        self.inc_skip("by_excluded_album", stats.skipped.by_excluded_album);
+        self.inc_skip("ampm_variant", stats.skipped.ampm_variant);
+        self.inc_skip("duplicates", stats.skipped.duplicates);
+        self.inc_skip("retry_exhausted", stats.skipped.retry_exhausted);
+        self.inc_skip("retry_only", stats.skipped.retry_only);
+
+        // Gauges — set to latest value.
+        self.cycle_duration_seconds.set(stats.elapsed_secs);
+
+        self.update_health_gauges(health).await;
+    }
+
+    /// Update only the health gauges and the /healthz snapshot.
+    ///
+    /// Use this on skipped cycles (no changes detected in watch mode) so that
+    /// `cycle_duration_seconds` and download counters are not clobbered.
+    pub(crate) async fn update_health_only(&self, health: &HealthStatus) {
+        self.update_health_gauges(health).await;
+    }
+
+    /// Increment the session expiration counter.
+    ///
+    /// Call this whenever a sync cycle is aborted due to an expired iCloud
+    /// session, in addition to the normal health update.
+    pub(crate) fn record_session_expiration(&self) {
+        self.session_expirations.inc();
+    }
+
+    async fn update_health_gauges(&self, health: &HealthStatus) {
+        self.consecutive_failures
+            .set(i64::from(health.consecutive_failures));
+        let last_success_ts = health
+            .last_success_at
+            .map(|t| t.timestamp() as f64)
+            .unwrap_or(0.0);
+        self.last_success_timestamp.set(last_success_ts);
+
+        let mut inner = self.inner.lock().await;
+        inner.health_snapshot = Some(HealthStatus {
+            last_sync_at: health.last_sync_at,
+            last_success_at: health.last_success_at,
+            consecutive_failures: health.consecutive_failures,
+            last_error: health.last_error.clone(),
+        });
+    }
+
+    fn inc_skip(&self, reason: &'static str, count: usize) {
+        if count > 0 {
+            self.skipped
+                .get_or_create(&SkipLabels { reason })
+                .inc_by(count as u64);
+        }
+    }
+}
+
+// ── HTTP handlers ─────────────────────────────────────────────────────────────
+
+async fn handle_metrics(State(handle): State<MetricsHandle>) -> impl IntoResponse {
+    let mut buf = String::new();
+    encode(&mut buf, &handle.registry).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "Failed to encode Prometheus metrics");
+    });
+
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/openmetrics-text; version=1.0.0; charset=utf-8"),
+        )],
+        buf,
+    )
+}
+
+async fn handle_healthz(State(handle): State<MetricsHandle>) -> impl IntoResponse {
+    let inner = handle.inner.lock().await;
+    match &inner.health_snapshot {
+        Some(h) => {
+            let consecutive_failures = h.consecutive_failures;
+            match serde_json::to_string_pretty(h) {
+                Ok(json) => {
+                    let status = if consecutive_failures >= 5 {
+                        StatusCode::SERVICE_UNAVAILABLE
+                    } else {
+                        StatusCode::OK
+                    };
+                    (
+                        status,
+                        [(
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static("application/json"),
+                        )],
+                        json,
+                    )
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to serialize health status for /healthz");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        [(
+                            header::CONTENT_TYPE,
+                            HeaderValue::from_static("application/json"),
+                        )],
+                        r#"{"error":"serialization failed"}"#.to_string(),
+                    )
+                }
+            }
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            )],
+            r#"{"status":"no sync cycle completed yet"}"#.to_string(),
+        ),
+    }
+}
+
+// ── Server entrypoint ─────────────────────────────────────────────────────────
+
+/// Bind and spawn the metrics HTTP server as a background tokio task.
+///
+/// Binds synchronously so that a misconfigured port fails at startup rather
+/// than silently. Returns a `MetricsHandle` the sync loop uses to push metrics
+/// after each cycle. The server shuts down gracefully when `shutdown_token` is
+/// cancelled.
+pub(crate) fn spawn_server(
+    port: u16,
+    shutdown_token: CancellationToken,
+) -> anyhow::Result<MetricsHandle> {
+    let handle = MetricsHandle::new();
+    let app = Router::new()
+        .route("/metrics", get(handle_metrics))
+        .route("/healthz", get(handle_healthz))
+        .with_state(handle.clone());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let std_listener = std::net::TcpListener::bind(addr)
+        .map_err(|e| anyhow::anyhow!("Failed to bind metrics server on port {port}: {e}"))?;
+    std_listener.set_nonblocking(true)?;
+    let listener = tokio::net::TcpListener::from_std(std_listener)?;
+
+    tracing::info!(port, "Prometheus metrics server listening");
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown_token.cancelled().await })
+            .await
+        {
+            tracing::warn!(error = %e, "Metrics server error");
+        }
+        tracing::info!(port, "Prometheus metrics server stopped");
+    });
+
+    Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+
+    fn healthy_status(consecutive_failures: u32) -> HealthStatus {
+        let mut h = HealthStatus::new();
+        if consecutive_failures == 0 {
+            h.record_success();
+        } else {
+            for i in 0..consecutive_failures {
+                h.record_failure(&format!("error {i}"));
+            }
+        }
+        h
+    }
+
+    fn stats_with(downloaded: usize, failed: usize, bytes: u64) -> SyncStats {
+        SyncStats {
+            downloaded,
+            failed,
+            bytes_downloaded: bytes,
+            ..SyncStats::default()
+        }
+    }
+
+    async fn render_metrics(handle: &MetricsHandle) -> String {
+        let response = handle_metrics(State(handle.clone())).await;
+        let body = axum::body::to_bytes(
+            axum::response::IntoResponse::into_response(response).into_body(),
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        String::from_utf8(body.to_vec()).unwrap()
+    }
+
+    async fn render_healthz(handle: &MetricsHandle) -> (axum::http::StatusCode, String) {
+        let response = axum::response::IntoResponse::into_response(
+            handle_healthz(State(handle.clone())).await,
+        );
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    // ── /metrics content-type ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn metrics_response_has_openmetrics_content_type() {
+        let handle = MetricsHandle::new();
+        let response =
+            axum::response::IntoResponse::into_response(handle_metrics(State(handle)).await);
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            content_type.contains("application/openmetrics-text"),
+            "unexpected content-type: {content_type}"
+        );
+    }
+
+    // ── counter accumulation ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn counters_reflect_single_cycle() {
+        let handle = MetricsHandle::new();
+        let stats = stats_with(5, 2, 1024);
+        handle.update(&stats, &healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_sync_downloaded_total 5"),
+            "output:\n{output}"
+        );
+        assert!(
+            output.contains("kei_sync_failed_total 2"),
+            "output:\n{output}"
+        );
+        assert!(
+            output.contains("kei_sync_bytes_downloaded_total 1024"),
+            "output:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn counters_accumulate_across_cycles() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&stats_with(3, 1, 500), &healthy_status(0))
+            .await;
+        handle
+            .update(&stats_with(4, 0, 300), &healthy_status(0))
+            .await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_sync_downloaded_total 7"),
+            "output:\n{output}"
+        );
+        assert!(
+            output.contains("kei_sync_failed_total 1"),
+            "output:\n{output}"
+        );
+        assert!(
+            output.contains("kei_sync_bytes_downloaded_total 800"),
+            "output:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gauges_reflect_only_the_latest_cycle() {
+        let handle = MetricsHandle::new();
+        let stats1 = SyncStats {
+            elapsed_secs: 10.0,
+            ..Default::default()
+        };
+        handle.update(&stats1, &healthy_status(0)).await;
+
+        let stats2 = SyncStats {
+            elapsed_secs: 25.0,
+            ..Default::default()
+        };
+        handle.update(&stats2, &healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_sync_cycle_duration_seconds 25"),
+            "output:\n{output}"
+        );
+        assert!(
+            !output.contains("kei_sync_cycle_duration_seconds 10"),
+            "old gauge value should not appear:\n{output}"
+        );
+    }
+
+    // ── update_health_only does not clobber cycle duration ────────────────────
+
+    #[tokio::test]
+    async fn cycle_duration_not_clobbered_by_health_only_update() {
+        let handle = MetricsHandle::new();
+        let stats = SyncStats {
+            elapsed_secs: 25.0,
+            ..Default::default()
+        };
+        handle.update(&stats, &healthy_status(0)).await;
+
+        // Simulate a skipped cycle: should not reset duration to 0.
+        handle.update_health_only(&healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_sync_cycle_duration_seconds 25"),
+            "cycle_duration_seconds should not be clobbered by update_health_only:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_only_update_still_refreshes_health_gauges() {
+        let handle = MetricsHandle::new();
+        // First real cycle with 3 failures.
+        handle
+            .update(&SyncStats::default(), &healthy_status(3))
+            .await;
+        // Skipped cycle that resolves to healthy.
+        handle.update_health_only(&healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_health_consecutive_failures 0"),
+            "health gauge should be updated by update_health_only:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_only_update_refreshes_healthz_snapshot() {
+        let handle = MetricsHandle::new();
+        handle.update_health_only(&healthy_status(0)).await;
+
+        let (status, _body) = render_healthz(&handle).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "/healthz should return 200 after update_health_only with no failures"
+        );
+    }
+
+    // ── interrupted counter ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn interrupted_flag_increments_counter() {
+        let handle = MetricsHandle::new();
+        let stats = SyncStats {
+            interrupted: true,
+            ..Default::default()
+        };
+        handle.update(&stats, &healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_sync_interrupted_cycles_total 1"),
+            "output:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_interrupted_cycle_does_not_increment_counter() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(0))
+            .await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            !output.contains("kei_sync_interrupted_cycles_total 1"),
+            "output:\n{output}"
+        );
+    }
+
+    // ── session expiration counter ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn session_expiration_counter_increments() {
+        let handle = MetricsHandle::new();
+        handle.record_session_expiration();
+        handle.record_session_expiration();
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_sync_session_expirations_total 2"),
+            "output:\n{output}"
+        );
+    }
+
+    // ── skip breakdown labels ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn skip_breakdown_emits_labelled_counters() {
+        let handle = MetricsHandle::new();
+        let mut stats = SyncStats::default();
+        stats.skipped.by_state = 10;
+        stats.skipped.on_disk = 3;
+        stats.skipped.retry_exhausted = 1;
+        handle.update(&stats, &healthy_status(0)).await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains(r#"reason="by_state""#) && output.contains("10"),
+            "by_state label missing:\n{output}"
+        );
+        assert!(
+            output.contains(r#"reason="on_disk""#) && output.contains("3"),
+            "on_disk label missing:\n{output}"
+        );
+        assert!(
+            output.contains(r#"reason="retry_exhausted""#) && output.contains("1"),
+            "retry_exhausted label missing:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_skips_do_not_create_label_series() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(0))
+            .await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            !output.contains(r#"reason="by_state""#),
+            "zero-count skip series should not appear:\n{output}"
+        );
+    }
+
+    // ── health gauges ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn consecutive_failures_gauge_tracks_health() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(3))
+            .await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_health_consecutive_failures 3"),
+            "output:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn consecutive_failures_gauge_resets_on_success() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(3))
+            .await;
+        handle
+            .update(&SyncStats::default(), &healthy_status(0))
+            .await;
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_health_consecutive_failures 0"),
+            "output:\n{output}"
+        );
+    }
+
+    // ── /healthz endpoint ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn healthz_returns_503_before_first_cycle() {
+        let handle = MetricsHandle::new();
+        let (status, _body) = render_healthz(&handle).await;
+        assert_eq!(status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_200_after_successful_cycle() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(0))
+            .await;
+
+        let (status, body) = render_healthz(&handle).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        serde_json::from_str::<serde_json::Value>(&body)
+            .expect("healthz body should be valid JSON");
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_503_when_consecutive_failures_reaches_threshold() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(5))
+            .await;
+
+        let (status, _body) = render_healthz(&handle).await;
+        assert_eq!(status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_200_when_consecutive_failures_below_threshold() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(4))
+            .await;
+
+        let (status, _body) = render_healthz(&handle).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn healthz_body_contains_expected_fields() {
+        let handle = MetricsHandle::new();
+        handle
+            .update(&SyncStats::default(), &healthy_status(0))
+            .await;
+
+        let (_status, body) = render_healthz(&handle).await;
+        let json: serde_json::Value =
+            serde_json::from_str(&body).expect("healthz body should be valid JSON");
+        assert!(
+            json.get("consecutive_failures").is_some(),
+            "missing consecutive_failures"
+        );
+        assert!(json.get("last_sync_at").is_some(), "missing last_sync_at");
+        assert!(
+            json.get("last_success_at").is_some(),
+            "missing last_success_at"
+        );
+    }
+}

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -416,6 +416,13 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     }
     sd_notifier.notify_ready();
 
+    // Spawn the Prometheus metrics + /healthz server if --metrics-port is set.
+    // Binds synchronously so a bad port fails at startup rather than silently.
+    let metrics_handle = config
+        .metrics_port
+        .map(|port| crate::metrics::spawn_server(port, shutdown_token.clone()))
+        .transpose()?;
+
     let mut health = health::HealthStatus::new();
     let mut consecutive_album_refresh_failures = 0u32;
 
@@ -440,6 +447,10 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // the 2-hour staleness window when no new photos are uploaded.
             health.record_success();
             health.write(&config.cookie_directory);
+            // Refresh health gauges only -- do not reset cycle_duration_seconds.
+            if let Some(ref handle) = metrics_handle {
+                handle.update_health_only(&health).await;
+            }
         } else {
             sd_notifier.notify_status("Syncing...");
             sd_notifier.notify_watchdog();
@@ -464,6 +475,14 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 health.record_success();
             }
             health.write(&config.cookie_directory);
+
+            // Update Prometheus metrics if the server is running.
+            if let Some(ref handle) = metrics_handle {
+                if cycle_result.session_expired {
+                    handle.record_session_expiration();
+                }
+                handle.update(&cycle_result.stats, &health).await;
+            }
 
             // Write JSON report if configured
             if let Some(report_path) = &config.report_json {


### PR DESCRIPTION
## Summary

Fixes #224

Adds an opt-in HTTP server that exposes a Prometheus `/metrics` endpoint and a `/healthz` endpoint. Activated via `--metrics-port <PORT>` or `KEI_METRICS_PORT`. When the flag is not set, behaviour is unchanged.

## Test plan

- `cargo fmt -- --check` passes
- `cargo clippy -- -D warnings` passes
- `cargo test --bin kei --test cli --test behavioral` passes (1229 unit + 103 behavioral + 95 CLI)
- 15 new unit tests added to `src/metrics.rs` covering counter accumulation, gauge semantics, skip label mapping, and all `/healthz` response codes

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --bin kei --test cli --test behavioral` passes