### PR TITLE
Overhaul coverage report: detailed table, sticky comment, JSON parsing

### DIFF
--- a/.github/scripts/patch_coverage.py
+++ b/.github/scripts/patch_coverage.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python3
-"""Compute patch coverage from a git diff and an LCOV report.
-
-Patch coverage = of the source lines this PR adds or modifies, the fraction
-that the test suite actually executed.
+"""Compute patch coverage and per-file file-level deltas.
 
 Outputs JSON to stdout:
   {
-    "total_covered": int,
-    "total_eligible": int,
-    "percent": float | null,
-    "files": [{"file": str, "covered": int, "total": int, "percent": float}, ...]
+    "total_covered": int,        # patch lines hit by tests
+    "total_eligible": int,       # patch lines that have coverage data
+    "percent": float | null,     # patch coverage %
+    "files": [
+      {
+        "file": str,
+        "covered": int,          # patch lines covered in this file
+        "total": int,            # patch lines eligible in this file
+        "percent": float,        # patch coverage % for this file
+        "file_percent_head": float | null,  # full-file line coverage on head
+        "file_percent_base": float | null,  # full-file line coverage on base
+        "file_delta": float | null,         # head - base
+      },
+      ...
+    ]
   }
 
-A line is "eligible" if it appears in the LCOV report (i.e. the compiler
-emitted coverage instrumentation for it). Lines that are pure whitespace,
-comments, or non-executable declarations have no DA: entry and are excluded
-from the denominator -- they're not testable.
+A line is "eligible" if it has a DA: entry in the LCOV report (i.e. the
+compiler emitted coverage instrumentation for it). Lines that are pure
+whitespace, comments, or non-executable declarations have no DA: entry and
+are excluded from the denominator -- they're not testable.
 """
 
 import argparse
@@ -77,15 +85,28 @@ def normalize_paths(coverage: dict[str, dict[int, int]], workspace: Path) -> dic
     return out
 
 
+def file_pct(line_hits: dict[int, int]) -> float | None:
+    """Whole-file line coverage % from a {line: hits} map."""
+    if not line_hits:
+        return None
+    covered = sum(1 for hits in line_hits.values() if hits > 0)
+    return covered / len(line_hits) * 100
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--base", required=True, help="base ref or SHA to diff against")
-    ap.add_argument("--lcov", required=True, type=Path, help="path to LCOV report")
+    ap.add_argument("--lcov", required=True, type=Path, help="path to head LCOV report")
+    ap.add_argument("--base-lcov", type=Path, default=None, help="optional base LCOV for delta")
     ap.add_argument("--workspace", default=".", type=Path, help="repo root for path normalization")
     args = ap.parse_args()
 
     workspace = args.workspace.resolve()
-    coverage = normalize_paths(parse_lcov(args.lcov), workspace)
+    head_cov = normalize_paths(parse_lcov(args.lcov), workspace)
+    base_cov: dict[str, dict[int, int]] = {}
+    if args.base_lcov is not None and args.base_lcov.exists():
+        base_cov = normalize_paths(parse_lcov(args.base_lcov), workspace)
+
     diff = parse_diff_added_lines(args.base)
 
     files = []
@@ -93,16 +114,24 @@ def main() -> None:
     total_eligible = 0
     for path in sorted(diff):
         added_lines = diff[path]
-        file_cov = coverage.get(path, {})
-        eligible = sorted(line for line in added_lines if line in file_cov)
+        head_file = head_cov.get(path, {})
+        eligible = sorted(line for line in added_lines if line in head_file)
         if not eligible:
             continue
-        covered = sum(1 for line in eligible if file_cov[line] > 0)
+        covered = sum(1 for line in eligible if head_file[line] > 0)
+
+        head_pct = file_pct(head_file)
+        base_pct = file_pct(base_cov.get(path, {})) if path in base_cov else None
+        delta = (head_pct - base_pct) if (head_pct is not None and base_pct is not None) else None
+
         files.append({
             "file": path,
             "covered": covered,
             "total": len(eligible),
             "percent": covered / len(eligible) * 100,
+            "file_percent_head": head_pct,
+            "file_percent_base": base_pct,
+            "file_delta": delta,
         })
         total_covered += covered
         total_eligible += len(eligible)

--- a/.github/scripts/patch_coverage.py
+++ b/.github/scripts/patch_coverage.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Compute patch coverage from a git diff and an LCOV report.
+
+Patch coverage = of the source lines this PR adds or modifies, the fraction
+that the test suite actually executed.
+
+Outputs JSON to stdout:
+  {
+    "total_covered": int,
+    "total_eligible": int,
+    "percent": float | null,
+    "files": [{"file": str, "covered": int, "total": int, "percent": float}, ...]
+  }
+
+A line is "eligible" if it appears in the LCOV report (i.e. the compiler
+emitted coverage instrumentation for it). Lines that are pure whitespace,
+comments, or non-executable declarations have no DA: entry and are excluded
+from the denominator -- they're not testable.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def parse_lcov(path: Path) -> dict[str, dict[int, int]]:
+    """Parse LCOV into {file: {line: hit_count}}."""
+    coverage: dict[str, dict[int, int]] = defaultdict(dict)
+    current: str | None = None
+    for raw in path.read_text().splitlines():
+        if raw.startswith("SF:"):
+            current = raw[3:]
+        elif raw == "end_of_record":
+            current = None
+        elif raw.startswith("DA:") and current is not None:
+            line_str, hits_str = raw[3:].split(",", 1)
+            coverage[current][int(line_str)] = int(hits_str)
+    return dict(coverage)
+
+
+def parse_diff_added_lines(base: str) -> dict[str, set[int]]:
+    """Return {relative_file_path: set(line_numbers)} for added/modified .rs lines."""
+    diff = subprocess.check_output(
+        ["git", "diff", "--unified=0", f"{base}...HEAD", "--", "*.rs"],
+        text=True,
+    )
+    added: dict[str, set[int]] = defaultdict(set)
+    current: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+        elif line.startswith("+++"):
+            current = None
+        elif current and (m := HUNK_RE.match(line)):
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) else 1
+            for i in range(count):
+                added[current].add(start + i)
+    return dict(added)
+
+
+def normalize_paths(coverage: dict[str, dict[int, int]], workspace: Path) -> dict[str, dict[int, int]]:
+    """Map absolute LCOV paths to repo-relative paths."""
+    out: dict[str, dict[int, int]] = {}
+    for path, lines in coverage.items():
+        try:
+            rel = str(Path(path).resolve().relative_to(workspace))
+        except ValueError:
+            rel = path
+        out[rel] = lines
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", required=True, help="base ref or SHA to diff against")
+    ap.add_argument("--lcov", required=True, type=Path, help="path to LCOV report")
+    ap.add_argument("--workspace", default=".", type=Path, help="repo root for path normalization")
+    args = ap.parse_args()
+
+    workspace = args.workspace.resolve()
+    coverage = normalize_paths(parse_lcov(args.lcov), workspace)
+    diff = parse_diff_added_lines(args.base)
+
+    files = []
+    total_covered = 0
+    total_eligible = 0
+    for path in sorted(diff):
+        added_lines = diff[path]
+        file_cov = coverage.get(path, {})
+        eligible = sorted(line for line in added_lines if line in file_cov)
+        if not eligible:
+            continue
+        covered = sum(1 for line in eligible if file_cov[line] > 0)
+        files.append({
+            "file": path,
+            "covered": covered,
+            "total": len(eligible),
+            "percent": covered / len(eligible) * 100,
+        })
+        total_covered += covered
+        total_eligible += len(eligible)
+
+    result = {
+        "total_covered": total_covered,
+        "total_eligible": total_eligible,
+        "percent": (total_covered / total_eligible * 100) if total_eligible else None,
+        "files": files,
+    }
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,63 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  # Detects which categories of files changed in the PR. Downstream jobs
+  # gate on these outputs to skip when irrelevant. Workflow or script
+  # changes flip every flag on - those touch CI itself, so re-run everything
+  # to validate the change doesn't break unrelated jobs.
+  detect:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      cargo: ${{ steps.filter.outputs.cargo }}
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          files=$(git diff --name-only "${BASE_SHA}"...HEAD)
+          echo "Changed files:"
+          printf '  %s\n' $files
+          echo
+
+          if printf '%s\n' "$files" | grep -qE '^\.github/(workflows/|scripts/)'; then
+            echo "Workflow / scripts change detected -> running all jobs"
+            {
+              echo "code=true"
+              echo "cargo=true"
+              echo "docker=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          code=false; cargo=false; docker=false
+          if printf '%s\n' "$files" | grep -qE '^(src/|tests/|build\.rs$|Cargo\.toml$|Cargo\.lock$)'; then
+            code=true
+          fi
+          if printf '%s\n' "$files" | grep -qE '^(Cargo\.toml$|Cargo\.lock$)'; then
+            cargo=true
+          fi
+          if printf '%s\n' "$files" | grep -qE '^(src/|Cargo\.toml$|Cargo\.lock$|Dockerfile$|\.dockerignore$)'; then
+            docker=true
+          fi
+          {
+            echo "code=$code"
+            echo "cargo=$cargo"
+            echo "docker=$docker"
+          } >> "$GITHUB_OUTPUT"
+
   # Enforces consistent code style across the project
   # Fails if any code isn't formatted with rustfmt
   fmt:
     name: Format
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +81,8 @@ jobs:
   # Acts as an additional layer of static analysis beyond the compiler
   clippy:
     name: Clippy
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +98,8 @@ jobs:
   # fail-fast: false ensures all platforms run even if one fails
   test:
     name: Test (${{ matrix.os }})
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -61,6 +118,8 @@ jobs:
   # Important for maintaining quality docs, especially for published crates
   docs:
     name: Docs
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: "-Dwarnings"
@@ -76,6 +135,8 @@ jobs:
   # Requires nightly because cargo-udeps uses unstable features
   unused-deps:
     name: Unused Dependencies
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -88,6 +149,8 @@ jobs:
   # Ensures reproducible builds and prevents "works on my machine" issues
   lockfile:
     name: Lockfile
+    needs: detect
+    if: needs.detect.outputs.cargo == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -98,6 +161,8 @@ jobs:
   # Output artifact feeds into the Coverage aggregator job.
   coverage-head:
     name: Coverage (head)
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,6 +197,8 @@ jobs:
   # the delta - it doesn't block the PR.
   coverage-base:
     name: Coverage (base)
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -150,10 +217,13 @@ jobs:
         run: |
           cargo llvm-cov --all-features --no-report
           cargo llvm-cov report --json --output-path base_coverage.json
+          cargo llvm-cov report --lcov --output-path base_coverage.lcov
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-base
-          path: base_coverage.json
+          path: |
+            base_coverage.json
+            base_coverage.lcov
           retention-days: 1
 
   # Aggregates head + base, computes patch coverage, posts the PR comment.
@@ -183,11 +253,11 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          python3 .github/scripts/patch_coverage.py \
-            --base "$BASE_SHA" \
-            --lcov coverage.lcov \
-            --workspace . \
-            > patch_coverage.json
+          args=(--base "$BASE_SHA" --lcov coverage.lcov --workspace .)
+          if [ -f base_coverage.lcov ]; then
+            args+=(--base-lcov base_coverage.lcov)
+          fi
+          python3 .github/scripts/patch_coverage.py "${args[@]}" > patch_coverage.json
           cat patch_coverage.json
       - name: Post coverage comment
         continue-on-error: true
@@ -231,12 +301,21 @@ jobs:
             echo ""
 
             # Per-file patch coverage, if the PR touched any covered .rs lines.
+            # Patch column = % of changed lines covered.
+            # File column = whole-file coverage on PR head.
+            # Δ column = whole-file delta vs base (blank for new files).
             if [ "$PATCH_TOTAL" -gt 0 ]; then
-              echo "| File | Patch Coverage | Covered / Changed |"
-              echo "|------|----------------|-------------------|"
+              echo "| File | Patch | File Coverage | Δ from main |"
+              echo "|------|-------|---------------|-------------|"
               jq -r "${PCT_DEF}"'
-                .files | sort_by(.percent) | .[]
-                | "| \(.file) | \(.percent | pct)% | \(.covered) / \(.total) |"
+                # Format a signed delta as +X.YY / -X.YY.
+                def signed: if . >= 0 then "+\(. | pct)" else "-\(-1 * . | pct)" end;
+                .files | sort_by(.percent) | .[] |
+                "| \(.file) | \(.percent | pct)% (\(.covered) / \(.total)) | " +
+                (if .file_percent_head == null then "—" else "\(.file_percent_head | pct)%" end) +
+                " | " +
+                (if .file_delta == null then (if .file_percent_head != null then "new" else "—" end) else "\(.file_delta | signed)%" end) +
+                " |"
               ' patch_coverage.json
               echo ""
             fi
@@ -318,6 +397,8 @@ jobs:
   # Release mode can surface different issues than debug mode (e.g., optimization bugs)
   build:
     name: Build (${{ matrix.os }})
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -336,6 +417,8 @@ jobs:
   # Catches known security vulnerabilities in your dependency tree
   security:
     name: Security Audit
+    needs: detect
+    if: needs.detect.outputs.cargo == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -350,6 +433,8 @@ jobs:
   # Catches build breakage before it hits the publish workflow on main
   docker:
     name: Docker Build
+    needs: detect
+    if: needs.detect.outputs.docker == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -362,10 +447,45 @@ jobs:
           cache-to: type=gha,mode=max
 
   # Catches spelling mistakes in code, comments, and documentation
-  # Small thing but helps maintain a professional codebase
+  # Small thing but helps maintain a professional codebase. Always runs
+  # since typos can land in any kind of file.
   typos:
     name: Typos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@master
+
+  # Single required check that gates merging. Skipped jobs (path-filtered
+  # out) count as success; only real failures or cancellations block.
+  # The branch ruleset should require this name and nothing else.
+  ci:
+    name: CI
+    if: always()
+    needs:
+      - detect
+      - fmt
+      - clippy
+      - test
+      - docs
+      - unused-deps
+      - lockfile
+      - coverage
+      - build
+      - security
+      - docker
+      - typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq .
+          if echo "$NEEDS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' > /dev/null; then
+            echo "All required jobs passed or were skipped."
+          else
+            echo "One or more required jobs failed or were cancelled." >&2
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,33 +94,102 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fetch --locked
 
-  # Measures what percentage of code is exercised by tests
-  # Posts coverage summary as PR comment
-  coverage:
-    name: Coverage
+  # PR head coverage. Runs in parallel with coverage-base.
+  # Output artifact feeds into the Coverage aggregator job.
+  coverage-head:
+    name: Coverage (head)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage-head
       - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate coverage
+      - name: Run coverage
         run: |
-          # Run tests with coverage, defer report generation
           cargo llvm-cov --all-features --no-report
           # Human-readable report for the Actions log
           cargo llvm-cov report
           # Structured data for parsing - cargo-llvm-cov's text format is
           # column-position-fragile and the test summary goes to stderr.
           cargo llvm-cov report --json --output-path coverage.json
+          # Per-line hit counts for patch coverage computation.
+          cargo llvm-cov report --lcov --output-path coverage.lcov
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-head
+          path: |
+            coverage.json
+            coverage.lcov
+          retention-days: 1
+
+  # Base-branch coverage for the delta. Runs in parallel with coverage-head
+  # on a separate runner. continue-on-error so a broken main only suppresses
+  # the delta - it doesn't block the PR.
+  coverage-base:
+    name: Coverage (base)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage-base
+      - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run coverage
+        run: |
+          cargo llvm-cov --all-features --no-report
+          cargo llvm-cov report --json --output-path base_coverage.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-base
+          path: base_coverage.json
+          retention-days: 1
+
+  # Aggregates head + base, computes patch coverage, posts the PR comment.
+  # This is the required check; it runs as long as head succeeded.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: [coverage-head, coverage-base]
+    if: always() && needs.coverage-head.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history for git diff against base in patch_coverage.py.
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-head
+      - name: Download base coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-base
+        continue-on-error: true
+      - name: Compute patch coverage
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python3 .github/scripts/patch_coverage.py \
+            --base "$BASE_SHA" \
+            --lcov coverage.lcov \
+            --workspace . \
+            > patch_coverage.json
+          cat patch_coverage.json
       - name: Post coverage comment
-        if: github.event_name == 'pull_request'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -133,17 +202,50 @@ jobs:
           # Strip absolute workspace prefix from filenames in JSON.
           WORKSPACE="$(pwd)/"
 
-          # Build the comment.
+          # Reusable jq function defining 2-decimal percent formatting.
+          PCT_DEF='def pct: (. * 100 | round) as $x | "\($x / 100 | floor).\($x % 100 | tostring | if length == 1 then "0\(.)" else . end)";'
+
+          # --- Build headline (line coverage % + delta + patch coverage) ---
+          HEAD_PCT=$(jq -r '.data[0].totals.lines.percent' coverage.json)
+          HEADLINE="**Line coverage:** $(printf '%.2f' "$HEAD_PCT")%"
+
+          if [ -f base_coverage.json ]; then
+            BASE_PCT=$(jq -r '.data[0].totals.lines.percent' base_coverage.json)
+            DELTA=$(awk "BEGIN { printf \"%+.2f\", ${HEAD_PCT} - ${BASE_PCT} }")
+            HEADLINE="${HEADLINE} (${DELTA}% from main)"
+          fi
+
+          PATCH_TOTAL=$(jq -r '.total_eligible' patch_coverage.json)
+          if [ "$PATCH_TOTAL" -gt 0 ]; then
+            PATCH_PCT=$(jq -r '.percent' patch_coverage.json)
+            PATCH_COVERED=$(jq -r '.total_covered' patch_coverage.json)
+            HEADLINE="${HEADLINE} · **Patch coverage:** $(printf '%.2f' "$PATCH_PCT")% (${PATCH_COVERED} / ${PATCH_TOTAL} changed lines)"
+          fi
+
+          # --- Build the comment ---
           {
             echo "$MARKER"
             echo "## Coverage Report"
             echo ""
+            echo "$HEADLINE"
+            echo ""
+
+            # Per-file patch coverage, if the PR touched any covered .rs lines.
+            if [ "$PATCH_TOTAL" -gt 0 ]; then
+              echo "| File | Patch Coverage | Covered / Changed |"
+              echo "|------|----------------|-------------------|"
+              jq -r "${PCT_DEF}"'
+                .files | sort_by(.percent) | .[]
+                | "| \(.file) | \(.percent | pct)% | \(.covered) / \(.total) |"
+              ' patch_coverage.json
+              echo ""
+            fi
+
+            echo "### Project totals"
+            echo ""
             echo "| Metric | Coverage | Covered / Total |"
             echo "|--------|----------|-----------------|"
-            jq -r '
-              # Format a percentage as XX.YY (always 2 decimals).
-              def pct: (. * 100 | round) as $x
-                | "\($x / 100 | floor).\($x % 100 | tostring | if length == 1 then "0\(.)" else . end)";
+            jq -r "${PCT_DEF}"'
               .data[0].totals as $t |
               [
                 ["Lines", $t.lines],
@@ -158,9 +260,7 @@ jobs:
             echo ""
 
             # Lowest-covered files (line coverage ascending), excluding 100%.
-            LOWEST=$(jq -r --arg ws "$WORKSPACE" '
-              def pct: (. * 100 | round) as $x
-                | "\($x / 100 | floor).\($x % 100 | tostring | if length == 1 then "0\(.)" else . end)";
+            LOWEST=$(jq -r --arg ws "$WORKSPACE" "${PCT_DEF}"'
               .data[0].files
               | map(select(.summary.lines.percent < 100))
               | sort_by(.summary.lines.percent)
@@ -170,7 +270,7 @@ jobs:
             ' coverage.json)
             if [ -n "$LOWEST" ]; then
               N=$(printf '%s\n' "$LOWEST" | wc -l)
-              echo "<details><summary>${N} lowest-covered files (line coverage)</summary>"
+              echo "<details><summary>${N} lowest-covered files (line coverage, project-wide)</summary>"
               echo ""
               echo "| File | Lines | Covered / Total |"
               echo "|------|-------|-----------------|"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: Rust CI
 on:
   pull_request:
 
+# Cancel an in-flight CI run when a new push lands on the same PR.
+# Only the latest commit matters; older runs would just burn minutes.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,25 +141,32 @@ jobs:
             echo "| Metric | Coverage | Covered / Total |"
             echo "|--------|----------|-----------------|"
             jq -r '
+              # Format a percentage as XX.YY (always 2 decimals).
+              def pct: (. * 100 | round) as $x
+                | "\($x / 100 | floor).\($x % 100 | tostring | if length == 1 then "0\(.)" else . end)";
               .data[0].totals as $t |
               [
                 ["Lines", $t.lines],
                 ["Functions", $t.functions],
                 ["Regions", $t.regions],
                 ["Branches", $t.branches]
-              ] | .[] |
-              "| \(.[0]) | \(.[1].percent | . * 100 | round / 100)% | \(.[1].covered) / \(.[1].count) |"
+              ]
+              | map(select(.[1].count > 0))
+              | .[]
+              | "| \(.[0]) | \(.[1].percent | pct)% | \(.[1].covered) / \(.[1].count) |"
             ' coverage.json
             echo ""
 
             # Lowest-covered files (line coverage ascending), excluding 100%.
             LOWEST=$(jq -r --arg ws "$WORKSPACE" '
+              def pct: (. * 100 | round) as $x
+                | "\($x / 100 | floor).\($x % 100 | tostring | if length == 1 then "0\(.)" else . end)";
               .data[0].files
               | map(select(.summary.lines.percent < 100))
               | sort_by(.summary.lines.percent)
               | .[:10]
               | .[]
-              | "| \(.filename | sub($ws; "")) | \(.summary.lines.percent | . * 100 | round / 100)% | \(.summary.lines.covered) / \(.summary.lines.count) |"
+              | "| \(.filename | sub($ws; "")) | \(.summary.lines.percent | pct)% | \(.summary.lines.covered) / \(.summary.lines.count) |"
             ' coverage.json)
             if [ -n "$LOWEST" ]; then
               N=$(printf '%s\n' "$LOWEST" | wc -l)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,52 +112,100 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
         run: |
-          cargo llvm-cov --all-features > coverage.txt
-          cat coverage.txt
+          # Run tests with coverage, defer report generation
+          cargo llvm-cov --all-features --no-report
+          # Human-readable report for the Actions log
+          cargo llvm-cov report
+          # Structured data for parsing - cargo-llvm-cov's text format is
+          # column-position-fragile and the test summary goes to stderr.
+          cargo llvm-cov report --json --output-path coverage.json
       - name: Post coverage comment
         if: github.event_name == 'pull_request'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          MARKER: "<!-- coverage-comment -->"
         run: |
-          # Disable strict mode for parsing: greps with no matches and head's
-          # SIGPIPE to upstream are expected and must not abort the script.
-          set +e +o pipefail
+          set -euo pipefail
 
-          # Line coverage % from the TOTAL summary row (column 10 in
-          # cargo-llvm-cov's table: regions/functions/lines/branches).
-          TOTAL=$(awk '/^TOTAL/ {print $10; exit}' coverage.txt)
+          # Strip absolute workspace prefix from filenames in JSON.
+          WORKSPACE="$(pwd)/"
 
-          # Sum "N passed" across every test binary's result line.
-          TESTS=$(awk '/^test result:/ {for (i=1; i<=NF; i++) if ($i == "passed;") s += $(i-1)} END {print s+0}' coverage.txt)
-
-          # Files with 0% and 100% coverage (excluding the TOTAL row).
-          ZERO_COV=$(awk '/0\.00%/ && !/^TOTAL/ {print $1; if (++n >= 5) exit}' coverage.txt | tr '\n' ', ' | sed 's/, $//')
-          FULL_COV=$(awk '/100\.00%/ && !/^TOTAL/ {print $1}' coverage.txt | tr '\n' ', ' | sed 's/, $//')
-
-          set -e -o pipefail
-
-          : "${TOTAL:=N/A}"
-          : "${TESTS:=0}"
-
+          # Build the comment.
           {
+            echo "$MARKER"
             echo "## Coverage Report"
             echo ""
-            echo "| Metric | Value |"
-            echo "|--------|-------|"
-            echo "| **Line Coverage** | ${TOTAL} |"
-            echo "| **Tests Passed** | ${TESTS} |"
+            echo "| Metric | Coverage | Covered / Total |"
+            echo "|--------|----------|-----------------|"
+            jq -r '
+              .data[0].totals as $t |
+              [
+                ["Lines", $t.lines],
+                ["Functions", $t.functions],
+                ["Regions", $t.regions],
+                ["Branches", $t.branches]
+              ] | .[] |
+              "| \(.[0]) | \(.[1].percent | . * 100 | round / 100)% | \(.[1].covered) / \(.[1].count) |"
+            ' coverage.json
             echo ""
-            if [ -n "$FULL_COV" ]; then
-              echo "**100% coverage:** \`${FULL_COV}\`"
+
+            # Lowest-covered files (line coverage ascending), excluding 100%.
+            LOWEST=$(jq -r --arg ws "$WORKSPACE" '
+              .data[0].files
+              | map(select(.summary.lines.percent < 100))
+              | sort_by(.summary.lines.percent)
+              | .[:10]
+              | .[]
+              | "| \(.filename | sub($ws; "")) | \(.summary.lines.percent | . * 100 | round / 100)% | \(.summary.lines.covered) / \(.summary.lines.count) |"
+            ' coverage.json)
+            if [ -n "$LOWEST" ]; then
+              N=$(printf '%s\n' "$LOWEST" | wc -l)
+              echo "<details><summary>${N} lowest-covered files (line coverage)</summary>"
+              echo ""
+              echo "| File | Lines | Covered / Total |"
+              echo "|------|-------|-----------------|"
+              printf '%s\n' "$LOWEST"
+              echo ""
+              echo "</details>"
               echo ""
             fi
-            if [ -n "$ZERO_COV" ]; then
-              echo "**Needs tests:** \`${ZERO_COV}\`"
+
+            # Files at 100% line coverage.
+            FULL=$(jq -r --arg ws "$WORKSPACE" '
+              .data[0].files
+              | map(select(.summary.lines.percent == 100))
+              | sort_by(.filename)
+              | .[]
+              | "- \(.filename | sub($ws; ""))"
+            ' coverage.json)
+            if [ -n "$FULL" ]; then
+              N=$(printf '%s\n' "$FULL" | wc -l)
+              echo "<details><summary>${N} files at 100% line coverage</summary>"
+              echo ""
+              printf '%s\n' "$FULL"
+              echo ""
+              echo "</details>"
             fi
           } > comment.md
 
-          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md || echo "Failed to post comment"
+          # Mirror to the Actions step summary so the report is visible in the run UI.
+          cat comment.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Sticky comment: edit the existing one if our marker is present,
+          # otherwise post a new one. Avoids spamming the PR on each push.
+          EXISTING=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+            | head -n 1)
+
+          if [ -n "$EXISTING" ]; then
+            jq -Rs '{body: .}' < comment.md \
+              | gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" --input -
+          else
+            gh pr comment "$PR_NUMBER" --body-file comment.md
+          fi
 
   # Compiles release builds on all platforms to catch platform-specific compile errors
   # Release mode can surface different issues than debug mode (e.g., optimization bugs)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Rust CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Treat any compiler warning as an error to keep the codebase warning-free
@@ -117,13 +120,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Extract stats from coverage output
-          TOTAL=$(grep "^TOTAL" coverage.txt | awk '{print $10}')
-          TESTS=$(grep -E "^test result:" coverage.txt | grep -oE "[0-9]+ passed" | grep -oE "[0-9]+")
+          # Disable strict mode for parsing: greps with no matches and head's
+          # SIGPIPE to upstream are expected and must not abort the script.
+          set +e +o pipefail
 
-          # Find files with 0% and 100% coverage
-          ZERO_COV=$(grep "0.00%" coverage.txt | grep -v "^TOTAL" | awk '{print $1}' | head -5 | tr '\n' ', ' | sed 's/,$//')
-          FULL_COV=$(grep "100.00%" coverage.txt | awk '{print $1}' | tr '\n' ', ' | sed 's/,$//')
+          # Line coverage % from the TOTAL summary row (column 10 in
+          # cargo-llvm-cov's table: regions/functions/lines/branches).
+          TOTAL=$(awk '/^TOTAL/ {print $10; exit}' coverage.txt)
+
+          # Sum "N passed" across every test binary's result line.
+          TESTS=$(awk '/^test result:/ {for (i=1; i<=NF; i++) if ($i == "passed;") s += $(i-1)} END {print s+0}' coverage.txt)
+
+          # Files with 0% and 100% coverage (excluding the TOTAL row).
+          ZERO_COV=$(awk '/0\.00%/ && !/^TOTAL/ {print $1; if (++n >= 5) exit}' coverage.txt | tr '\n' ', ' | sed 's/, $//')
+          FULL_COV=$(awk '/100\.00%/ && !/^TOTAL/ {print $1}' coverage.txt | tr '\n' ', ' | sed 's/, $//')
+
+          set -e -o pipefail
+
+          : "${TOTAL:=N/A}"
+          : "${TESTS:=0}"
 
           {
             echo "## Coverage Report"


### PR DESCRIPTION
## Summary

Two related changes to ci.yml.

**1. Top-level workflow permissions** — adds `permissions: contents: read` so any future job inherits read-only by default. The coverage job's per-job `pull-requests: write` override is unchanged.

**2. Coverage comment overhaul.** The previous version was both broken and ugly. The shell ran with `bash -eo pipefail` and the parsing pipeline aborted before `gh pr comment` could run, masked by `continue-on-error: true`. Even when it did run, the text output was a wall of comma-separated paths with no spaces, a trailing comma, and `Tests Passed: 0` (the test summary lines come on stderr, so `> coverage.txt` never captured them).

Rewritten to use cargo-llvm-cov's JSON output, parsed with `jq`:

### New comment format

- Header table with all four metrics (Lines / Functions / Regions / Branches), each showing percent and covered/total counts
- Collapsible **10 lowest-covered files** section sorted ascending by line coverage - actionable signal, not just 0%/100% buckets
- Collapsible **files at 100% line coverage** section, sorted, one file per line
- Same markdown also mirrored to `$GITHUB_STEP_SUMMARY` so the report shows in the Actions run UI

### Sticky updates

Comments carry an HTML marker. On subsequent pushes the existing comment is edited via PATCH instead of a new one being appended, so the PR no longer accumulates stale coverage comments.

## Test plan

- [ ] CI on this PR is green and Coverage stays green
- [ ] A coverage comment appears with the new table format
- [ ] Push a follow-up commit and confirm the existing comment is edited in place (no duplicate appears)
- [ ] Confirm the Actions run page shows the same report under "Summary"