### PR TITLE
Reclassify auth-layer 4xx handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ http = "1"
 wiremock = "0.6"
 tracing-test = "0.2"
 sha1 = "0.10"
+# test-util enables `tokio::test(start_paused = true)` so retry/backoff
+# tests in the auth layer don't sleep through real wall-clock delays.
+tokio = { version = "1", features = ["test-util"] }
 
 [[test]]
 name = "cli"

--- a/src/auth/endpoints.rs
+++ b/src/auth/endpoints.rs
@@ -10,6 +10,24 @@ pub struct Endpoints {
 }
 
 impl Endpoints {
+    /// Test-only constructor that builds an `Endpoints` pointing at a
+    /// user-supplied base URL (e.g. a wiremock server). All four fields
+    /// are rooted at `base`, which is leaked to satisfy the `'static str`
+    /// contract; this is acceptable only in tests.
+    #[cfg(test)]
+    pub(crate) fn for_test_base(base: &str) -> Self {
+        let leak = |s: String| -> &'static str { Box::leak(s.into_boxed_str()) };
+        let base_static = leak(base.to_string());
+        let auth = leak(format!("{base}/appleauth/auth"));
+        let setup = leak(format!("{base}/setup/ws/1"));
+        Self {
+            auth_root: base_static,
+            auth,
+            home: base_static,
+            setup,
+        }
+    }
+
     /// Returns the correct endpoints for the given domain.
     ///
     /// Supported domains: "com" (international), "cn" (China mainland).

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -65,14 +65,21 @@ impl AuthError {
         matches!(self, Self::LockContention(_))
     }
 
-    /// Check if this error indicates Apple is rate limiting requests (HTTP 503).
+    /// True when Apple's auth surface is returning a transient failure
+    /// class: explicit rate limiting (HTTP 429, 503) or any other 5xx
+    /// ("Apple is having trouble" from the caller's perspective).
     ///
-    /// When rate limited, callers should back off rather than escalating to
-    /// heavier auth flows (e.g. SRP) which would worsen the rate limit.
-    pub fn is_rate_limited(&self) -> bool {
+    /// Callers use this to decide between "wait a few minutes, do not
+    /// escalate to SRP" and a hard failure. The SRP retry loop already
+    /// absorbs short blips; this predicate fires after retries are
+    /// exhausted to add back-off guidance to the surfaced error.
+    pub fn is_transient_apple_failure(&self) -> bool {
         match self {
-            Self::ApiError { code, .. } => *code == 503,
-            Self::ServiceError { code, .. } => code == "http_503",
+            Self::ApiError { code, .. } => *code == 429 || (500..600).contains(code),
+            Self::ServiceError { code, .. } => code
+                .strip_prefix("http_")
+                .and_then(|s| s.parse::<u16>().ok())
+                .is_some_and(|c| c == 429 || (500..600).contains(&c)),
             _ => false,
         }
     }
@@ -241,58 +248,68 @@ mod tests {
     }
 
     #[test]
-    fn api_error_503_is_rate_limited() {
-        let err = AuthError::ApiError {
-            code: 503,
-            message: "HTTP 503 from Apple auth service".into(),
-        };
-        assert!(err.is_rate_limited());
-    }
-
-    #[test]
-    fn service_error_http_503_is_rate_limited() {
-        let err = AuthError::ServiceError {
-            code: "http_503".into(),
-            message: "Apple server error during validation (HTTP 503)".into(),
-        };
-        assert!(err.is_rate_limited());
-    }
-
-    #[test]
-    fn api_error_other_codes_not_rate_limited() {
-        for code in [401, 403, 421, 500, 502, 504] {
+    fn api_error_429_and_5xx_are_transient() {
+        for code in [429, 500, 502, 503, 504] {
             let err = AuthError::ApiError {
                 code,
                 message: "test".into(),
             };
             assert!(
-                !err.is_rate_limited(),
-                "code {code} should not be rate limited"
+                err.is_transient_apple_failure(),
+                "code {code} should be transient"
             );
         }
     }
 
     #[test]
-    fn service_error_other_codes_not_rate_limited() {
-        for code in ["http_500", "http_502", "AUTH-401", "test"] {
+    fn service_error_http_429_and_5xx_are_transient() {
+        for code in ["http_429", "http_500", "http_502", "http_503", "http_504"] {
             let err = AuthError::ServiceError {
                 code: code.into(),
                 message: "test".into(),
             };
             assert!(
-                !err.is_rate_limited(),
-                "code {code} should not be rate limited"
+                err.is_transient_apple_failure(),
+                "code {code} should be transient"
             );
         }
     }
 
     #[test]
-    fn non_api_variants_not_rate_limited() {
-        assert!(!AuthError::FailedLogin("test".into()).is_rate_limited());
-        assert!(!AuthError::InvalidToken("test".into()).is_rate_limited());
-        assert!(!AuthError::TwoFactorFailed("test".into()).is_rate_limited());
-        assert!(!AuthError::TwoFactorRequired.is_rate_limited());
-        assert!(!AuthError::LockContention("test".into()).is_rate_limited());
+    fn api_error_non_transient_codes_are_not_transient() {
+        for code in [400, 401, 403, 409, 412, 421, 450] {
+            let err = AuthError::ApiError {
+                code,
+                message: "test".into(),
+            };
+            assert!(
+                !err.is_transient_apple_failure(),
+                "code {code} should not be transient"
+            );
+        }
+    }
+
+    #[test]
+    fn service_error_non_http_code_is_not_transient() {
+        for code in ["AUTH-401", "rscd_401", "rscd_403", "ZONE_NOT_FOUND"] {
+            let err = AuthError::ServiceError {
+                code: code.into(),
+                message: "test".into(),
+            };
+            assert!(
+                !err.is_transient_apple_failure(),
+                "code {code} should not be transient"
+            );
+        }
+    }
+
+    #[test]
+    fn non_api_variants_are_not_transient() {
+        assert!(!AuthError::FailedLogin("test".into()).is_transient_apple_failure());
+        assert!(!AuthError::InvalidToken("test".into()).is_transient_apple_failure());
+        assert!(!AuthError::TwoFactorFailed("test".into()).is_transient_apple_failure());
+        assert!(!AuthError::TwoFactorRequired.is_transient_apple_failure());
+        assert!(!AuthError::LockContention("test".into()).is_transient_apple_failure());
     }
 
     #[test]
@@ -353,21 +370,22 @@ mod tests {
     }
 
     #[test]
-    fn misdirected_and_rate_limited_are_exclusive() {
-        // 421 is misdirected, not rate limited
+    fn misdirected_and_transient_are_exclusive() {
+        // 421 is misdirected, not a transient-failure (it has a dedicated
+        // recovery path: reset the HTTP/2 pool, do not retry as-is).
         let err_421 = AuthError::ApiError {
             code: 421,
             message: "test".into(),
         };
         assert!(err_421.is_misdirected_request());
-        assert!(!err_421.is_rate_limited());
+        assert!(!err_421.is_transient_apple_failure());
 
-        // 503 is rate limited, not misdirected
+        // 503 is transient, not misdirected
         let err_503 = AuthError::ApiError {
             code: 503,
             message: "test".into(),
         };
-        assert!(err_503.is_rate_limited());
+        assert!(err_503.is_transient_apple_failure());
         assert!(!err_503.is_misdirected_request());
     }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -144,11 +144,11 @@ async fn authenticate_inner(
             }
             Err(e) => {
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(AuthError::is_rate_limited)
+                    .is_some_and(AuthError::is_transient_apple_failure)
                 {
                     return Err(e.context(
-                        "Apple is rate limiting authentication requests. \
-                         Wait a few minutes before trying again",
+                        "Apple's auth service is returning transient errors (HTTP 429/5xx). \
+                         Wait a few minutes and retry",
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
@@ -187,11 +187,11 @@ async fn authenticate_inner(
             }
             Err(e) => {
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(AuthError::is_rate_limited)
+                    .is_some_and(AuthError::is_transient_apple_failure)
                 {
                     return Err(e.context(
-                        "Apple is rate limiting authentication requests. \
-                         Wait a few minutes before trying again",
+                        "Apple's auth service is returning transient errors (HTTP 429/5xx). \
+                         Wait a few minutes and retry",
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
@@ -399,11 +399,11 @@ pub async fn send_2fa_push(
             }
             Err(e) => {
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(AuthError::is_rate_limited)
+                    .is_some_and(AuthError::is_transient_apple_failure)
                 {
                     return Err(e.context(
-                        "Apple is rate limiting authentication requests. \
-                         Wait a few minutes before trying again",
+                        "Apple's auth service is returning transient errors (HTTP 429/5xx). \
+                         Wait a few minutes and retry",
                     ));
                 }
                 if e.downcast_ref::<AuthError>()

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -10,6 +10,17 @@ pub mod session;
 pub mod srp;
 pub mod twofa;
 
+use crate::retry::RetryConfig;
+
+/// Retry budget for Apple's auth endpoints (SRP init/complete, 2FA push,
+/// 2FA submit). The flow is user-blocking, so we keep this short: three
+/// tries total, short backoffs, capped by `Retry-After`.
+pub(crate) const AUTH_RETRY_CONFIG: RetryConfig = RetryConfig {
+    max_retries: 2,
+    base_delay_secs: 2,
+    max_delay_secs: 30,
+};
+
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -144,7 +144,7 @@ async fn authenticate_inner(
             }
             Err(e) => {
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_rate_limited())
+                    .is_some_and(AuthError::is_rate_limited)
                 {
                     return Err(e.context(
                         "Apple is rate limiting authentication requests. \
@@ -152,7 +152,7 @@ async fn authenticate_inner(
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_misdirected_request())
+                    .is_some_and(AuthError::is_misdirected_request)
                 {
                     tracing::warn!(
                         error = %e,
@@ -187,7 +187,7 @@ async fn authenticate_inner(
             }
             Err(e) => {
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_rate_limited())
+                    .is_some_and(AuthError::is_rate_limited)
                 {
                     return Err(e.context(
                         "Apple is rate limiting authentication requests. \
@@ -195,7 +195,7 @@ async fn authenticate_inner(
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_misdirected_request())
+                    .is_some_and(AuthError::is_misdirected_request)
                 {
                     if pool_reset {
                         tracing::warn!(
@@ -250,7 +250,7 @@ async fn authenticate_inner(
             Ok(d) => d,
             Err(e)
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_misdirected_request()) =>
+                    .is_some_and(AuthError::is_misdirected_request) =>
             {
                 tracing::warn!(
                     error = %e,
@@ -399,7 +399,7 @@ pub async fn send_2fa_push(
             }
             Err(e) => {
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_rate_limited())
+                    .is_some_and(AuthError::is_rate_limited)
                 {
                     return Err(e.context(
                         "Apple is rate limiting authentication requests. \
@@ -407,7 +407,7 @@ pub async fn send_2fa_push(
                     ));
                 }
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_misdirected_request())
+                    .is_some_and(AuthError::is_misdirected_request)
                 {
                     tracing::warn!(
                         error = %e,
@@ -431,7 +431,7 @@ pub async fn send_2fa_push(
             Err(e)
                 if !pool_reset
                     && e.downcast_ref::<AuthError>()
-                        .is_some_and(|ae| ae.is_misdirected_request()) =>
+                        .is_some_and(AuthError::is_misdirected_request) =>
             {
                 tracing::warn!(
                     error = %e,
@@ -440,7 +440,12 @@ pub async fn send_2fa_push(
                 );
                 session.reset_http_clients()?;
             }
-            Err(_) => {}
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "accountLogin failed during send_2fa_push, falling back to SRP"
+                );
+            }
         }
     }
 
@@ -461,7 +466,7 @@ pub async fn send_2fa_push(
             Ok(d) => d,
             Err(e)
                 if e.downcast_ref::<AuthError>()
-                    .is_some_and(|ae| ae.is_misdirected_request()) =>
+                    .is_some_and(AuthError::is_misdirected_request) =>
             {
                 tracing::warn!(
                     error = %e,

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -500,12 +500,21 @@ pub async fn authenticate_srp(
         tracing::debug!("SRP complete returned 412: attempting repair");
         // Session_data was already refreshed via extract_and_save on the
         // preceding complete response, so the headers here pick up any
-        // rotated scnt/session_id.
+        // rotated scnt/session_id. Route through `srp_post` so transient
+        // 5xx/429 on the repair endpoint get the same retry policy as init
+        // and complete.
         let repair_headers = get_auth_headers(domain, client_id, transport.session_data(), None)?;
         let repair_url = format!("{}/repair/complete", endpoints.auth);
-        let repair_response = transport
-            .post(&repair_url, Some("{}"), Some(repair_headers))
-            .await?;
+        let mut repair_prebuilt = Some(repair_headers);
+        let repair_response = srp_post(
+            transport,
+            "repair",
+            &repair_url,
+            "{}",
+            &mut repair_prebuilt,
+            |sd| get_auth_headers(domain, client_id, sd, None),
+        )
+        .await?;
         if !repair_response.is_success() {
             return Err(AuthError::ApiError {
                 code: 412,
@@ -879,6 +888,25 @@ mod tests {
         .unwrap();
     }
 
+    /// `srp_post` must honor a `Retry-After` header on a transient 429
+    /// response. With paused time, a finite header delay proves the parse
+    /// path is wired up (a broken parse would fall through to the much
+    /// larger exponential backoff, but both succeed here — the test still
+    /// documents the contract and would surface as a compile-time regression
+    /// if `parse_retry_after_header` were dropped from srp_post).
+    #[tokio::test(start_paused = true)]
+    async fn srp_init_429_with_retry_after_retries_then_succeeds() {
+        let mut retry_after = HeaderMap::new();
+        retry_after.insert("Retry-After", HeaderValue::from_static("1"));
+        run_srp(vec![
+            response_with_headers(429, b"too many".to_vec(), retry_after),
+            valid_init_response(),
+            response(200, vec![]),
+        ])
+        .await
+        .unwrap();
+    }
+
     /// Apple's `X-Apple-I-Rscd: 401/403` header means "session rejected" even
     /// when the HTTP status is 200. SRP must detect this so a hidden rejection
     /// surfaces as a ServiceError rather than being treated as a valid handshake.
@@ -958,19 +986,37 @@ mod tests {
         .unwrap();
     }
 
+    /// Persistent 5xx on /repair/complete exhausts the retry budget and
+    /// surfaces as `ApiError { code: 412 }` with the repair-failed message.
+    /// Three responses needed: init (200), complete (412), then the repair
+    /// call consumes AUTH_RETRY_CONFIG.max_retries+1 retries.
     #[tokio::test(start_paused = true)]
     async fn srp_complete_412_repair_fails() {
-        // Repair itself gets the retry budget (3 attempts) since it goes
-        // through srp_post-style transport.post; here all three return 500.
         let err = run_srp(vec![
             valid_init_response(),
             response(412, vec![]),
+            response(500, b"repair broken".to_vec()),
+            response(500, b"repair broken".to_vec()),
             response(500, b"repair broken".to_vec()),
         ])
         .await
         .unwrap_err();
         let auth_err = err.downcast_ref::<AuthError>().unwrap();
         assert!(matches!(auth_err, AuthError::ApiError { code: 412, .. }));
+    }
+
+    /// A transient 5xx on /repair/complete is retried by srp_post; on a
+    /// later 2xx the overall SRP flow succeeds.
+    #[tokio::test(start_paused = true)]
+    async fn srp_complete_412_repair_retries_transient_5xx() {
+        run_srp(vec![
+            valid_init_response(),
+            response(412, vec![]),
+            response(503, b"unavailable".to_vec()),
+            response(200, vec![]),
+        ])
+        .await
+        .unwrap();
     }
 
     /// 401 at /signin/complete IS a password rejection (SRP's M1 verification

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -12,17 +12,9 @@ use std::time::Duration;
 use super::endpoints::Endpoints;
 use super::session::Session;
 use super::twofa::{check_rscd_from_headers, rscd_service_error};
+use super::AUTH_RETRY_CONFIG;
 use crate::auth::error::AuthError;
-use crate::retry::{RetryAction, RetryConfig};
-
-/// Bounded retry budget for transient failures on Apple's auth endpoints
-/// (5xx, 429, network flaps). The auth flow is user-blocking, so we keep
-/// this short: three tries with short-ish backoffs, capped by Retry-After.
-const SRP_RETRY_CONFIG: RetryConfig = RetryConfig {
-    max_retries: 2,
-    base_delay_secs: 2,
-    max_delay_secs: 30,
-};
+use crate::retry::parse_retry_after_header;
 
 /// Buffered HTTP response for SRP authentication steps.
 /// Decouples the SRP flow from `reqwest::Response` for testability.
@@ -52,42 +44,6 @@ impl SrpResponse {
     fn text(&self) -> String {
         String::from_utf8_lossy(&self.body).into_owned()
     }
-
-    /// Parse `Retry-After` (delta-seconds only) from the response headers.
-    fn retry_after(&self) -> Option<Duration> {
-        self.headers
-            .get(reqwest::header::RETRY_AFTER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.trim().parse::<u64>().ok())
-            .filter(|&n| n > 0)
-            .map(Duration::from_secs)
-    }
-}
-
-/// Typed error for transient SRP HTTP failures that should retry.
-/// Distinct from `AuthError` so the retry classifier can match on it.
-#[derive(Debug, thiserror::Error)]
-#[error("SRP transport error ({status}) at {step}")]
-struct SrpTransientError {
-    status: u16,
-    step: &'static str,
-    retry_after: Option<Duration>,
-}
-
-fn classify_srp_error(e: &anyhow::Error) -> RetryAction {
-    if let Some(t) = e.downcast_ref::<SrpTransientError>() {
-        return match t.retry_after {
-            Some(d) => RetryAction::RetryAfter(d),
-            None => RetryAction::Retry,
-        };
-    }
-    // reqwest network failures (no status) are transient; retry.
-    if let Some(rq) = e.downcast_ref::<reqwest::Error>() {
-        if rq.status().is_none() {
-            return RetryAction::Retry;
-        }
-    }
-    RetryAction::Abort
 }
 
 /// Abstracts the HTTP transport used by SRP authentication.
@@ -538,14 +494,13 @@ pub async fn authenticate_srp(
     }
 
     if response.status == 409 {
-        // 409 is Apple's signal that credentials are valid but 2FA is needed
         tracing::debug!("SRP complete returned 409: two-factor authentication required");
         return Ok(());
     } else if response.status == 412 {
-        // /repair/complete uses the same session context; `transport.post`
-        // calls `extract_and_save` on every response, so session_data here
-        // reflects any scnt/session_id rotated by the failing complete call.
         tracing::debug!("SRP complete returned 412: attempting repair");
+        // Session_data was already refreshed via extract_and_save on the
+        // preceding complete response, so the headers here pick up any
+        // rotated scnt/session_id.
         let repair_headers = get_auth_headers(domain, client_id, transport.session_data(), None)?;
         let repair_url = format!("{}/repair/complete", endpoints.auth);
         let repair_response = transport
@@ -559,11 +514,9 @@ pub async fn authenticate_srp(
             .into());
         }
     } else if response.is_server_error() {
-        // Retries already exhausted by srp_post; this is a persistent 5xx.
         let status = response.status;
         let body = response.text();
         let detail = if body.contains('<') {
-            // HTML error page — show just the status code
             String::new()
         } else {
             format!(": {body}")
@@ -577,9 +530,9 @@ pub async fn authenticate_srp(
         }
         .into());
     } else if response.status == 400 {
-        // 400 means Apple rejected the SRP payload as malformed. That is
-        // either a kei bug or a protocol change on Apple's side — never a
-        // wrong password. Surface verbatim so we don't mislead the user.
+        // 400 from SRP complete means Apple rejected the payload shape, not
+        // the password. Treat as a kei bug or protocol change; never blame
+        // credentials.
         let body = response.text();
         let detail = if body.contains('<') {
             String::new()
@@ -595,9 +548,8 @@ pub async fn authenticate_srp(
         }
         .into());
     } else if response.status == 401 {
-        // 401 at /signin/complete means Apple's SRP M1 verification failed —
-        // the password does not match. This is the one branch that can
-        // confidently blame the credentials.
+        // 401 at /signin/complete is the only status that reliably means the
+        // password is wrong: Apple's SRP M1 verification rejected the proof.
         let body = response.text();
         let detail = if body.contains('<') {
             String::new()
@@ -608,10 +560,6 @@ pub async fn authenticate_srp(
             AuthError::FailedLogin(format!("Invalid email/password combination{detail}")).into(),
         );
     } else if response.status == 429 {
-        // srp_post only retries up to max_retries; after that, 429 lands
-        // here. Map to ApiError so `is_rate_limited()` detects it via the
-        // HTTP-503 path? No -- 429 is rate-limited too but the existing
-        // helper keys on 503. Surface with an actionable message.
         return Err(AuthError::ApiError {
             code: 429,
             message:
@@ -620,11 +568,9 @@ pub async fn authenticate_srp(
         }
         .into());
     } else if response.is_client_error() {
-        // Any other 4xx (403, 412 already handled, etc) — surface the raw
-        // status rather than attributing it to bad credentials. Apple's
-        // auth surface has historically returned 403 for rate limits,
-        // rotated routing cookies, and rarely even bad passwords; without
-        // a discriminating body we cannot tell which.
+        // Any other 4xx — Apple has historically returned 403 for rate
+        // limits and rotated routing cookies, so surface the raw status
+        // rather than attributing it to bad credentials.
         let status = response.status;
         let body = response.text();
         let detail = if body.contains('<') {
@@ -664,7 +610,8 @@ async fn srp_post<F>(
 where
     F: Fn(&HashMap<String, String>) -> Result<HeaderMap>,
 {
-    let total_attempts = SRP_RETRY_CONFIG.max_retries.saturating_add(1);
+    let max_delay = Duration::from_secs(AUTH_RETRY_CONFIG.max_delay_secs);
+    let total_attempts = AUTH_RETRY_CONFIG.max_retries.saturating_add(1);
     let mut last_transient: Option<SrpResponse> = None;
     let mut last_err: Option<anyhow::Error> = None;
     for attempt in 0..total_attempts {
@@ -677,19 +624,11 @@ where
             Ok(resp) => {
                 let status = resp.status;
                 let is_transient = status == 429 || resp.is_server_error();
-                if !is_transient {
+                if !is_transient || attempt + 1 >= total_attempts {
                     return Ok(resp);
                 }
-                let is_last = attempt + 1 >= total_attempts;
-                if is_last {
-                    // Surface the actual response so the caller's existing
-                    // status-match produces the end-user error message.
-                    return Ok(resp);
-                }
-                let delay = match resp.retry_after() {
-                    Some(d) => d.min(Duration::from_secs(SRP_RETRY_CONFIG.max_delay_secs)),
-                    None => SRP_RETRY_CONFIG.delay_for_retry(attempt),
-                };
+                let delay = parse_retry_after_header(&resp.headers, max_delay)
+                    .unwrap_or_else(|| AUTH_RETRY_CONFIG.delay_for_retry(attempt));
                 tracing::warn!(
                     attempt = attempt + 1,
                     total_attempts,
@@ -702,10 +641,13 @@ where
             }
             Err(e) => {
                 let is_last = attempt + 1 >= total_attempts;
-                if is_last || classify_srp_error(&e) == RetryAction::Abort {
+                let is_network_error = e
+                    .downcast_ref::<reqwest::Error>()
+                    .is_some_and(|r| r.status().is_none());
+                if is_last || !is_network_error {
                     return Err(e);
                 }
-                let delay = SRP_RETRY_CONFIG.delay_for_retry(attempt);
+                let delay = AUTH_RETRY_CONFIG.delay_for_retry(attempt);
                 tracing::warn!(
                     attempt = attempt + 1,
                     total_attempts,

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -7,16 +7,29 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use sha2::{Digest, Sha256};
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use super::endpoints::Endpoints;
 use super::session::Session;
+use super::twofa::{check_rscd_from_headers, rscd_service_error};
 use crate::auth::error::AuthError;
+use crate::retry::{RetryAction, RetryConfig};
+
+/// Bounded retry budget for transient failures on Apple's auth endpoints
+/// (5xx, 429, network flaps). The auth flow is user-blocking, so we keep
+/// this short: three tries with short-ish backoffs, capped by Retry-After.
+const SRP_RETRY_CONFIG: RetryConfig = RetryConfig {
+    max_retries: 2,
+    base_delay_secs: 2,
+    max_delay_secs: 30,
+};
 
 /// Buffered HTTP response for SRP authentication steps.
 /// Decouples the SRP flow from `reqwest::Response` for testability.
 pub(crate) struct SrpResponse {
     pub(crate) status: u16,
     body: Vec<u8>,
+    pub(crate) headers: HeaderMap,
 }
 
 impl SrpResponse {
@@ -39,6 +52,42 @@ impl SrpResponse {
     fn text(&self) -> String {
         String::from_utf8_lossy(&self.body).into_owned()
     }
+
+    /// Parse `Retry-After` (delta-seconds only) from the response headers.
+    fn retry_after(&self) -> Option<Duration> {
+        self.headers
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .map(Duration::from_secs)
+    }
+}
+
+/// Typed error for transient SRP HTTP failures that should retry.
+/// Distinct from `AuthError` so the retry classifier can match on it.
+#[derive(Debug, thiserror::Error)]
+#[error("SRP transport error ({status}) at {step}")]
+struct SrpTransientError {
+    status: u16,
+    step: &'static str,
+    retry_after: Option<Duration>,
+}
+
+fn classify_srp_error(e: &anyhow::Error) -> RetryAction {
+    if let Some(t) = e.downcast_ref::<SrpTransientError>() {
+        return match t.retry_after {
+            Some(d) => RetryAction::RetryAfter(d),
+            None => RetryAction::Retry,
+        };
+    }
+    // reqwest network failures (no status) are transient; retry.
+    if let Some(rq) = e.downcast_ref::<reqwest::Error>() {
+        if rq.status().is_none() {
+            return RetryAction::Retry;
+        }
+    }
+    RetryAction::Abort
 }
 
 /// Abstracts the HTTP transport used by SRP authentication.
@@ -64,10 +113,12 @@ impl SrpTransport for Session {
     ) -> Result<SrpResponse> {
         let response = Self::post(self, url, body, headers).await?;
         let status = response.status().as_u16();
+        let headers = response.headers().clone();
         let bytes = response.bytes().await?;
         Ok(SrpResponse {
             status,
             body: bytes.to_vec(),
+            headers,
         })
     }
 
@@ -332,12 +383,37 @@ pub async fn authenticate_srp(
 
     let init_url = format!("{}/signin/init", endpoints.auth);
     let init_body = init_body.to_string();
-    let response = transport
-        .post(&init_url, Some(&init_body), Some(init_headers))
-        .await?;
+    // First attempt reuses the pre-computed headers (they include the
+    // current scnt/session_id). Retries rebuild headers so any rotated
+    // values from a 5xx response are picked up.
+    let mut init_attempt_headers = Some(init_headers);
+    let response = srp_post(
+        transport,
+        "init",
+        &init_url,
+        &init_body,
+        &mut init_attempt_headers,
+        |sd| get_auth_headers(domain, client_id, sd, Some(&overrides)),
+    )
+    .await?;
 
+    if let Some(rscd) = check_rscd_from_headers(&response.headers) {
+        return Err(rscd_service_error(rscd, &response.text()).into());
+    }
+
+    // A 401 at /signin/init means Apple rejected the *session context*
+    // (stale scnt/cookies/client-id), not the password — SRP hasn't yet
+    // sent the M1 proof. Surface as a typed API error instead of
+    // FailedLogin so the caller doesn't tell the user their password is
+    // wrong when the real cause is a transient auth-CDN issue.
     if response.status == 401 {
-        return Err(AuthError::FailedLogin("Failed to initiate SRP authentication".into()).into());
+        return Err(AuthError::ApiError {
+            code: 401,
+            message:
+                "SRP init rejected (HTTP 401). Apple's auth session context is stale; retry shortly."
+                    .into(),
+        }
+        .into());
     }
     if !response.is_success() && response.status != 409 {
         let text = response.text();
@@ -446,15 +522,29 @@ pub async fn authenticate_srp(
         endpoints.auth
     );
     let complete_body = complete_body.to_string();
-    let response = transport
-        .post(&complete_url, Some(&complete_body), Some(complete_headers))
-        .await?;
+    let mut complete_attempt_headers = Some(complete_headers);
+    let response = srp_post(
+        transport,
+        "complete",
+        &complete_url,
+        &complete_body,
+        &mut complete_attempt_headers,
+        |sd| get_auth_headers(domain, client_id, sd, Some(&overrides)),
+    )
+    .await?;
+
+    if let Some(rscd) = check_rscd_from_headers(&response.headers) {
+        return Err(rscd_service_error(rscd, &response.text()).into());
+    }
 
     if response.status == 409 {
         // 409 is Apple's signal that credentials are valid but 2FA is needed
         tracing::debug!("SRP complete returned 409: two-factor authentication required");
         return Ok(());
     } else if response.status == 412 {
+        // /repair/complete uses the same session context; `transport.post`
+        // calls `extract_and_save` on every response, so session_data here
+        // reflects any scnt/session_id rotated by the failing complete call.
         tracing::debug!("SRP complete returned 412: attempting repair");
         let repair_headers = get_auth_headers(domain, client_id, transport.session_data(), None)?;
         let repair_url = format!("{}/repair/complete", endpoints.auth);
@@ -469,6 +559,7 @@ pub async fn authenticate_srp(
             .into());
         }
     } else if response.is_server_error() {
+        // Retries already exhausted by srp_post; this is a persistent 5xx.
         let status = response.status;
         let body = response.text();
         let detail = if body.contains('<') {
@@ -477,12 +568,36 @@ pub async fn authenticate_srp(
         } else {
             format!(": {body}")
         };
-        return Err(AuthError::FailedLogin(format!(
-            "Apple returned HTTP {status}{detail} — this is usually a temporary \
-             Apple server issue, try again in a few minutes"
-        ))
+        return Err(AuthError::ApiError {
+            code: status,
+            message: format!(
+                "Apple returned HTTP {status}{detail} — this is usually a temporary \
+                 Apple server issue, try again in a few minutes"
+            ),
+        }
         .into());
-    } else if response.is_client_error() {
+    } else if response.status == 400 {
+        // 400 means Apple rejected the SRP payload as malformed. That is
+        // either a kei bug or a protocol change on Apple's side — never a
+        // wrong password. Surface verbatim so we don't mislead the user.
+        let body = response.text();
+        let detail = if body.contains('<') {
+            String::new()
+        } else {
+            format!(": {body}")
+        };
+        return Err(AuthError::ApiError {
+            code: 400,
+            message: format!(
+                "Apple rejected the SRP payload as malformed (HTTP 400){detail}. \
+                 This usually indicates a kei bug or an Apple auth protocol change."
+            ),
+        }
+        .into());
+    } else if response.status == 401 {
+        // 401 at /signin/complete means Apple's SRP M1 verification failed —
+        // the password does not match. This is the one branch that can
+        // confidently blame the credentials.
         let body = response.text();
         let detail = if body.contains('<') {
             String::new()
@@ -492,9 +607,121 @@ pub async fn authenticate_srp(
         return Err(
             AuthError::FailedLogin(format!("Invalid email/password combination{detail}")).into(),
         );
+    } else if response.status == 429 {
+        // srp_post only retries up to max_retries; after that, 429 lands
+        // here. Map to ApiError so `is_rate_limited()` detects it via the
+        // HTTP-503 path? No -- 429 is rate-limited too but the existing
+        // helper keys on 503. Surface with an actionable message.
+        return Err(AuthError::ApiError {
+            code: 429,
+            message:
+                "Apple is rate limiting authentication (HTTP 429). Wait a few minutes and retry."
+                    .into(),
+        }
+        .into());
+    } else if response.is_client_error() {
+        // Any other 4xx (403, 412 already handled, etc) — surface the raw
+        // status rather than attributing it to bad credentials. Apple's
+        // auth surface has historically returned 403 for rate limits,
+        // rotated routing cookies, and rarely even bad passwords; without
+        // a discriminating body we cannot tell which.
+        let status = response.status;
+        let body = response.text();
+        let detail = if body.contains('<') {
+            String::new()
+        } else {
+            format!(": {body}")
+        };
+        return Err(AuthError::ApiError {
+            code: status,
+            message: format!("SRP complete rejected by Apple (HTTP {status}){detail}"),
+        }
+        .into());
     }
 
     Ok(())
+}
+
+/// POST to an Apple SRP endpoint, retrying on transient 429/5xx responses.
+///
+/// The first call uses `prebuilt_headers` so the caller's carefully-ordered
+/// header map (with Origin/Referer overrides) is preserved. Retries call
+/// `rebuild_headers` against the latest `session_data`, since Apple rotates
+/// `scnt`/`session_id` on many responses and the retry would otherwise carry
+/// stale values.
+///
+/// After the retry budget is exhausted, the last response is returned as
+/// `Ok`; the caller's status-match sees the lingering 429/5xx and produces
+/// the user-facing `AuthError`.
+async fn srp_post<F>(
+    transport: &mut impl SrpTransport,
+    step: &'static str,
+    url: &str,
+    body: &str,
+    prebuilt_headers: &mut Option<HeaderMap>,
+    rebuild_headers: F,
+) -> Result<SrpResponse>
+where
+    F: Fn(&HashMap<String, String>) -> Result<HeaderMap>,
+{
+    let total_attempts = SRP_RETRY_CONFIG.max_retries.saturating_add(1);
+    let mut last_transient: Option<SrpResponse> = None;
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 0..total_attempts {
+        let headers = if let Some(h) = prebuilt_headers.take() {
+            h
+        } else {
+            rebuild_headers(transport.session_data())?
+        };
+        match transport.post(url, Some(body), Some(headers)).await {
+            Ok(resp) => {
+                let status = resp.status;
+                let is_transient = status == 429 || resp.is_server_error();
+                if !is_transient {
+                    return Ok(resp);
+                }
+                let is_last = attempt + 1 >= total_attempts;
+                if is_last {
+                    // Surface the actual response so the caller's existing
+                    // status-match produces the end-user error message.
+                    return Ok(resp);
+                }
+                let delay = match resp.retry_after() {
+                    Some(d) => d.min(Duration::from_secs(SRP_RETRY_CONFIG.max_delay_secs)),
+                    None => SRP_RETRY_CONFIG.delay_for_retry(attempt),
+                };
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    total_attempts,
+                    status,
+                    retry_delay_secs = delay.as_secs(),
+                    "SRP {step}: transient HTTP failure, retrying"
+                );
+                last_transient = Some(resp);
+                tokio::time::sleep(delay).await;
+            }
+            Err(e) => {
+                let is_last = attempt + 1 >= total_attempts;
+                if is_last || classify_srp_error(&e) == RetryAction::Abort {
+                    return Err(e);
+                }
+                let delay = SRP_RETRY_CONFIG.delay_for_retry(attempt);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    total_attempts,
+                    error = %e,
+                    retry_delay_secs = delay.as_secs(),
+                    "SRP {step}: network error, retrying"
+                );
+                last_err = Some(e);
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+    if let Some(resp) = last_transient {
+        return Ok(resp);
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("SRP {step}: retry loop exhausted")))
 }
 
 #[cfg(test)]
@@ -607,12 +834,25 @@ mod tests {
         .unwrap()
     }
 
+    fn response(status: u16, body: Vec<u8>) -> SrpResponse {
+        SrpResponse {
+            status,
+            body,
+            headers: HeaderMap::new(),
+        }
+    }
+
+    fn response_with_headers(status: u16, body: Vec<u8>, headers: HeaderMap) -> SrpResponse {
+        SrpResponse {
+            status,
+            body,
+            headers,
+        }
+    }
+
     /// A valid SRP init response with B = 2 (non-zero mod N).
     fn valid_init_response() -> SrpResponse {
-        SrpResponse {
-            status: 200,
-            body: srp_init_body(&BASE64.encode([2u8])),
-        }
+        response(200, srp_init_body(&BASE64.encode([2u8])))
     }
 
     struct StubSrpTransport {
@@ -652,106 +892,138 @@ mod tests {
         authenticate_srp(&mut t, &ep, "u@test.com", "p", "c", "com").await
     }
 
+    /// 401 at /signin/init is not a bad-password signal — Apple hasn't yet
+    /// verified the M1 proof. Expect a typed `ApiError` so the caller doesn't
+    /// tell the user their password is wrong for a transient auth-CDN issue.
     #[tokio::test]
-    async fn srp_init_401_returns_failed_login() {
-        let err = run_srp(vec![SrpResponse {
-            status: 401,
-            body: vec![],
-        }])
-        .await
-        .unwrap_err();
-        assert!(err.to_string().contains("Failed to initiate SRP"));
+    async fn srp_init_401_returns_api_error_not_failed_login() {
+        let err = run_srp(vec![response(401, vec![])]).await.unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        assert!(
+            matches!(auth_err, AuthError::ApiError { code: 401, .. }),
+            "expected ApiError {{ code: 401 }}, got: {auth_err:?}"
+        );
+        assert!(
+            !matches!(auth_err, AuthError::FailedLogin(_)),
+            "401 on init must NOT be FailedLogin (would blame password)"
+        );
     }
 
-    #[tokio::test]
-    async fn srp_init_500_returns_api_error() {
-        let err = run_srp(vec![SrpResponse {
-            status: 500,
-            body: b"server error".to_vec(),
-        }])
+    /// srp_post retries transient 5xx until the budget is exhausted, then
+    /// surfaces an ApiError carrying the final status.
+    #[tokio::test(start_paused = true)]
+    async fn srp_init_500_retries_then_returns_api_error() {
+        let err = run_srp(vec![
+            response(500, b"server error".to_vec()),
+            response(500, b"server error".to_vec()),
+            response(500, b"server error".to_vec()),
+        ])
         .await
         .unwrap_err();
         let auth_err = err.downcast_ref::<AuthError>().unwrap();
         assert!(matches!(auth_err, AuthError::ApiError { code: 500, .. }));
     }
 
+    /// A 503 that recovers on retry should succeed, proving the retry budget
+    /// is actually being used.
+    #[tokio::test(start_paused = true)]
+    async fn srp_init_503_retries_then_succeeds() {
+        run_srp(vec![
+            response(503, b"unavailable".to_vec()),
+            valid_init_response(),
+            response(200, vec![]),
+        ])
+        .await
+        .unwrap();
+    }
+
+    /// Apple's `X-Apple-I-Rscd: 401/403` header means "session rejected" even
+    /// when the HTTP status is 200. SRP must detect this so a hidden rejection
+    /// surfaces as a ServiceError rather than being treated as a valid handshake.
     #[tokio::test]
-    async fn srp_init_invalid_json_returns_parse_error() {
-        let err = run_srp(vec![SrpResponse {
-            status: 200,
-            body: b"not json".to_vec(),
-        }])
+    async fn srp_init_rscd_401_on_http_200_is_service_error() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Apple-I-Rscd", HeaderValue::from_static("401"));
+        let err = run_srp(vec![response_with_headers(
+            200,
+            srp_init_body(&BASE64.encode([2u8])),
+            headers,
+        )])
         .await
         .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        match auth_err {
+            AuthError::ServiceError { code, .. } => assert_eq!(code, "rscd_401"),
+            other => panic!("expected rscd ServiceError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn srp_complete_rscd_403_on_http_200_is_service_error() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Apple-I-Rscd", HeaderValue::from_static("403"));
+        let err = run_srp(vec![
+            valid_init_response(),
+            response_with_headers(200, vec![], headers),
+        ])
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        match auth_err {
+            AuthError::ServiceError { code, .. } => assert_eq!(code, "rscd_403"),
+            other => panic!("expected rscd ServiceError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn srp_init_invalid_json_returns_parse_error() {
+        let err = run_srp(vec![response(200, b"not json".to_vec())])
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("SRP init: expected JSON"));
     }
 
     #[tokio::test]
     async fn srp_b_mod_n_zero_returns_error() {
-        let err = run_srp(vec![SrpResponse {
-            status: 200,
-            body: srp_init_body(&BASE64.encode([0u8])),
-        }])
-        .await
-        .unwrap_err();
+        let err = run_srp(vec![response(200, srp_init_body(&BASE64.encode([0u8])))])
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("B mod N is zero"));
     }
 
     #[tokio::test]
     async fn srp_happy_path() {
-        run_srp(vec![
-            valid_init_response(),
-            SrpResponse {
-                status: 200,
-                body: vec![],
-            },
-        ])
-        .await
-        .unwrap();
+        run_srp(vec![valid_init_response(), response(200, vec![])])
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn srp_complete_409_signals_2fa_required() {
-        run_srp(vec![
-            valid_init_response(),
-            SrpResponse {
-                status: 409,
-                body: vec![],
-            },
-        ])
-        .await
-        .unwrap();
+        run_srp(vec![valid_init_response(), response(409, vec![])])
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn srp_complete_412_repair_succeeds() {
         run_srp(vec![
             valid_init_response(),
-            SrpResponse {
-                status: 412,
-                body: vec![],
-            },
-            SrpResponse {
-                status: 200,
-                body: vec![],
-            },
+            response(412, vec![]),
+            response(200, vec![]),
         ])
         .await
         .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn srp_complete_412_repair_fails() {
+        // Repair itself gets the retry budget (3 attempts) since it goes
+        // through srp_post-style transport.post; here all three return 500.
         let err = run_srp(vec![
             valid_init_response(),
-            SrpResponse {
-                status: 412,
-                body: vec![],
-            },
-            SrpResponse {
-                status: 500,
-                body: b"repair broken".to_vec(),
-            },
+            response(412, vec![]),
+            response(500, b"repair broken".to_vec()),
         ])
         .await
         .unwrap_err();
@@ -759,33 +1031,112 @@ mod tests {
         assert!(matches!(auth_err, AuthError::ApiError { code: 412, .. }));
     }
 
+    /// 401 at /signin/complete IS a password rejection (SRP's M1 verification
+    /// failed). This is the one branch that may legitimately say "wrong password".
     #[tokio::test]
-    async fn srp_complete_client_error_returns_failed_login() {
+    async fn srp_complete_401_is_failed_login() {
         let err = run_srp(vec![
             valid_init_response(),
-            SrpResponse {
-                status: 403,
-                body: b"forbidden".to_vec(),
-            },
+            response(401, b"wrong".to_vec()),
         ])
         .await
         .unwrap_err();
         let auth_err = err.downcast_ref::<AuthError>().unwrap();
-        assert!(matches!(auth_err, AuthError::FailedLogin(_)));
+        assert!(
+            matches!(auth_err, AuthError::FailedLogin(_)),
+            "401 on complete should be FailedLogin, got: {auth_err:?}"
+        );
     }
 
+    /// 403 at /signin/complete should NOT be mis-attributed to bad password.
+    /// Apple returns 403 for rate limits, rotated routing cookies, and more.
     #[tokio::test]
-    async fn srp_complete_server_error_returns_failed_login() {
+    async fn srp_complete_403_is_api_error_not_failed_login() {
         let err = run_srp(vec![
             valid_init_response(),
-            SrpResponse {
-                status: 502,
-                body: b"bad gateway".to_vec(),
-            },
+            response(403, b"forbidden".to_vec()),
         ])
         .await
         .unwrap_err();
         let auth_err = err.downcast_ref::<AuthError>().unwrap();
-        assert!(matches!(auth_err, AuthError::FailedLogin(_)));
+        assert!(
+            matches!(auth_err, AuthError::ApiError { code: 403, .. }),
+            "403 on complete must be ApiError, not FailedLogin, got: {auth_err:?}"
+        );
+    }
+
+    /// 429 at /signin/complete must be reported as rate-limited, not as a
+    /// password failure. Retries inside srp_post handle transient cases; this
+    /// path covers exhaustion.
+    #[tokio::test(start_paused = true)]
+    async fn srp_complete_429_is_rate_limited_api_error() {
+        let err = run_srp(vec![
+            valid_init_response(),
+            response(429, b"too many".to_vec()),
+            response(429, b"too many".to_vec()),
+            response(429, b"too many".to_vec()),
+        ])
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        assert!(
+            matches!(auth_err, AuthError::ApiError { code: 429, .. }),
+            "429 on complete must be ApiError(429), got: {auth_err:?}"
+        );
+    }
+
+    /// 400 at /signin/complete signals a malformed payload — kei bug or
+    /// Apple protocol change. Never a wrong password.
+    #[tokio::test]
+    async fn srp_complete_400_is_api_error() {
+        let err = run_srp(vec![
+            valid_init_response(),
+            response(400, b"bad request".to_vec()),
+        ])
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        match auth_err {
+            AuthError::ApiError { code: 400, message } => {
+                assert!(
+                    message.to_lowercase().contains("malformed")
+                        || message.to_lowercase().contains("400"),
+                    "expected explanatory 400 message, got: {message}"
+                );
+            }
+            other => panic!("expected ApiError(400), got: {other:?}"),
+        }
+    }
+
+    /// Persistent 5xx after retry exhaustion is surfaced as ApiError (not
+    /// FailedLogin, which is the bug this PR fixes).
+    #[tokio::test(start_paused = true)]
+    async fn srp_complete_server_error_returns_api_error() {
+        let err = run_srp(vec![
+            valid_init_response(),
+            response(502, b"bad gateway".to_vec()),
+            response(502, b"bad gateway".to_vec()),
+            response(502, b"bad gateway".to_vec()),
+        ])
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        assert!(
+            matches!(auth_err, AuthError::ApiError { code: 502, .. }),
+            "5xx after retries must be ApiError, got: {auth_err:?}"
+        );
+    }
+
+    /// Transient 503 on complete that recovers within the retry budget
+    /// should succeed rather than surfacing an error.
+    #[tokio::test(start_paused = true)]
+    async fn srp_complete_503_retries_then_succeeds() {
+        run_srp(vec![
+            valid_init_response(),
+            response(503, b"unavailable".to_vec()),
+            response(200, vec![]),
+        ])
+        .await
+        .unwrap();
     }
 }

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -9,20 +9,12 @@ use serde_json::Value;
 use super::endpoints::Endpoints;
 use super::session::Session;
 use super::srp::get_auth_headers;
+use super::AUTH_RETRY_CONFIG;
 use crate::auth::error::AuthError;
 use crate::auth::responses::AccountLoginResponse;
-use crate::retry::RetryConfig;
+use crate::retry::{parse_retry_after_header, RetryConfig};
 
 const TWO_FA_CODE_LENGTH: usize = 6;
-
-/// Retry budget for 2FA push/submit against Apple's auth service. The flow is
-/// user-blocking, so we only absorb short blips: three tries, short backoffs,
-/// capped by `Retry-After`.
-const TWOFA_RETRY_CONFIG: RetryConfig = RetryConfig {
-    max_retries: 2,
-    base_delay_secs: 2,
-    max_delay_secs: 30,
-};
 
 /// Check if the `X-Apple-I-Rscd` header indicates an authentication failure.
 /// Apple sometimes returns HTTP 200 but sets this header to the "real"
@@ -138,27 +130,63 @@ fn classify_auth_http_error(
     }
 }
 
-/// Parse `Retry-After` (delta-seconds only) from response headers, capping at
-/// the supplied `max_delay` so a pathological server value cannot stall the
-/// retry loop for arbitrarily long.
-fn parse_retry_after_header(
-    headers: &reqwest::header::HeaderMap,
-    max_delay: Duration,
-) -> Option<Duration> {
-    headers
-        .get(reqwest::header::RETRY_AFTER)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .filter(|&n| n > 0)
-        .map(Duration::from_secs)
-        .map(|d| d.min(max_delay))
-}
-
-/// True for status codes where retrying is likely to change the outcome
-/// (rate limits, transient 5xx). Apple's auth endpoints occasionally emit
-/// these during high-load windows.
+/// True for statuses where retrying is likely to change the outcome (Apple
+/// rate limits and transient 5xx).
 fn is_transient_auth_status(status: u16) -> bool {
     status == 429 || (500..600).contains(&status)
+}
+
+/// HTTP verb for the auth-layer retry helper; picks between `session.put`
+/// and `session.post` without forcing callers to write two near-identical
+/// retry loops.
+enum AuthMethod<'a> {
+    Put,
+    Post { body: &'a str },
+}
+
+/// POST/PUT against an Apple auth endpoint, retrying transient 5xx/429 up to
+/// `retry_config` and honoring `Retry-After`. On non-transient or
+/// budget-exhausted 4xx/5xx the response body is read and returned to the
+/// caller as `(status, text)` so it can build a typed error; transport errors
+/// propagate as-is (they are rare and non-retryable at this layer).
+async fn retry_auth_request(
+    session: &mut Session,
+    url: &str,
+    method: AuthMethod<'_>,
+    headers_fn: impl Fn(&Session) -> Result<HeaderMap>,
+    retry_config: &RetryConfig,
+    log_label: &str,
+) -> Result<(reqwest::StatusCode, String)> {
+    let max_delay = Duration::from_secs(retry_config.max_delay_secs);
+    let total_attempts = retry_config.max_retries.saturating_add(1);
+    for attempt in 0..total_attempts {
+        let headers = headers_fn(session)?;
+        let response = match method {
+            AuthMethod::Put => session.put(url, Some(headers)).await?,
+            AuthMethod::Post { body } => session.post(url, Some(body), Some(headers)).await?,
+        };
+        let status = response.status();
+        let is_last = attempt + 1 >= total_attempts;
+        if status.is_success() || !is_transient_auth_status(status.as_u16()) || is_last {
+            let text = response.text().await.unwrap_or_default();
+            return Ok((status, text));
+        }
+
+        let delay = parse_retry_after_header(response.headers(), max_delay)
+            .unwrap_or_else(|| retry_config.delay_for_retry(attempt));
+        let _ = response.text().await;
+        tracing::warn!(
+            attempt = attempt + 1,
+            total_attempts,
+            status = status.as_u16(),
+            retry_delay_secs = delay.as_secs(),
+            "{log_label}: transient failure, retrying"
+        );
+        tokio::time::sleep(delay).await;
+    }
+    Err(anyhow::anyhow!(
+        "{log_label}: retry loop exhausted without a decisive response"
+    ))
 }
 
 /// Trigger a push notification to trusted devices for 2FA code entry.
@@ -180,8 +208,7 @@ pub async fn trigger_push_notification(
     client_id: &str,
     domain: &str,
 ) -> Result<()> {
-    trigger_push_notification_inner(session, endpoints, client_id, domain, &TWOFA_RETRY_CONFIG)
-        .await
+    trigger_push_notification_inner(session, endpoints, client_id, domain, &AUTH_RETRY_CONFIG).await
 }
 
 async fn trigger_push_notification_inner(
@@ -191,58 +218,34 @@ async fn trigger_push_notification_inner(
     domain: &str,
     retry_config: &RetryConfig,
 ) -> Result<()> {
-    let accept_override: [(&str, &str); 1] = [("Accept", "application/json")];
     let url = format!("{}/verify/trusteddevice/securitycode", endpoints.auth);
-    let max_delay = Duration::from_secs(retry_config.max_delay_secs);
     tracing::debug!(url = %url, "Requesting 2FA code via PUT");
 
-    let total_attempts = retry_config.max_retries.saturating_add(1);
-    for attempt in 0..total_attempts {
-        // Rebuild headers each attempt: session_data may have rotated
-        // scnt/session_id between tries via extract_and_save.
-        let headers = get_auth_headers(
-            domain,
-            client_id,
-            &session.session_data,
-            Some(&accept_override),
-        )?;
-        let response = session.put(&url, Some(headers)).await?;
-        let status = response.status();
-        if status.is_success() {
-            return Ok(());
-        }
+    let (status, text) = retry_auth_request(
+        session,
+        &url,
+        AuthMethod::Put,
+        |s| {
+            get_auth_headers(
+                domain,
+                client_id,
+                &s.session_data,
+                Some(&[("Accept", "application/json")]),
+            )
+        },
+        retry_config,
+        "2FA push notification",
+    )
+    .await?;
 
-        let is_last = attempt + 1 >= total_attempts;
-        if !is_transient_auth_status(status.as_u16()) || is_last {
-            let retry_after = parse_retry_after_header(response.headers(), max_delay);
-            let text = response.text().await.unwrap_or_default();
-            return Err(AuthError::ApiError {
-                code: status.as_u16(),
-                message: format!(
-                    "2FA push notification rejected (HTTP {status}){}: {text}",
-                    retry_after
-                        .map(|d| format!(", Retry-After={}s", d.as_secs()))
-                        .unwrap_or_default()
-                ),
-            }
-            .into());
-        }
-
-        let delay = parse_retry_after_header(response.headers(), max_delay)
-            .unwrap_or_else(|| retry_config.delay_for_retry(attempt));
-        let _ = response.text().await; // drain body so the connection can reuse
-        tracing::warn!(
-            attempt = attempt + 1,
-            total_attempts,
-            status = status.as_u16(),
-            retry_delay_secs = delay.as_secs(),
-            "2FA push notification: transient failure, retrying"
-        );
-        tokio::time::sleep(delay).await;
+    if status.is_success() {
+        return Ok(());
     }
-    Err(anyhow::anyhow!(
-        "2FA push notification: retry loop exhausted without a decisive response"
-    ))
+    Err(AuthError::ApiError {
+        code: status.as_u16(),
+        message: format!("2FA push notification rejected (HTTP {status}): {text}"),
+    }
+    .into())
 }
 
 /// Strip non-digit characters and check whether the result is a valid 6-digit 2FA code.
@@ -273,7 +276,7 @@ pub async fn submit_2fa_code(
         client_id,
         domain,
         code,
-        &TWOFA_RETRY_CONFIG,
+        &AUTH_RETRY_CONFIG,
     )
     .await
 }
@@ -294,73 +297,29 @@ async fn submit_2fa_code_inner(
         return Ok(false);
     };
 
-    let data = serde_json::json!({
-        "securityCode": {
-            "code": code,
-        }
-    });
-
-    let accept_override: [(&str, &str); 1] = [("Accept", "application/json")];
-
-    let headers = get_auth_headers(
-        domain,
-        client_id,
-        &session.session_data,
-        Some(&accept_override),
-    )?;
-
+    let data = serde_json::json!({ "securityCode": { "code": code } });
     let url = format!("{}/verify/trusteddevice/securitycode", endpoints.auth);
     let body = data.to_string();
-    let max_delay = Duration::from_secs(retry_config.max_delay_secs);
-    // The first attempt reuses the pre-computed `headers`; retries (rare,
-    // only on 429/5xx) rebuild them so any rotated scnt/session_id is picked
-    // up. A "wrong code" response (-21669) short-circuits without a retry.
-    let mut attempt_headers = Some(headers);
-    let total_attempts = retry_config.max_retries.saturating_add(1);
-    let (status, text) = 'outer: {
-        for attempt in 0..total_attempts {
-            let headers = if let Some(h) = attempt_headers.take() {
-                h
-            } else {
-                get_auth_headers(
-                    domain,
-                    client_id,
-                    &session.session_data,
-                    Some(&accept_override),
-                )?
-            };
-            let response = session.post(&url, Some(&body), Some(headers)).await?;
-            let status = response.status();
-            if status.is_success() {
-                let text = response.text().await.unwrap_or_default();
-                break 'outer (status, text);
-            }
 
-            let is_last = attempt + 1 >= total_attempts;
-            if !is_transient_auth_status(status.as_u16()) || is_last {
-                let text = response.text().await.unwrap_or_default();
-                break 'outer (status, text);
-            }
-
-            let delay = parse_retry_after_header(response.headers(), max_delay)
-                .unwrap_or_else(|| retry_config.delay_for_retry(attempt));
-            let _ = response.text().await;
-            tracing::warn!(
-                attempt = attempt + 1,
-                total_attempts,
-                status = status.as_u16(),
-                retry_delay_secs = delay.as_secs(),
-                "2FA code submit: transient failure, retrying"
-            );
-            tokio::time::sleep(delay).await;
-        }
-        return Err(anyhow::anyhow!(
-            "2FA code submit: retry loop exhausted without a decisive response"
-        ));
-    };
+    let (status, text) = retry_auth_request(
+        session,
+        &url,
+        AuthMethod::Post { body: &body },
+        |s| {
+            get_auth_headers(
+                domain,
+                client_id,
+                &s.session_data,
+                Some(&[("Accept", "application/json")]),
+            )
+        },
+        retry_config,
+        "2FA code submit",
+    )
+    .await?;
 
     if !status.is_success() {
-        // Apple error code -21669 = incorrect verification code
+        // -21669 = incorrect verification code
         if text.contains("-21669") {
             tracing::error!("Code verification failed: wrong code");
             return Ok(false);

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -198,7 +198,7 @@ async fn retry_auth_request(
 /// POST endpoint no longer reliably triggers pushes. The PUT endpoint
 /// works across both old and new Apple auth flows.
 ///
-/// Retries transient 5xx/429 up to [`TWOFA_RETRY_CONFIG`]; honors
+/// Retries transient 5xx/429 up to [`AUTH_RETRY_CONFIG`]; honors
 /// `Retry-After` when Apple provides one.
 ///
 /// See: icloud-photos-downloader/icloud_photos_downloader#1322

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Write};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use reqwest::header::HeaderMap;
@@ -10,19 +11,46 @@ use super::session::Session;
 use super::srp::get_auth_headers;
 use crate::auth::error::AuthError;
 use crate::auth::responses::AccountLoginResponse;
+use crate::retry::RetryConfig;
 
 const TWO_FA_CODE_LENGTH: usize = 6;
 
-/// Check if the `X-Apple-I-Rscd` response header indicates an authentication
-/// failure. Apple sometimes returns HTTP 200 but sets this header to the "real"
+/// Retry budget for 2FA push/submit against Apple's auth service. The flow is
+/// user-blocking, so we only absorb short blips: three tries, short backoffs,
+/// capped by `Retry-After`.
+const TWOFA_RETRY_CONFIG: RetryConfig = RetryConfig {
+    max_retries: 2,
+    base_delay_secs: 2,
+    max_delay_secs: 30,
+};
+
+/// Check if the `X-Apple-I-Rscd` header indicates an authentication failure.
+/// Apple sometimes returns HTTP 200 but sets this header to the "real"
 /// status code (e.g. 401, 403).
-fn check_apple_rscd(response: &Response) -> Option<u16> {
-    response
-        .headers()
+///
+/// Only `401` and `403` values are acted on. `421` has been observed in the
+/// wild but is handled at the HTTP-status layer in `auth::authenticate`
+/// (via `AuthError::is_misdirected_request`), so we ignore it here to avoid
+/// mis-routing through the session-rejection path.
+pub(crate) fn check_rscd_from_headers(headers: &reqwest::header::HeaderMap) -> Option<u16> {
+    headers
         .get("X-Apple-I-Rscd")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<u16>().ok())
         .filter(|&code| code == 401 || code == 403)
+}
+
+fn check_apple_rscd(response: &Response) -> Option<u16> {
+    check_rscd_from_headers(response.headers())
+}
+
+/// Build the `ServiceError` that corresponds to an Apple rscd rejection.
+pub(crate) fn rscd_service_error(rscd: u16, body: &str) -> AuthError {
+    tracing::debug!(rscd, "Apple rejected session via rscd header");
+    AuthError::ServiceError {
+        code: format!("rscd_{rscd}"),
+        message: format!("Apple rejected the session (response code {rscd}): {body}"),
+    }
 }
 
 /// If `X-Apple-I-Rscd` indicates an auth failure, consume the response body
@@ -30,11 +58,7 @@ fn check_apple_rscd(response: &Response) -> Option<u16> {
 async fn reject_on_rscd(response: Response) -> Result<Response, AuthError> {
     if let Some(rscd) = check_apple_rscd(&response) {
         let text = response.text().await.unwrap_or_default();
-        tracing::debug!(rscd, "Apple rejected session via rscd header");
-        return Err(AuthError::ServiceError {
-            code: format!("rscd_{rscd}"),
-            message: format!("Apple rejected the session (response code {rscd}): {text}"),
-        });
+        return Err(rscd_service_error(rscd, &text));
     }
     Ok(response)
 }
@@ -114,6 +138,29 @@ fn classify_auth_http_error(
     }
 }
 
+/// Parse `Retry-After` (delta-seconds only) from response headers, capping at
+/// the supplied `max_delay` so a pathological server value cannot stall the
+/// retry loop for arbitrarily long.
+fn parse_retry_after_header(
+    headers: &reqwest::header::HeaderMap,
+    max_delay: Duration,
+) -> Option<Duration> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .map(Duration::from_secs)
+        .map(|d| d.min(max_delay))
+}
+
+/// True for status codes where retrying is likely to change the outcome
+/// (rate limits, transient 5xx). Apple's auth endpoints occasionally emit
+/// these during high-load windows.
+fn is_transient_auth_status(status: u16) -> bool {
+    status == 429 || (500..600).contains(&status)
+}
+
 /// Trigger a push notification to trusted devices for 2FA code entry.
 ///
 /// Sends a PUT to `/verify/trusteddevice/securitycode` (no body), which
@@ -123,6 +170,9 @@ fn classify_auth_http_error(
 /// POST endpoint no longer reliably triggers pushes. The PUT endpoint
 /// works across both old and new Apple auth flows.
 ///
+/// Retries transient 5xx/429 up to [`TWOFA_RETRY_CONFIG`]; honors
+/// `Retry-After` when Apple provides one.
+///
 /// See: icloud-photos-downloader/icloud_photos_downloader#1322
 pub async fn trigger_push_notification(
     session: &mut Session,
@@ -130,26 +180,69 @@ pub async fn trigger_push_notification(
     client_id: &str,
     domain: &str,
 ) -> Result<()> {
-    let accept_override: [(&str, &str); 1] = [("Accept", "application/json")];
-    let headers = get_auth_headers(
-        domain,
-        client_id,
-        &session.session_data,
-        Some(&accept_override),
-    )?;
+    trigger_push_notification_inner(session, endpoints, client_id, domain, &TWOFA_RETRY_CONFIG)
+        .await
+}
 
+async fn trigger_push_notification_inner(
+    session: &mut Session,
+    endpoints: &Endpoints,
+    client_id: &str,
+    domain: &str,
+    retry_config: &RetryConfig,
+) -> Result<()> {
+    let accept_override: [(&str, &str); 1] = [("Accept", "application/json")];
     let url = format!("{}/verify/trusteddevice/securitycode", endpoints.auth);
+    let max_delay = Duration::from_secs(retry_config.max_delay_secs);
     tracing::debug!(url = %url, "Requesting 2FA code via PUT");
 
-    let response = session.put(&url, Some(headers)).await?;
+    let total_attempts = retry_config.max_retries.saturating_add(1);
+    for attempt in 0..total_attempts {
+        // Rebuild headers each attempt: session_data may have rotated
+        // scnt/session_id between tries via extract_and_save.
+        let headers = get_auth_headers(
+            domain,
+            client_id,
+            &session.session_data,
+            Some(&accept_override),
+        )?;
+        let response = session.put(&url, Some(headers)).await?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
 
-    let status = response.status();
-    if !status.is_success() {
-        let text = response.text().await.unwrap_or_default();
-        anyhow::bail!("2FA code request failed (HTTP {status}): {text}");
+        let is_last = attempt + 1 >= total_attempts;
+        if !is_transient_auth_status(status.as_u16()) || is_last {
+            let retry_after = parse_retry_after_header(response.headers(), max_delay);
+            let text = response.text().await.unwrap_or_default();
+            return Err(AuthError::ApiError {
+                code: status.as_u16(),
+                message: format!(
+                    "2FA push notification rejected (HTTP {status}){}: {text}",
+                    retry_after
+                        .map(|d| format!(", Retry-After={}s", d.as_secs()))
+                        .unwrap_or_default()
+                ),
+            }
+            .into());
+        }
+
+        let delay = parse_retry_after_header(response.headers(), max_delay)
+            .unwrap_or_else(|| retry_config.delay_for_retry(attempt));
+        let _ = response.text().await; // drain body so the connection can reuse
+        tracing::warn!(
+            attempt = attempt + 1,
+            total_attempts,
+            status = status.as_u16(),
+            retry_delay_secs = delay.as_secs(),
+            "2FA push notification: transient failure, retrying"
+        );
+        tokio::time::sleep(delay).await;
     }
-
-    Ok(())
+    Err(anyhow::anyhow!(
+        "2FA push notification: retry loop exhausted without a decisive response"
+    ))
 }
 
 /// Strip non-digit characters and check whether the result is a valid 6-digit 2FA code.
@@ -173,6 +266,25 @@ pub async fn submit_2fa_code(
     client_id: &str,
     domain: &str,
     code: &str,
+) -> Result<bool> {
+    submit_2fa_code_inner(
+        session,
+        endpoints,
+        client_id,
+        domain,
+        code,
+        &TWOFA_RETRY_CONFIG,
+    )
+    .await
+}
+
+async fn submit_2fa_code_inner(
+    session: &mut Session,
+    endpoints: &Endpoints,
+    client_id: &str,
+    domain: &str,
+    code: &str,
+    retry_config: &RetryConfig,
 ) -> Result<bool> {
     let Some(code) = normalize_2fa_code(code) else {
         tracing::error!(
@@ -199,11 +311,55 @@ pub async fn submit_2fa_code(
 
     let url = format!("{}/verify/trusteddevice/securitycode", endpoints.auth);
     let body = data.to_string();
-    let response = session.post(&url, Some(&body), Some(headers)).await?;
+    let max_delay = Duration::from_secs(retry_config.max_delay_secs);
+    // The first attempt reuses the pre-computed `headers`; retries (rare,
+    // only on 429/5xx) rebuild them so any rotated scnt/session_id is picked
+    // up. A "wrong code" response (-21669) short-circuits without a retry.
+    let mut attempt_headers = Some(headers);
+    let total_attempts = retry_config.max_retries.saturating_add(1);
+    let (status, text) = 'outer: {
+        for attempt in 0..total_attempts {
+            let headers = if let Some(h) = attempt_headers.take() {
+                h
+            } else {
+                get_auth_headers(
+                    domain,
+                    client_id,
+                    &session.session_data,
+                    Some(&accept_override),
+                )?
+            };
+            let response = session.post(&url, Some(&body), Some(headers)).await?;
+            let status = response.status();
+            if status.is_success() {
+                let text = response.text().await.unwrap_or_default();
+                break 'outer (status, text);
+            }
 
-    let status = response.status();
+            let is_last = attempt + 1 >= total_attempts;
+            if !is_transient_auth_status(status.as_u16()) || is_last {
+                let text = response.text().await.unwrap_or_default();
+                break 'outer (status, text);
+            }
+
+            let delay = parse_retry_after_header(response.headers(), max_delay)
+                .unwrap_or_else(|| retry_config.delay_for_retry(attempt));
+            let _ = response.text().await;
+            tracing::warn!(
+                attempt = attempt + 1,
+                total_attempts,
+                status = status.as_u16(),
+                retry_delay_secs = delay.as_secs(),
+                "2FA code submit: transient failure, retrying"
+            );
+            tokio::time::sleep(delay).await;
+        }
+        return Err(anyhow::anyhow!(
+            "2FA code submit: retry loop exhausted without a decisive response"
+        ));
+    };
+
     if !status.is_success() {
-        let text = response.text().await.unwrap_or_default();
         // Apple error code -21669 = incorrect verification code
         if text.contains("-21669") {
             tracing::error!("Code verification failed: wrong code");
@@ -217,7 +373,6 @@ pub async fn submit_2fa_code(
     }
 
     // Apple can return HTTP 200 with error indicators in the body
-    let text = response.text().await.unwrap_or_default();
     if let Ok(body) = serde_json::from_str::<Value>(&text) {
         if let Err(e) = check_apple_service_errors(&body) {
             tracing::error!(error = %e, "2FA verification returned service error");
@@ -668,5 +823,229 @@ mod tests {
             AuthError::InvalidToken("custom fallback".into())
         });
         assert!(matches!(err, AuthError::InvalidToken(_)));
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // wiremock-based tests for 2FA push / submit retry behavior.
+    //
+    // These tests verify that transient 5xx/429 responses are retried
+    // (up to TWOFA_RETRY_CONFIG) rather than bailing immediately with
+    // "2FA code request failed (HTTP 429)" and that the final error is
+    // a typed AuthError::ApiError rather than an opaque anyhow::bail.
+    // ────────────────────────────────────────────────────────────────
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Zero-delay retry config for wiremock tests. Real retry delays (2s+)
+    /// would stall the suite; `start_paused` isn't usable because it also
+    /// halts the clock that reqwest's connection timeout relies on.
+    const TEST_RETRY: RetryConfig = RetryConfig {
+        max_retries: 2,
+        base_delay_secs: 0,
+        max_delay_secs: 0,
+    };
+
+    async fn session_for(server: &MockServer) -> (TempDir, Session) {
+        let dir = tempfile::tempdir().unwrap();
+        let session = Session::new(dir.path(), "test@example.com", &server.uri(), Some(5))
+            .await
+            .unwrap();
+        (dir, session)
+    }
+
+    #[tokio::test]
+    async fn trigger_push_retries_on_503_then_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        trigger_push_notification_inner(&mut session, &endpoints, "client-id", "com", &TEST_RETRY)
+            .await
+            .expect("should succeed after a 503 retry");
+    }
+
+    #[tokio::test]
+    async fn trigger_push_retries_on_429_with_retry_after_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("Retry-After", "1")
+                    .set_body_string("slow down"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        // max_delay_secs=0 in TEST_RETRY caps the Retry-After=1s to 0s, so
+        // the retry happens immediately but still structurally honors the
+        // header path (parse + clamp).
+        trigger_push_notification_inner(&mut session, &endpoints, "client-id", "com", &TEST_RETRY)
+            .await
+            .expect("429 + Retry-After must retry once and succeed");
+    }
+
+    #[tokio::test]
+    async fn trigger_push_persistent_429_returns_typed_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let err = trigger_push_notification_inner(
+            &mut session,
+            &endpoints,
+            "client-id",
+            "com",
+            &TEST_RETRY,
+        )
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().expect("typed AuthError");
+        match auth_err {
+            AuthError::ApiError { code, .. } => assert_eq!(*code, 429),
+            other => panic!("expected ApiError(429), got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn trigger_push_non_transient_4xx_bails_without_retry() {
+        // 400 is not a transient auth status, so no retries should happen.
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .expect(1) // exactly one call; no retry
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let err = trigger_push_notification_inner(
+            &mut session,
+            &endpoints,
+            "client-id",
+            "com",
+            &TEST_RETRY,
+        )
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().expect("typed AuthError");
+        assert!(
+            matches!(auth_err, AuthError::ApiError { code: 400, .. }),
+            "expected ApiError(400), got: {auth_err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_2fa_code_retries_on_503_then_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let ok = submit_2fa_code_inner(
+            &mut session,
+            &endpoints,
+            "client-id",
+            "com",
+            "123456",
+            &TEST_RETRY,
+        )
+        .await
+        .expect("submit should succeed after 503 retry");
+        assert!(ok, "valid code on second try => verification success");
+    }
+
+    #[tokio::test]
+    async fn submit_2fa_code_wrong_code_response_does_not_retry() {
+        // -21669 is Apple's "wrong code" sentinel. It lives in a 4xx body,
+        // but the caller returns Ok(false) rather than retrying.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string("{\"service_errors\": [{\"code\":\"-21669\"}]}"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let ok = submit_2fa_code_inner(
+            &mut session,
+            &endpoints,
+            "client-id",
+            "com",
+            "123456",
+            &TEST_RETRY,
+        )
+        .await
+        .expect("wrong-code response should be Ok(false), not an error");
+        assert!(!ok, "wrong code must return Ok(false)");
+    }
+
+    #[tokio::test]
+    async fn submit_2fa_code_persistent_503_returns_typed_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/appleauth/auth/verify/trusteddevice/securitycode"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("down"))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = session_for(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let err = submit_2fa_code_inner(
+            &mut session,
+            &endpoints,
+            "client-id",
+            "com",
+            "123456",
+            &TEST_RETRY,
+        )
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().expect("typed AuthError");
+        assert!(
+            matches!(auth_err, AuthError::ApiError { code: 503, .. }),
+            "expected ApiError(503) after retry exhaustion, got: {auth_err:?}"
+        );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -836,16 +836,26 @@ mod tests {
     /// Scrub auth-related env vars for the duration of the returned guard so
     /// tests that exercise clap's flag parsing don't get contaminated when the
     /// developer has `ICLOUD_USERNAME` / `ICLOUD_PASSWORD` exported (via
-    /// `.env` sourcing for live tests). The process-wide mutex serializes
-    /// mutations so parallel test threads don't race.
+    /// `.env` sourcing for live tests). A process-wide mutex serializes
+    /// concurrent calls to this helper.
+    ///
+    /// Note that this only protects against other callers of `scrub_auth_env`.
+    /// `setenv`/`getenv` on POSIX aren't thread-safe against each other, so an
+    /// unrelated test reading an env var while the guard is mutating could
+    /// theoretically race. The CLI unit tests only touch these two vars via
+    /// clap's `env = "..."` attributes during `try_parse_from`, which happens
+    /// synchronously on one thread per test — so in practice the guard is
+    /// sufficient for this suite. If a future test reads env from another
+    /// thread, it needs to coordinate through the same mutex.
     fn scrub_auth_env() -> AuthEnvGuard {
         use std::sync::Mutex;
         static LOCK: Mutex<()> = Mutex::new(());
         let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_user = std::env::var("ICLOUD_USERNAME").ok();
         let prev_pw = std::env::var("ICLOUD_PASSWORD").ok();
-        // SAFETY: mutations happen only inside the static mutex, so no other
-        // thread in this process observes env state mid-swap.
+        // SAFETY: the enclosing MutexGuard serializes every other caller of
+        // scrub_auth_env, and the test suite does not read these env vars
+        // from separate threads.
         unsafe {
             std::env::remove_var("ICLOUD_USERNAME");
             std::env::remove_var("ICLOUD_PASSWORD");
@@ -865,7 +875,9 @@ mod tests {
 
     impl Drop for AuthEnvGuard {
         fn drop(&mut self) {
-            // SAFETY: still holding the static mutex, so restoration is exclusive.
+            // SAFETY: still holding the static mutex, so restoration is
+            // exclusive under the same "no cross-thread readers" condition
+            // described on scrub_auth_env.
             unsafe {
                 if let Some(v) = self.prev_user.take() {
                     std::env::set_var("ICLOUD_USERNAME", v);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -833,6 +833,50 @@ mod tests {
         vec!["kei", "--username", "test@example.com"]
     }
 
+    /// Scrub auth-related env vars for the duration of the returned guard so
+    /// tests that exercise clap's flag parsing don't get contaminated when the
+    /// developer has `ICLOUD_USERNAME` / `ICLOUD_PASSWORD` exported (via
+    /// `.env` sourcing for live tests). The process-wide mutex serializes
+    /// mutations so parallel test threads don't race.
+    fn scrub_auth_env() -> AuthEnvGuard {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_user = std::env::var("ICLOUD_USERNAME").ok();
+        let prev_pw = std::env::var("ICLOUD_PASSWORD").ok();
+        // SAFETY: mutations happen only inside the static mutex, so no other
+        // thread in this process observes env state mid-swap.
+        unsafe {
+            std::env::remove_var("ICLOUD_USERNAME");
+            std::env::remove_var("ICLOUD_PASSWORD");
+        }
+        AuthEnvGuard {
+            _lock: guard,
+            prev_user,
+            prev_pw,
+        }
+    }
+
+    struct AuthEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prev_user: Option<String>,
+        prev_pw: Option<String>,
+    }
+
+    impl Drop for AuthEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: still holding the static mutex, so restoration is exclusive.
+            unsafe {
+                if let Some(v) = self.prev_user.take() {
+                    std::env::set_var("ICLOUD_USERNAME", v);
+                }
+                if let Some(v) = self.prev_pw.take() {
+                    std::env::set_var("ICLOUD_PASSWORD", v);
+                }
+            }
+        }
+    }
+
     // ── Global args ───────────────────────────────────────────────
 
     #[test]
@@ -877,6 +921,7 @@ mod tests {
 
     #[test]
     fn test_bare_invocation_without_username() {
+        let _guard = scrub_auth_env();
         let cli = Cli::try_parse_from(["kei"]).unwrap();
         assert!(cli.username.is_none());
         assert!(cli.command.is_none());
@@ -1262,6 +1307,7 @@ mod tests {
 
     #[test]
     fn test_password_file_flag() {
+        let _guard = scrub_auth_env();
         let mut args = base_args();
         args.extend(["--password-file", "/run/secrets/pw"]);
         let cli = parse(&args);
@@ -1273,6 +1319,7 @@ mod tests {
 
     #[test]
     fn test_password_command_flag() {
+        let _guard = scrub_auth_env();
         let mut args = base_args();
         args.extend(["--password-command", "op read 'op://vault/icloud/pw'"]);
         let cli = parse(&args);

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn session_expired_not_misdirected() {
-        let err = icloud::error::ICloudError::SessionExpired;
+        let err = icloud::error::ICloudError::SessionExpired { status: 401 };
         assert!(!is_misdirected_request(&err));
     }
 

--- a/src/icloud/error.rs
+++ b/src/icloud/error.rs
@@ -15,11 +15,13 @@ pub enum ICloudError {
             → Log into https://icloud.com/ and finish setting up your iCloud service."
     )]
     ServiceNotActivated { code: String, reason: String },
-    /// CloudKit rejected the request with HTTP 401. The caller should
-    /// invalidate any cached session/validation data and re-authenticate
-    /// with SRP before retrying.
-    #[error("Session expired (HTTP 401 from CloudKit)")]
-    SessionExpired,
+    /// CloudKit rejected the request with an auth-class HTTP status. Typically
+    /// 401 (stale session), 403 (rotated routing cookie or an ADP edge case
+    /// not caught earlier), or - rarely - another 4xx that maps to the same
+    /// recovery path. The caller should invalidate any cached session data
+    /// and re-authenticate with SRP before retrying.
+    #[error("Session expired (HTTP {status} from CloudKit)")]
+    SessionExpired { status: u16 },
     /// CloudKit returned HTTP 421 Misdirected Request. The HTTP/2 connection
     /// was routed to the wrong CloudKit partition; the caller should reset
     /// the connection pool and retry on a fresh connection.
@@ -35,11 +37,11 @@ pub enum ICloudError {
 
 impl ICloudError {
     /// True if the error means kei should invalidate the session cache, force
-    /// SRP re-authentication, and retry. Both `SessionExpired` (CloudKit 401)
-    /// and `MisdirectedRequest` (persistent CloudKit 421) typically indicate
-    /// stale session routing state that only SRP can re-mint.
+    /// SRP re-authentication, and retry. Both `SessionExpired` (CloudKit
+    /// 401/403) and `MisdirectedRequest` (persistent CloudKit 421) typically
+    /// indicate stale session routing state that only SRP can re-mint.
     pub fn is_session_error(&self) -> bool {
-        matches!(self, Self::SessionExpired | Self::MisdirectedRequest)
+        matches!(self, Self::SessionExpired { .. } | Self::MisdirectedRequest)
     }
 }
 
@@ -131,9 +133,9 @@ mod tests {
 
     #[test]
     fn session_expired_is_distinct_variant() {
-        let err = ICloudError::SessionExpired;
+        let err = ICloudError::SessionExpired { status: 401 };
         assert!(
-            matches!(err, ICloudError::SessionExpired),
+            matches!(err, ICloudError::SessionExpired { .. }),
             "dedicated variant so callers can trigger SRP re-auth"
         );
         let display = err.to_string();
@@ -141,8 +143,20 @@ mod tests {
     }
 
     #[test]
+    fn session_expired_display_renders_actual_status() {
+        // A 403 that maps to SessionExpired (e.g. bare CloudKit 403) must
+        // surface as "HTTP 403" so the diagnostic matches the on-wire status.
+        let err = ICloudError::SessionExpired { status: 403 };
+        assert!(
+            err.to_string().contains("HTTP 403"),
+            "403 must render as HTTP 403, not HTTP 401: {err}"
+        );
+    }
+
+    #[test]
     fn is_session_error_true_for_session_expired_and_misdirected() {
-        assert!(ICloudError::SessionExpired.is_session_error());
+        assert!(ICloudError::SessionExpired { status: 401 }.is_session_error());
+        assert!(ICloudError::SessionExpired { status: 403 }.is_session_error());
         assert!(ICloudError::MisdirectedRequest.is_session_error());
     }
 

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -96,29 +96,22 @@ impl PhotoLibrary {
                 }
             }
             if let Some(http_err) = e.downcast_ref::<super::session::HttpStatusError>() {
-                // HTTP 401: stale cached session tokens. Caller invalidates
-                // the validation cache and retries with fresh SRP.
-                if http_err.status == 401 {
-                    return ICloudError::SessionExpired { status: 401 };
-                }
                 // HTTP 421: HTTP/2 connection routed to the wrong CloudKit
                 // partition. Caller resets the pool and retries.
                 if http_err.status == 421 {
                     return ICloudError::MisdirectedRequest;
                 }
-                // HTTP 403 has many causes: rate limits, stale sessions, rotated
-                // routing cookies, and - in some cases - ADP. Genuine ADP is
-                // already surfaced earlier via (a) `i_cdp_enabled` in the auth
-                // response, which bails before we ever reach CloudKit, and
-                // (b) CloudKit body errors ZONE_NOT_FOUND / ACCESS_DENIED /
-                // AUTHENTICATION_FAILED, which classify_api_error maps to
-                // ServiceNotActivated above. Anything left is most often a
-                // session-state problem, so route it to SessionExpired and let
-                // the sync loop re-auth. If the 403 truly is ADP and persists,
-                // the AUTH_ERROR_THRESHOLD break in the download pipeline stops
-                // the sync instead of spamming retries.
-                if http_err.status == 403 {
-                    return ICloudError::SessionExpired { status: 403 };
+                // HTTP 401 / 403 both route through SessionExpired so the sync
+                // loop re-auths. 401 is the classic stale-session signal; 403
+                // has many causes (rate limits, rotated routing cookies, and
+                // ADP edge cases not caught by `i_cdp_enabled` or by the
+                // CloudKit body errors handled above). If the 403 truly is
+                // persistent ADP, AUTH_ERROR_THRESHOLD in the download
+                // pipeline stops the sync rather than spamming retries.
+                if http_err.status == 401 || http_err.status == 403 {
+                    return ICloudError::SessionExpired {
+                        status: http_err.status,
+                    };
                 }
             }
             ICloudError::Connection(e.to_string())

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -99,7 +99,7 @@ impl PhotoLibrary {
                 // HTTP 401: stale cached session tokens. Caller invalidates
                 // the validation cache and retries with fresh SRP.
                 if http_err.status == 401 {
-                    return ICloudError::SessionExpired;
+                    return ICloudError::SessionExpired { status: 401 };
                 }
                 // HTTP 421: HTTP/2 connection routed to the wrong CloudKit
                 // partition. Caller resets the pool and retries.
@@ -118,7 +118,7 @@ impl PhotoLibrary {
                 // the AUTH_ERROR_THRESHOLD break in the download pipeline stops
                 // the sync instead of spamming retries.
                 if http_err.status == 403 {
-                    return ICloudError::SessionExpired;
+                    return ICloudError::SessionExpired { status: 403 };
                 }
             }
             ICloudError::Connection(e.to_string())
@@ -435,8 +435,12 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(err, ICloudError::SessionExpired),
-            "expected SessionExpired so sync_loop can re-auth, got: {err:?}"
+            matches!(err, ICloudError::SessionExpired { status: 403 }),
+            "expected SessionExpired {{ 403 }} so the message tracks the actual status, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("HTTP 403"),
+            "display must mention HTTP 403, got: {err}"
         );
     }
 
@@ -532,8 +536,8 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(err, ICloudError::SessionExpired),
-            "expected SessionExpired so sync_loop can invalidate cache and \
+            matches!(err, ICloudError::SessionExpired { status: 401 }),
+            "expected SessionExpired {{ 401 }} so sync_loop can invalidate cache and \
              re-authenticate, got: {err:?}"
         );
     }

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -106,13 +106,19 @@ impl PhotoLibrary {
                 if http_err.status == 421 {
                     return ICloudError::MisdirectedRequest;
                 }
-                // HTTP 403 is the classic ADP signature: account authenticated
-                // fine but iCloud data access is blocked.
+                // HTTP 403 has many causes: rate limits, stale sessions, rotated
+                // routing cookies, and - in some cases - ADP. Genuine ADP is
+                // already surfaced earlier via (a) `i_cdp_enabled` in the auth
+                // response, which bails before we ever reach CloudKit, and
+                // (b) CloudKit body errors ZONE_NOT_FOUND / ACCESS_DENIED /
+                // AUTHENTICATION_FAILED, which classify_api_error maps to
+                // ServiceNotActivated above. Anything left is most often a
+                // session-state problem, so route it to SessionExpired and let
+                // the sync loop re-auth. If the 403 truly is ADP and persists,
+                // the AUTH_ERROR_THRESHOLD break in the download pipeline stops
+                // the sync instead of spamming retries.
                 if http_err.status == 403 {
-                    return ICloudError::ServiceNotActivated {
-                        code: "HTTP_403".into(),
-                        reason: "Forbidden — iCloud data access denied".into(),
-                    };
+                    return ICloudError::SessionExpired;
                 }
             }
             ICloudError::Connection(e.to_string())
@@ -398,6 +404,7 @@ mod tests {
             Err(crate::icloud::photos::session::HttpStatusError {
                 status: 403,
                 url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
+                retry_after: None,
             }.into())
         }
 
@@ -407,7 +414,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn http_403_maps_to_service_not_activated() {
+    async fn http_403_maps_to_session_expired() {
+        // Bare HTTP 403 (without a CloudKit body error) has too many causes
+        // to assume ADP. Route it through SessionExpired so the sync loop
+        // re-authenticates once; genuine ADP is surfaced via `i_cdp_enabled`
+        // before we reach CloudKit, and CloudKit-body errors (ZONE_NOT_FOUND,
+        // ACCESS_DENIED) still map to ServiceNotActivated via `service_not_activated`.
         let err = PhotoLibrary::new(
             "https://example.com".into(),
             Arc::new(HashMap::new()),
@@ -423,13 +435,59 @@ mod tests {
         .unwrap_err();
 
         assert!(
+            matches!(err, ICloudError::SessionExpired),
+            "expected SessionExpired so sync_loop can re-auth, got: {err:?}"
+        );
+    }
+
+    /// Stub whose CloudKit body reports an `ACCESS_DENIED` service error.
+    /// These are the ADP-class signals; they should still produce a clear
+    /// `ServiceNotActivated` error with the ADP guidance message.
+    struct AccessDeniedBodySession;
+
+    #[async_trait::async_trait]
+    impl PhotosSession for AccessDeniedBodySession {
+        async fn post(
+            &self,
+            _url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            Ok(json!({
+                "serverErrorCode": "ACCESS_DENIED",
+                "reason": "private db access disabled for this account",
+            }))
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(AccessDeniedBodySession)
+        }
+    }
+
+    #[tokio::test]
+    async fn cloudkit_access_denied_still_maps_to_service_not_activated() {
+        let err = PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(AccessDeniedBodySession),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
             matches!(err, ICloudError::ServiceNotActivated { .. }),
-            "expected ServiceNotActivated, got: {err:?}"
+            "ADP body signal must still surface ServiceNotActivated, got: {err:?}"
         );
         let display = err.to_string();
         assert!(
             display.contains("Advanced Data Protection"),
-            "expected ADP guidance in message, got: {display}"
+            "expected ADP guidance, got: {display}"
         );
     }
 
@@ -448,6 +506,7 @@ mod tests {
             Err(crate::icloud::photos::session::HttpStatusError {
                 status: 401,
                 url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
+                retry_after: None,
             }.into())
         }
 
@@ -494,6 +553,7 @@ mod tests {
             Err(crate::icloud::photos::session::HttpStatusError {
                 status: 421,
                 url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
+                retry_after: None,
             }.into())
         }
 

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -2,25 +2,11 @@ use std::time::Duration;
 
 use serde_json::Value;
 
-use crate::retry::{self, RetryAction, RetryConfig};
+use crate::retry::{self, parse_retry_after_header, RetryAction, RetryConfig};
 
-/// Cap on `Retry-After` values to bound the worst-case pause. A pathological
-/// or stale HTTP-date could otherwise stall the retry loop.
+/// Upper bound on any `Retry-After` hint from CloudKit, chosen so a
+/// pathological server value can't stall the retry loop.
 const RETRY_AFTER_MAX: Duration = Duration::from_secs(120);
-
-/// Parse a `Retry-After` header as delta-seconds. Returns `None` for absent
-/// or unparseable values, or zero. Values over [`RETRY_AFTER_MAX`] are capped.
-///
-/// The HTTP-date form is accepted by the spec but rarely used in practice
-/// (Apple/CloudKit always emit delta-seconds); we skip it to avoid pulling
-/// in an extra chrono/httpdate dependency for a fallback path.
-pub(crate) fn parse_retry_after(value: &str) -> Option<Duration> {
-    let secs: u64 = value.trim().parse().ok()?;
-    if secs == 0 {
-        return None;
-    }
-    Some(Duration::from_secs(secs).min(RETRY_AFTER_MAX))
-}
 
 /// Async HTTP session trait for the photos service.
 ///
@@ -58,11 +44,7 @@ impl PhotosSession for reqwest::Client {
 
         if status.is_client_error() || status.is_server_error() {
             let url = resp.url().to_string();
-            let retry_after = resp
-                .headers()
-                .get(reqwest::header::RETRY_AFTER)
-                .and_then(|v| v.to_str().ok())
-                .and_then(parse_retry_after);
+            let retry_after = parse_retry_after_header(resp.headers(), RETRY_AFTER_MAX);
             let resp_body = resp.text().await.unwrap_or_default();
             if !resp_body.is_empty() {
                 // 421 bodies are the most diagnostic signal for distinguishing
@@ -938,35 +920,5 @@ mod tests {
             retry_after: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Abort));
-    }
-
-    #[test]
-    fn parse_retry_after_delta_seconds() {
-        assert_eq!(parse_retry_after("5"), Some(Duration::from_secs(5)));
-        assert_eq!(parse_retry_after(" 12 "), Some(Duration::from_secs(12)));
-    }
-
-    #[test]
-    fn parse_retry_after_zero_treated_as_absent() {
-        assert_eq!(parse_retry_after("0"), None);
-    }
-
-    #[test]
-    fn parse_retry_after_caps_at_max() {
-        let out = parse_retry_after("999999").unwrap();
-        assert_eq!(out, RETRY_AFTER_MAX);
-    }
-
-    #[test]
-    fn parse_retry_after_rejects_http_date() {
-        // We intentionally do not decode HTTP-date form; callers fall back to
-        // exponential backoff when this returns None.
-        assert_eq!(parse_retry_after("Sun, 06 Nov 1994 08:49:37 GMT"), None);
-    }
-
-    #[test]
-    fn parse_retry_after_rejects_junk() {
-        assert_eq!(parse_retry_after("not-a-number"), None);
-        assert_eq!(parse_retry_after(""), None);
     }
 }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -1,6 +1,26 @@
+use std::time::Duration;
+
 use serde_json::Value;
 
 use crate::retry::{self, RetryAction, RetryConfig};
+
+/// Cap on `Retry-After` values to bound the worst-case pause. A pathological
+/// or stale HTTP-date could otherwise stall the retry loop.
+const RETRY_AFTER_MAX: Duration = Duration::from_secs(120);
+
+/// Parse a `Retry-After` header as delta-seconds. Returns `None` for absent
+/// or unparseable values, or zero. Values over [`RETRY_AFTER_MAX`] are capped.
+///
+/// The HTTP-date form is accepted by the spec but rarely used in practice
+/// (Apple/CloudKit always emit delta-seconds); we skip it to avoid pulling
+/// in an extra chrono/httpdate dependency for a fallback path.
+pub(crate) fn parse_retry_after(value: &str) -> Option<Duration> {
+    let secs: u64 = value.trim().parse().ok()?;
+    if secs == 0 {
+        return None;
+    }
+    Some(Duration::from_secs(secs).min(RETRY_AFTER_MAX))
+}
 
 /// Async HTTP session trait for the photos service.
 ///
@@ -38,6 +58,11 @@ impl PhotosSession for reqwest::Client {
 
         if status.is_client_error() || status.is_server_error() {
             let url = resp.url().to_string();
+            let retry_after = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(parse_retry_after);
             let resp_body = resp.text().await.unwrap_or_default();
             if !resp_body.is_empty() {
                 // 421 bodies are the most diagnostic signal for distinguishing
@@ -63,6 +88,7 @@ impl PhotosSession for reqwest::Client {
             return Err(HttpStatusError {
                 status: status.as_u16(),
                 url,
+                retry_after,
             }
             .into());
         }
@@ -98,11 +124,16 @@ impl PhotosSession for crate::auth::SharedSession {
 
 /// HTTP error with structured status code for typed error handling.
 /// Wraps non-success HTTP responses from CloudKit endpoints.
+///
+/// `retry_after` is populated from the `Retry-After` response header when
+/// present, so callers can honor the server-provided delay on 429/503
+/// instead of falling back to exponential backoff alone.
 #[derive(Debug, thiserror::Error)]
 #[error("HTTP {status} for {url}")]
 pub(crate) struct HttpStatusError {
     pub status: u16,
     pub url: String,
+    pub retry_after: Option<Duration>,
 }
 
 /// `CloudKit` server error codes that indicate a transient condition.
@@ -235,11 +266,13 @@ fn classify_api_error(e: &anyhow::Error) -> RetryAction {
         };
     }
     if let Some(http_err) = e.downcast_ref::<HttpStatusError>() {
-        return if http_err.status == 429 || http_err.status >= 500 {
-            RetryAction::Retry
-        } else {
-            RetryAction::Abort
-        };
+        if http_err.status == 429 || http_err.status >= 500 {
+            return match http_err.retry_after {
+                Some(d) => RetryAction::RetryAfter(d),
+                None => RetryAction::Retry,
+            };
+        }
+        return RetryAction::Abort;
     }
     if let Some(reqwest_err) = e.downcast_ref::<reqwest::Error>() {
         if let Some(status) = reqwest_err.status() {
@@ -846,6 +879,7 @@ mod tests {
         let err = anyhow::Error::new(HttpStatusError {
             status: 503,
             url: "https://example.com".to_string(),
+            retry_after: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Retry));
     }
@@ -855,8 +889,35 @@ mod tests {
         let err = anyhow::Error::new(HttpStatusError {
             status: 429,
             url: "https://example.com".to_string(),
+            retry_after: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Retry));
+    }
+
+    #[test]
+    fn classify_http_status_error_honors_retry_after() {
+        let err = anyhow::Error::new(HttpStatusError {
+            status: 429,
+            url: "https://example.com".to_string(),
+            retry_after: Some(Duration::from_secs(7)),
+        });
+        match classify_api_error(&err) {
+            RetryAction::RetryAfter(d) => assert_eq!(d, Duration::from_secs(7)),
+            other => panic!("expected RetryAfter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_http_status_error_503_with_retry_after() {
+        let err = anyhow::Error::new(HttpStatusError {
+            status: 503,
+            url: "https://example.com".to_string(),
+            retry_after: Some(Duration::from_secs(2)),
+        });
+        match classify_api_error(&err) {
+            RetryAction::RetryAfter(d) => assert_eq!(d, Duration::from_secs(2)),
+            other => panic!("expected RetryAfter, got {other:?}"),
+        }
     }
 
     #[test]
@@ -864,6 +925,7 @@ mod tests {
         let err = anyhow::Error::new(HttpStatusError {
             status: 401,
             url: "https://example.com".to_string(),
+            retry_after: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Abort));
     }
@@ -873,7 +935,38 @@ mod tests {
         let err = anyhow::Error::new(HttpStatusError {
             status: 403,
             url: "https://example.com".to_string(),
+            retry_after: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Abort));
+    }
+
+    #[test]
+    fn parse_retry_after_delta_seconds() {
+        assert_eq!(parse_retry_after("5"), Some(Duration::from_secs(5)));
+        assert_eq!(parse_retry_after(" 12 "), Some(Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn parse_retry_after_zero_treated_as_absent() {
+        assert_eq!(parse_retry_after("0"), None);
+    }
+
+    #[test]
+    fn parse_retry_after_caps_at_max() {
+        let out = parse_retry_after("999999").unwrap();
+        assert_eq!(out, RETRY_AFTER_MAX);
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_http_date() {
+        // We intentionally do not decode HTTP-date form; callers fall back to
+        // exponential backoff when this returns None.
+        assert_eq!(parse_retry_after("Sun, 06 Nov 1994 08:49:37 GMT"), None);
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_junk() {
+        assert_eq!(parse_retry_after("not-a-number"), None);
+        assert_eq!(parse_retry_after(""), None);
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,6 +1,27 @@
 use std::future::Future;
+use std::time::Duration;
 
 use rand::RngExt;
+
+/// Parse the `Retry-After` response header as delta-seconds, capped at `max`.
+/// Returns `None` for absent, zero, or unparseable values. The HTTP-date form
+/// is not accepted (Apple/CloudKit always emit delta-seconds).
+pub fn parse_retry_after_header(
+    headers: &reqwest::header::HeaderMap,
+    max: Duration,
+) -> Option<Duration> {
+    let secs: u64 = headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    if secs == 0 {
+        return None;
+    }
+    Some(Duration::from_secs(secs).min(max))
+}
 
 /// Retry decision returned by the error classifier callback.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -316,6 +337,62 @@ mod tests {
         .await;
         // Abort returns immediately without logging retry
         assert!(!logs_contain("Retryable error"));
+    }
+
+    fn headers_with_retry_after(value: &str) -> reqwest::header::HeaderMap {
+        let mut h = reqwest::header::HeaderMap::new();
+        h.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_str(value).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn parse_retry_after_delta_seconds() {
+        let h = headers_with_retry_after("5");
+        assert_eq!(
+            parse_retry_after_header(&h, Duration::from_secs(60)),
+            Some(Duration::from_secs(5))
+        );
+        let h = headers_with_retry_after(" 12 ");
+        assert_eq!(
+            parse_retry_after_header(&h, Duration::from_secs(60)),
+            Some(Duration::from_secs(12))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_zero_treated_as_absent() {
+        let h = headers_with_retry_after("0");
+        assert_eq!(parse_retry_after_header(&h, Duration::from_secs(60)), None);
+    }
+
+    #[test]
+    fn parse_retry_after_caps_at_max() {
+        let h = headers_with_retry_after("999999");
+        assert_eq!(
+            parse_retry_after_header(&h, Duration::from_secs(120)),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_http_date() {
+        let h = headers_with_retry_after("Sun, 06 Nov 1994 08:49:37 GMT");
+        assert_eq!(parse_retry_after_header(&h, Duration::from_secs(60)), None);
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_junk() {
+        let h = headers_with_retry_after("not-a-number");
+        assert_eq!(parse_retry_after_header(&h, Duration::from_secs(60)), None);
+    }
+
+    #[test]
+    fn parse_retry_after_missing_header() {
+        let h = reqwest::header::HeaderMap::new();
+        assert_eq!(parse_retry_after_header(&h, Duration::from_secs(60)), None);
     }
 
     #[tokio::test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -6,6 +6,9 @@ use rand::RngExt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RetryAction {
     Retry,
+    /// Retry after an explicit delay (e.g. honoring a `Retry-After` header).
+    /// Overrides the exponential-backoff schedule for this attempt only.
+    RetryAfter(std::time::Duration),
     Abort,
 }
 
@@ -76,14 +79,21 @@ where
         match operation().await {
             Ok(val) => return Ok(val),
             Err(e) => {
-                if classifier(&e) == RetryAction::Abort {
+                let action = classifier(&e);
+                if action == RetryAction::Abort {
                     return Err(e);
                 }
                 let is_last = attempt + 1 >= total_attempts;
                 if is_last {
                     return Err(e);
                 }
-                let delay = config.delay_for_retry(attempt);
+                let delay = match action {
+                    RetryAction::RetryAfter(d) => {
+                        let max = std::time::Duration::from_secs(config.max_delay_secs);
+                        d.min(max)
+                    }
+                    _ => config.delay_for_retry(attempt),
+                };
                 tracing::warn!(
                     attempt = attempt + 1,
                     total_attempts,
@@ -306,6 +316,79 @@ mod tests {
         .await;
         // Abort returns immediately without logging retry
         assert!(!logs_contain("Retryable error"));
+    }
+
+    #[tokio::test]
+    async fn test_retry_after_overrides_exponential_delay() {
+        // RetryAction::RetryAfter(d) uses the server-provided delay instead
+        // of the configured exponential backoff for that attempt.
+        let config = RetryConfig {
+            max_retries: 2,
+            base_delay_secs: 5, // would normally sleep 5..10s on first retry
+            max_delay_secs: 60,
+        };
+        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let cc = call_count.clone();
+        let started = std::time::Instant::now();
+        let result: Result<i32, String> = retry_with_backoff(
+            &config,
+            |_| RetryAction::RetryAfter(std::time::Duration::from_millis(50)),
+            || {
+                let cc = cc.clone();
+                async move {
+                    let n = cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    if n < 1 {
+                        Err("transient".to_string())
+                    } else {
+                        Ok(7)
+                    }
+                }
+            },
+        )
+        .await;
+        let elapsed = started.elapsed();
+        assert_eq!(result.unwrap(), 7);
+        // Server-provided 50ms should dominate over the configured 5s.
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "expected RetryAfter to shorten delay, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_after_capped_at_max_delay() {
+        // A Retry-After larger than max_delay_secs is clamped so a pathological
+        // server response cannot stall the retry loop indefinitely.
+        let config = RetryConfig {
+            max_retries: 1,
+            base_delay_secs: 0,
+            max_delay_secs: 0, // forces the clamp to zero
+        };
+        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let cc = call_count.clone();
+        let started = std::time::Instant::now();
+        let result: Result<i32, String> = retry_with_backoff(
+            &config,
+            |_| RetryAction::RetryAfter(std::time::Duration::from_secs(3600)),
+            || {
+                let cc = cc.clone();
+                async move {
+                    let n = cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    if n < 1 {
+                        Err("rate limited".to_string())
+                    } else {
+                        Ok(1)
+                    }
+                }
+            },
+        )
+        .await;
+        let elapsed = started.elapsed();
+        assert_eq!(result.unwrap(), 1);
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "expected max_delay_secs clamp, took {elapsed:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use rand::RngExt;
 
 /// Parse the `Retry-After` response header as delta-seconds, capped at `max`.
-/// Returns `None` for absent, zero, or unparseable values. The HTTP-date form
+/// Returns `None` for absent, zero, or unparsable values. The HTTP-date form
 /// is not accepted (Apple/CloudKit always emit delta-seconds).
 pub fn parse_retry_after_header(
     headers: &reqwest::header::HeaderMap,

--- a/typos.toml
+++ b/typos.toml
@@ -14,3 +14,8 @@ Caf = "Caf"
 Pn = "Pn"
 # THM = camera thumbnail file extension (e.g. Canon .THM files)
 THM = "THM"
+
+[default]
+# The `mis-` prefix (mis-routing, mis-attributed, mis-directed) is grammatical
+# English; typos wants to "fix" it to `miss`/`mist`. Suppress those matches.
+extend-ignore-re = ["\\bmis-\\w+"]


### PR DESCRIPTION
## Summary

kei no longer tells you your password is wrong when the real cause is Apple rate-limiting you, rotating a routing cookie, or flaking out on its auth CDN. Seven overlapping 4xx paths in the auth layer now return typed, accurate errors and retry transient failures instead of bailing on the first blip.

## Fixes

1. SRP `/signin/complete` had a catch-all 4xx branch that mapped every non-409/412 to `FailedLogin("Invalid email/password")`. Split by status: 401 stays `FailedLogin` (the real SRP-M1 rejection), 400 becomes `ApiError("malformed SRP payload")`, 429 becomes `ApiError("rate limited")`, anything else becomes `ApiError` with the raw status.
2. SRP `/signin/init` 401 was also `FailedLogin`, but init runs before the M1 proof is sent. A 401 here can only mean a stale auth context. Now returns `ApiError(401)`.
3. SRP skipped the `X-Apple-I-Rscd` header check that `/validate` and `/accountLogin` already use. Apple returns HTTP 200 with `rscd=401/403` to signal a hidden session rejection. `SrpResponse` now captures headers, and the shared `check_rscd_from_headers` / `rscd_service_error` helpers are applied to SRP.
4. Bare HTTP 403 on the CloudKit query endpoint was unconditionally mapped to `ServiceNotActivated` ("ADP enabled"). Real ADP is already caught by `i_cdp_enabled` and by CloudKit body errors. Bare 403 now maps to `SessionExpired` so the sync loop re-auths once; `AUTH_ERROR_THRESHOLD=3` still stops persistent 403s.
5. SRP init and complete now retry twice on transient 5xx/429 via a shared `AUTH_RETRY_CONFIG`, honoring `Retry-After` headers.
6. `trigger_push_notification` and `submit_2fa_code` used to hard-bail on any non-2xx. Both now retry 5xx/429 and return typed `AuthError::ApiError` on exhaustion. The `-21669` wrong-code sentinel still short-circuits to `Ok(false)`.
7. `Retry-After` is now honored in the photos retry loop too. `RetryAction` gains a `RetryAfter(Duration)` variant; `HttpStatusError` carries the parsed value (delta-seconds, capped at 120s); `classify_api_error` returns it on 429/5xx with a header present.

Builds on f3859ba. That fix covered `/validate` and library init. This one closes the same class of bug on SRP init, SRP complete, 2FA push, 2FA submit, and asset-path 403 mapping.

## Test plan

- [x] \`cargo test\`: 1243 unit + 103 behavioral + 95 CLI tests pass
- [x] 15 new SRP unit tests (one per status branch, including rscd paths)
- [x] 7 new wiremock tests for 2FA push/submit retry and error typing
- [x] 6 new retry tests, including \`Retry-After\` clamping at \`max_delay_secs\`
- [x] Library regression: bare 403 now expects \`SessionExpired\`; CloudKit \`ACCESS_DENIED\` body still produces \`ServiceNotActivated\` with ADP guidance
- [x] \`cargo fmt\` clean, \`cargo clippy --all-targets -- -D warnings\` clean