### PR TITLE
Detect FIDO/WebAuthn security keys at signin (fixes #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Apple IDs with FIDO/WebAuthn security keys fail fast with a clear error.** Accounts with a YubiKey or other hardware security key registered could sign in through SRP + 2FA, then hit an opaque CloudKit `HTTP 401 AUTHENTICATION_FAILED "no auth method found"` on the first API call and loop through re-auth until `AUTH_ERROR_THRESHOLD` stopped the sync. SRP now inspects the `/signin/complete` 409 body for `fsaChallenge` / `keyNames` and bails with `AuthError::FidoNotSupported { key_names }` before prompting for a 2FA code. The message names the registered keys and points to Settings > Apple ID & iCloud > Sign-In & Security > Security Keys. As a defense-in-depth, `HttpStatusError` now preserves a truncated copy of the CloudKit error body, and a 401 carrying "no auth method found" logs a WARN with the security-key hint and a link to the tracking issue. ([#221])
+
+[#221]: https://github.com/rhoopr/kei/issues/221
+
+---
+
 ## [0.9.0] - 2026-04-18
 
 ### Added

--- a/src/auth/error.rs
+++ b/src/auth/error.rs
@@ -1,5 +1,16 @@
 use thiserror::Error;
 
+/// Format an optional list of security-key names for display.
+/// Returns " (YubiKey 5C, Passkey-1)" when names are known, or an empty
+/// string when Apple did not disclose them.
+fn format_fido_keys(keys: &[String]) -> String {
+    if keys.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", keys.join(", "))
+    }
+}
+
 /// Custom error types for iCloud authentication.
 #[derive(Debug, Error)]
 pub enum AuthError {
@@ -20,6 +31,20 @@ pub enum AuthError {
 
     #[error("Two-factor authentication is required (no code provided)")]
     TwoFactorRequired,
+
+    /// The Apple ID has FIDO/WebAuthn hardware security keys registered.
+    /// Apple signals this via `fsaChallenge` / `keyNames` in the 2FA
+    /// challenge body. CloudKit rejects sessions minted through this path
+    /// with "no auth method found", so kei bails early rather than let the
+    /// user hit that downstream failure and loop through re-auth.
+    #[error(
+        "This Apple ID has FIDO/WebAuthn hardware security keys registered{}. \
+         kei does not yet support this authentication method (see issue #221).\n\n\
+         To use kei with this account, remove the security keys at:\n  \
+         Settings > Apple ID & iCloud > Sign-In & Security > Security Keys",
+        format_fido_keys(key_names)
+    )]
+    FidoNotSupported { key_names: Vec<String> },
 
     #[error("Session lock held by another instance: {0}")]
     LockContention(String),
@@ -387,6 +412,61 @@ mod tests {
         };
         assert!(err_503.is_transient_apple_failure());
         assert!(!err_503.is_misdirected_request());
+    }
+
+    #[test]
+    fn fido_not_supported_display_with_key_names() {
+        let err = AuthError::FidoNotSupported {
+            key_names: vec!["YubiKey 5C".into(), "Passkey-Home".into()],
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("YubiKey 5C"),
+            "display should name the registered key, got: {msg}"
+        );
+        assert!(
+            msg.contains("Passkey-Home"),
+            "display should list all keys, got: {msg}"
+        );
+        assert!(
+            msg.contains("#221"),
+            "display should reference the tracking issue, got: {msg}"
+        );
+        assert!(
+            msg.contains("Sign-In & Security"),
+            "display should point to the settings path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn fido_not_supported_display_without_key_names() {
+        // Apple's response may omit keyNames (empty array) while still
+        // signaling FIDO via fsaChallenge. The message must still render
+        // cleanly without a trailing empty parenthesis.
+        let err = AuthError::FidoNotSupported { key_names: vec![] };
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("()"),
+            "empty key list should not render empty parens, got: {msg}"
+        );
+        assert!(
+            msg.contains("security keys registered"),
+            "base message must still be present, got: {msg}"
+        );
+        assert!(msg.contains("#221"), "issue link required, got: {msg}");
+    }
+
+    #[test]
+    fn fido_not_supported_is_not_transient() {
+        // FIDO detection is a terminal error: no amount of retry will help
+        // until the user removes the keys from their account.
+        let err = AuthError::FidoNotSupported {
+            key_names: vec!["YubiKey".into()],
+        };
+        assert!(!err.is_transient_apple_failure());
+        assert!(!err.is_misdirected_request());
+        assert!(!err.is_two_factor_required());
+        assert!(!err.is_lock_contention());
     }
 
     #[test]

--- a/src/auth/responses.rs
+++ b/src/auth/responses.rs
@@ -31,6 +31,37 @@ pub struct SrpInitResponse {
     pub protocol: String,
 }
 
+/// Subset of Apple's `/signin/complete` 409 body used to detect FIDO/WebAuthn
+/// security-key requirements. When `fsa_challenge` is present or `key_names`
+/// is non-empty, the account requires a security-key tap that kei can't
+/// perform headless. Sessions minted through this flow get rejected by
+/// CloudKit with "no auth method found" (issue #221), so we bail early.
+///
+/// Other 2FA-challenge fields (`trustedDevices`, `trustedPhoneNumbers`,
+/// `securityCode`) are ignored here — they're handled further down the
+/// existing 2FA prompt path.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TwoFactorChallenge {
+    /// Present iff Apple is asking for a FIDO/WebAuthn assertion.
+    /// The object's internals (challenge, keyHandles, rpId) are not
+    /// inspected — presence alone is the signal.
+    #[serde(default)]
+    pub fsa_challenge: Option<Value>,
+    /// Human-readable names of registered security keys, e.g.
+    /// `["YubiKey 5C"]`. Surfaced verbatim so the user can identify
+    /// which keys to remove.
+    #[serde(default)]
+    pub key_names: Vec<String>,
+}
+
+impl TwoFactorChallenge {
+    /// True if Apple's 2FA challenge includes a FIDO/WebAuthn assertion.
+    pub(crate) fn requires_fido(&self) -> bool {
+        self.fsa_challenge.is_some() || !self.key_names.is_empty()
+    }
+}
+
 /// An error entry from Apple's `service_errors` array.
 /// Apple auth APIs sometimes return HTTP 200 with error details in the body
 /// instead of using HTTP status codes.
@@ -123,6 +154,65 @@ pub(crate) struct WebserviceEndpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn two_factor_challenge_detects_fsa_challenge() {
+        let json = r#"{
+            "trustedDevices": [],
+            "authType": "hsa2",
+            "fsaChallenge": {
+                "challenge": "abc123",
+                "keyHandles": ["handle-1"],
+                "rpId": "apple.com"
+            },
+            "keyNames": ["YubiKey 5C"]
+        }"#;
+        let parsed: TwoFactorChallenge = serde_json::from_str(json).unwrap();
+        assert!(parsed.requires_fido());
+        assert_eq!(parsed.key_names, vec!["YubiKey 5C".to_string()]);
+    }
+
+    #[test]
+    fn two_factor_challenge_detects_key_names_without_fsa_challenge() {
+        // Defensive: Apple could send keyNames without fsaChallenge in some
+        // flow we haven't seen; still treat as FIDO.
+        let json = r#"{"keyNames": ["YubiKey 5C", "Passkey-Home"]}"#;
+        let parsed: TwoFactorChallenge = serde_json::from_str(json).unwrap();
+        assert!(parsed.requires_fido());
+        assert_eq!(parsed.key_names.len(), 2);
+    }
+
+    #[test]
+    fn two_factor_challenge_ignores_device_only_2fa() {
+        // A normal HSA2 challenge (no security keys) must NOT match.
+        let json = r#"{
+            "trustedDevices": [{"id": "d1"}],
+            "trustedPhoneNumbers": [{"id": 1, "numberWithDialCode": "+1 •••-•••-1234"}],
+            "authType": "hsa2",
+            "securityCode": {"length": 6}
+        }"#;
+        let parsed: TwoFactorChallenge = serde_json::from_str(json).unwrap();
+        assert!(!parsed.requires_fido());
+        assert!(parsed.key_names.is_empty());
+    }
+
+    #[test]
+    fn two_factor_challenge_defaults_on_missing_fields() {
+        // Minimal body must deserialize cleanly and report no FIDO.
+        let parsed: TwoFactorChallenge = serde_json::from_str("{}").unwrap();
+        assert!(!parsed.requires_fido());
+    }
+
+    #[test]
+    fn two_factor_challenge_handles_empty_body_via_default() {
+        // The SRP handler calls `.unwrap_or_default()` when the 409 body
+        // isn't valid JSON. The default must report no FIDO so a transient
+        // parse miss doesn't incorrectly bail a legitimate device-push
+        // 2FA flow.
+        let parsed = TwoFactorChallenge::default();
+        assert!(!parsed.requires_fido());
+        assert!(parsed.key_names.is_empty());
+    }
 
     #[test]
     fn test_srp_init_response_deserialize() {

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -1214,4 +1214,204 @@ mod tests {
         .await
         .unwrap();
     }
+
+    // ────────────────────────────────────────────────────────────────
+    // wiremock-based tests: exercise the FIDO detection path through a
+    // real HTTP client and SRP math, not the StubSrpTransport. Guards
+    // against regressions where the 409 body parsing works in isolation
+    // but the reqwest buffering, status-code branch, or JSON decode
+    // path drops the signal before `authenticate_srp` sees it.
+    // ────────────────────────────────────────────────────────────────
+
+    use crate::auth::session::Session;
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn wm_session(server: &MockServer) -> (TempDir, Session) {
+        let dir = tempfile::tempdir().unwrap();
+        let session = Session::new(dir.path(), "test@example.com", &server.uri(), Some(5))
+            .await
+            .unwrap();
+        (dir, session)
+    }
+
+    /// Minimal SRP init body that produces tractable math in tests:
+    /// `B = 2`, `iteration = 1`. Apple's real responses have iteration
+    /// counts in the tens of thousands; 1 is fine because the point of
+    /// this test isn't to exercise PBKDF2, it's to drive the request
+    /// through the HTTP layer to the 409 branch.
+    fn wm_srp_init_body() -> String {
+        serde_json::json!({
+            "salt": BASE64.encode(b"salt1234"),
+            "b": BASE64.encode([2u8]),
+            "c": "challenge-token",
+            "iteration": 1,
+            "protocol": "s2k"
+        })
+        .to_string()
+    }
+
+    /// End-to-end: real SRP handshake against a wiremock server that
+    /// returns 409 with an `fsaChallenge`. The test proves the FIDO
+    /// signal survives the full HTTP round-trip (reqwest buffering,
+    /// status check, JSON parse) and surfaces as the typed
+    /// `FidoNotSupported` error with the key names Apple disclosed.
+    #[tokio::test]
+    async fn srp_wiremock_fsa_challenge_returns_fido_not_supported() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/init"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(wm_srp_init_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/complete"))
+            .respond_with(ResponseTemplate::new(409).set_body_string(
+                r#"{
+                    "fsaChallenge": {"challenge": "abc", "keyHandles": ["h1"], "rpId": "apple.com"},
+                    "keyNames": ["YubiKey 5C", "Passkey-Home"],
+                    "authType": "hsa2",
+                    "trustedDevices": []
+                }"#,
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = wm_session(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let err = authenticate_srp(
+            &mut session,
+            &endpoints,
+            "test@example.com",
+            "hunter2",
+            "client-id",
+            "com",
+        )
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().expect("typed AuthError");
+        match auth_err {
+            AuthError::FidoNotSupported { key_names } => {
+                assert_eq!(
+                    key_names,
+                    &vec!["YubiKey 5C".to_string(), "Passkey-Home".to_string()],
+                    "key_names must round-trip verbatim so the error message can name the keys"
+                );
+            }
+            other => panic!("expected FidoNotSupported, got: {other:?}"),
+        }
+    }
+
+    /// End-to-end control: an ordinary device-push 2FA 409 (no security
+    /// keys) must NOT trigger FIDO detection. `authenticate_srp` returns
+    /// `Ok(())` so the caller can prompt for the code. Guards against a
+    /// future refactor that over-broadens the detection check.
+    #[tokio::test]
+    async fn srp_wiremock_ordinary_2fa_passes_through() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/init"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(wm_srp_init_body()))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/complete"))
+            .respond_with(ResponseTemplate::new(409).set_body_string(
+                r#"{
+                    "trustedDevices": [{"id": "d1"}],
+                    "trustedPhoneNumbers": [{"id": 1, "numberWithDialCode": "+1 •••-•••-1234"}],
+                    "authType": "hsa2",
+                    "securityCode": {"length": 6}
+                }"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = wm_session(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        authenticate_srp(
+            &mut session,
+            &endpoints,
+            "test@example.com",
+            "hunter2",
+            "client-id",
+            "com",
+        )
+        .await
+        .expect("ordinary 2FA 409 must not be mis-classified as FIDO");
+    }
+
+    /// A 409 with `keyNames` but no `fsaChallenge` must still bail as
+    /// FIDO. Defensive against Apple flow variants we haven't directly
+    /// observed.
+    #[tokio::test]
+    async fn srp_wiremock_key_names_only_returns_fido_not_supported() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/init"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(wm_srp_init_body()))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/complete"))
+            .respond_with(
+                ResponseTemplate::new(409)
+                    .set_body_string(r#"{"keyNames": ["Solo V2"], "authType": "hsa2"}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = wm_session(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        let err = authenticate_srp(
+            &mut session,
+            &endpoints,
+            "test@example.com",
+            "hunter2",
+            "client-id",
+            "com",
+        )
+        .await
+        .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().expect("typed AuthError");
+        assert!(
+            matches!(auth_err, AuthError::FidoNotSupported { .. }),
+            "keyNames alone must still trigger FIDO bail, got: {auth_err:?}"
+        );
+    }
+
+    /// A 409 with a malformed body must fall through to the normal 2FA
+    /// path (returning `Ok(())`), not spuriously bail as FIDO. Guards
+    /// against a future parser change that would treat a parse error as
+    /// "FIDO present".
+    #[tokio::test]
+    async fn srp_wiremock_unparseable_409_falls_through_to_2fa() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/init"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(wm_srp_init_body()))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(wm_path("/appleauth/auth/signin/complete"))
+            .respond_with(ResponseTemplate::new(409).set_body_string("<html>oops</html>"))
+            .mount(&server)
+            .await;
+
+        let (_dir, mut session) = wm_session(&server).await;
+        let endpoints = Endpoints::for_test_base(&server.uri());
+        authenticate_srp(
+            &mut session,
+            &endpoints,
+            "test@example.com",
+            "hunter2",
+            "client-id",
+            "com",
+        )
+        .await
+        .expect("unparseable 409 must fall through to the 2FA path, not bail as FIDO");
+    }
 }

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -494,6 +494,23 @@ pub async fn authenticate_srp(
     }
 
     if response.status == 409 {
+        // The 409 body carries the 2FA challenge metadata. When the account
+        // has FIDO/WebAuthn security keys registered, Apple includes an
+        // `fsaChallenge` object (and usually a `keyNames` array). CloudKit
+        // rejects sessions minted through this flow with "no auth method
+        // found" (issue #221), so bail before prompting for a 2FA code the
+        // user can't complete headless.
+        let challenge: super::responses::TwoFactorChallenge = response.json().unwrap_or_default();
+        if challenge.requires_fido() {
+            tracing::debug!(
+                key_count = challenge.key_names.len(),
+                "SRP complete returned 409 with FIDO/WebAuthn challenge; unsupported"
+            );
+            return Err(AuthError::FidoNotSupported {
+                key_names: challenge.key_names,
+            }
+            .into());
+        }
         tracing::debug!("SRP complete returned 409: two-factor authentication required");
         return Ok(());
     } else if response.status == 412 {
@@ -973,6 +990,76 @@ mod tests {
         run_srp(vec![valid_init_response(), response(409, vec![])])
             .await
             .unwrap();
+    }
+
+    /// 409 with an `fsaChallenge` field means the account has a FIDO/WebAuthn
+    /// security key registered. kei can't complete that challenge, so the
+    /// caller must see a typed `FidoNotSupported` error rather than
+    /// proceeding to prompt for a 2FA code (which would hang or fail
+    /// silently downstream at the CloudKit handshake).
+    #[tokio::test]
+    async fn srp_complete_409_with_fsa_challenge_returns_fido_not_supported() {
+        let body = br#"{
+            "fsaChallenge": {"challenge": "abc", "keyHandles": ["h1"], "rpId": "apple.com"},
+            "keyNames": ["YubiKey 5C"],
+            "authType": "hsa2"
+        }"#;
+        let err = run_srp(vec![valid_init_response(), response(409, body.to_vec())])
+            .await
+            .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        match auth_err {
+            AuthError::FidoNotSupported { key_names } => {
+                assert_eq!(key_names, &vec!["YubiKey 5C".to_string()]);
+            }
+            other => panic!("expected FidoNotSupported, got: {other:?}"),
+        }
+    }
+
+    /// Defensive: Apple could send `keyNames` without `fsaChallenge` in a
+    /// flow we haven't observed. Treat the presence of any named security
+    /// keys as a FIDO signal.
+    #[tokio::test]
+    async fn srp_complete_409_with_only_key_names_returns_fido_not_supported() {
+        let body = br#"{"keyNames": ["Passkey-Home"]}"#;
+        let err = run_srp(vec![valid_init_response(), response(409, body.to_vec())])
+            .await
+            .unwrap_err();
+        let auth_err = err.downcast_ref::<AuthError>().unwrap();
+        assert!(
+            matches!(auth_err, AuthError::FidoNotSupported { .. }),
+            "expected FidoNotSupported, got: {auth_err:?}"
+        );
+    }
+
+    /// A normal HSA2 challenge (push to trusted device, SMS to trusted
+    /// phone) must continue through the existing 2FA flow — the FIDO
+    /// detection must not false-positive on the usual 409 shape.
+    #[tokio::test]
+    async fn srp_complete_409_without_fido_fields_passes_through() {
+        let body = br#"{
+            "trustedDevices": [{"id": "d1"}],
+            "trustedPhoneNumbers": [{"id": 1}],
+            "authType": "hsa2",
+            "securityCode": {"length": 6}
+        }"#;
+        run_srp(vec![valid_init_response(), response(409, body.to_vec())])
+            .await
+            .unwrap();
+    }
+
+    /// If Apple returns a 409 with an unparsable body (rare but possible on
+    /// upstream errors or protocol drift), the default-derived
+    /// `TwoFactorChallenge` reports no FIDO, and SRP falls through to the
+    /// normal 2FA path rather than incorrectly bailing.
+    #[tokio::test]
+    async fn srp_complete_409_with_unparsable_body_falls_through_to_2fa() {
+        run_srp(vec![
+            valid_init_response(),
+            response(409, b"not json".to_vec()),
+        ])
+        .await
+        .unwrap();
     }
 
     #[tokio::test]

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -1388,7 +1388,7 @@ mod tests {
     /// against a future parser change that would treat a parse error as
     /// "FIDO present".
     #[tokio::test]
-    async fn srp_wiremock_unparseable_409_falls_through_to_2fa() {
+    async fn srp_wiremock_unparsable_409_falls_through_to_2fa() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(wm_path("/appleauth/auth/signin/init"))
@@ -1412,6 +1412,6 @@ mod tests {
             "com",
         )
         .await
-        .expect("unparseable 409 must fall through to the 2FA path, not bail as FIDO");
+        .expect("unparsable 409 must fall through to the 2FA path, not bail as FIDO");
     }
 }

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -618,6 +618,75 @@ mod tests {
         );
     }
 
+    /// When the 401 body contains "no auth method found", the mapping must
+    /// emit a WARN naming security keys as the likely cause and pointing
+    /// at issue #221. This is the defense-in-depth hint that fires if a
+    /// future Apple flow change bypasses the SRP-level FIDO detection.
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn http_401_no_auth_method_found_logs_security_key_hint() {
+        let _err = PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(NoAuthMethodFoundSession),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            logs_contain("no auth method found"),
+            "WARN must quote the CloudKit signal so reporters can grep for it"
+        );
+        assert!(
+            logs_contain("FIDO/WebAuthn security keys"),
+            "WARN must name FIDO/WebAuthn as the likely cause"
+        );
+        assert!(
+            logs_contain("#221"),
+            "WARN must link to the tracking issue so the user can find context"
+        );
+        assert!(
+            logs_contain("Sign-In & Security"),
+            "WARN must include the settings path to remove the keys"
+        );
+    }
+
+    /// A plain 401 without the "no auth method found" signal must NOT
+    /// emit the FIDO hint — that would confuse users whose session is
+    /// stale for ordinary reasons (expired trust token, rotated cookies).
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn http_401_without_fido_body_does_not_log_security_key_hint() {
+        let _err = PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(Unauthorized401Session),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            !logs_contain("FIDO/WebAuthn security keys"),
+            "ordinary stale-session 401 must not trigger the FIDO hint"
+        );
+        assert!(
+            !logs_contain("Sign-In & Security"),
+            "only 'no auth method found' bodies should produce the settings hint"
+        );
+    }
+
     /// Stub that returns HTTP 421, the signature of a misdirected CloudKit
     /// connection that survived the `init_photos_service` pool-reset retry.
     struct Misdirected421Session;

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -109,6 +109,28 @@ impl PhotoLibrary {
                 // persistent ADP, AUTH_ERROR_THRESHOLD in the download
                 // pipeline stops the sync rather than spamming retries.
                 if http_err.status == 401 || http_err.status == 403 {
+                    // Defense-in-depth for FIDO/security-key accounts: the
+                    // SRP path detects `fsaChallenge` / `keyNames` up front
+                    // and bails with `AuthError::FidoNotSupported`, but if
+                    // Apple drops those fields in some future flow, the
+                    // failure mode is a CloudKit 401 with "no auth method
+                    // found" in the body. Log the hint so a reporter sees
+                    // it even when kei falls into the re-auth loop. See
+                    // issue #221.
+                    if http_err.status == 401 {
+                        if let Some(body) = http_err.body.as_deref() {
+                            if body.contains("no auth method found") {
+                                tracing::warn!(
+                                    url = %http_err.url,
+                                    body = %body,
+                                    "CloudKit 401 'no auth method found' — usually means \
+                                     FIDO/WebAuthn security keys are on the account (issue \
+                                     #221). Remove them at Settings > Apple ID & iCloud > \
+                                     Sign-In & Security > Security Keys."
+                                );
+                            }
+                        }
+                    }
                     return ICloudError::SessionExpired {
                         status: http_err.status,
                     };
@@ -398,6 +420,7 @@ mod tests {
                 status: 403,
                 url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
                 retry_after: None,
+                body: None,
             }.into())
         }
 
@@ -504,6 +527,7 @@ mod tests {
                 status: 401,
                 url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
                 retry_after: None,
+                body: None,
             }.into())
         }
 
@@ -535,6 +559,65 @@ mod tests {
         );
     }
 
+    /// Stub that returns HTTP 401 with a CloudKit "no auth method found" body.
+    /// This is the FIDO-account failure mode from issue #221 when the SRP-side
+    /// up-front detection has been bypassed (e.g. Apple drops the
+    /// `fsaChallenge` field in a future flow).
+    struct NoAuthMethodFoundSession;
+
+    #[async_trait::async_trait]
+    impl PhotosSession for NoAuthMethodFoundSession {
+        async fn post(
+            &self,
+            _url: &str,
+            _body: String,
+            _headers: &[(&str, &str)],
+        ) -> anyhow::Result<Value> {
+            Err(crate::icloud::photos::session::HttpStatusError {
+                status: 401,
+                url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
+                retry_after: None,
+                body: Some(
+                    r#"{"serverErrorCode":"AUTHENTICATION_FAILED","reason":"no auth method found"}"#
+                        .into(),
+                ),
+            }.into())
+        }
+
+        fn clone_box(&self) -> Box<dyn PhotosSession> {
+            Box::new(NoAuthMethodFoundSession)
+        }
+    }
+
+    /// Even when the CloudKit 401 body identifies a FIDO-class failure, the
+    /// mapping still routes to `SessionExpired` so the existing `sync_loop`
+    /// re-auth path runs (capped by `AUTH_ERROR_THRESHOLD`). The up-front
+    /// detection in `auth/srp.rs` is the primary fix; this test pins the
+    /// belt-and-suspenders behavior so a future refactor doesn't silently
+    /// stop producing the warning or change the retry contract.
+    #[tokio::test]
+    async fn http_401_no_auth_method_found_still_maps_to_session_expired() {
+        let err = PhotoLibrary::new(
+            "https://example.com".into(),
+            Arc::new(HashMap::new()),
+            Box::new(NoAuthMethodFoundSession),
+            Arc::new(json!({"zoneName": "PrimarySync"})),
+            "private".into(),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ICloudError::SessionExpired { status: 401 }),
+            "FIDO-class 401 bodies must still route to SessionExpired so \
+             AUTH_ERROR_THRESHOLD in sync_loop bounds the re-auth loop, got: {err:?}"
+        );
+    }
+
     /// Stub that returns HTTP 421, the signature of a misdirected CloudKit
     /// connection that survived the `init_photos_service` pool-reset retry.
     struct Misdirected421Session;
@@ -551,6 +634,7 @@ mod tests {
                 status: 421,
                 url: "https://p60-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/query".into(),
                 retry_after: None,
+                body: None,
             }.into())
         }
 

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -67,10 +67,16 @@ impl PhotosSession for reqwest::Client {
                     );
                 }
             }
+            let preserved = if resp_body.is_empty() {
+                None
+            } else {
+                Some(truncate_body(&resp_body))
+            };
             return Err(HttpStatusError {
                 status: status.as_u16(),
                 url,
                 retry_after,
+                body: preserved,
             }
             .into());
         }
@@ -110,12 +116,38 @@ impl PhotosSession for crate::auth::SharedSession {
 /// `retry_after` is populated from the `Retry-After` response header when
 /// present, so callers can honor the server-provided delay on 429/503
 /// instead of falling back to exponential backoff alone.
+///
+/// `body` carries a truncated copy of the response body so downstream
+/// error mapping (e.g. detecting "no auth method found" in a CloudKit 401
+/// that typically indicates FIDO/security keys on the account) can read
+/// the payload without re-requesting. Truncated to keep memory bounded
+/// when CloudKit occasionally returns large HTML error pages.
 #[derive(Debug, thiserror::Error)]
 #[error("HTTP {status} for {url}")]
 pub(crate) struct HttpStatusError {
     pub status: u16,
     pub url: String,
     pub retry_after: Option<Duration>,
+    pub body: Option<String>,
+}
+
+/// Maximum number of bytes preserved from an HTTP error body. Apple's
+/// CloudKit error JSON is typically a few hundred bytes; HTML error pages
+/// and stack traces are occasionally much larger. Cap it so a degenerate
+/// response can't bloat the error path.
+const MAX_PRESERVED_BODY: usize = 1024;
+
+/// Shorten `body` to at most `MAX_PRESERVED_BODY` bytes without splitting
+/// a multi-byte UTF-8 character.
+fn truncate_body(body: &str) -> String {
+    if body.len() <= MAX_PRESERVED_BODY {
+        return body.to_string();
+    }
+    let mut end = MAX_PRESERVED_BODY;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &body[..end])
 }
 
 /// `CloudKit` server error codes that indicate a transient condition.
@@ -862,6 +894,7 @@ mod tests {
             status: 503,
             url: "https://example.com".to_string(),
             retry_after: None,
+            body: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Retry));
     }
@@ -872,6 +905,7 @@ mod tests {
             status: 429,
             url: "https://example.com".to_string(),
             retry_after: None,
+            body: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Retry));
     }
@@ -882,6 +916,7 @@ mod tests {
             status: 429,
             url: "https://example.com".to_string(),
             retry_after: Some(Duration::from_secs(7)),
+            body: None,
         });
         match classify_api_error(&err) {
             RetryAction::RetryAfter(d) => assert_eq!(d, Duration::from_secs(7)),
@@ -895,6 +930,7 @@ mod tests {
             status: 503,
             url: "https://example.com".to_string(),
             retry_after: Some(Duration::from_secs(2)),
+            body: None,
         });
         match classify_api_error(&err) {
             RetryAction::RetryAfter(d) => assert_eq!(d, Duration::from_secs(2)),
@@ -908,6 +944,7 @@ mod tests {
             status: 401,
             url: "https://example.com".to_string(),
             retry_after: None,
+            body: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Abort));
     }
@@ -918,7 +955,41 @@ mod tests {
             status: 403,
             url: "https://example.com".to_string(),
             retry_after: None,
+            body: None,
         });
         assert!(matches!(classify_api_error(&err), RetryAction::Abort));
+    }
+
+    #[test]
+    fn truncate_body_leaves_short_bodies_unchanged() {
+        let body = r#"{"serverErrorCode":"AUTHENTICATION_FAILED","reason":"no auth method found"}"#;
+        assert_eq!(truncate_body(body), body);
+    }
+
+    #[test]
+    fn truncate_body_clips_oversized_bodies() {
+        let body = "x".repeat(MAX_PRESERVED_BODY * 2);
+        let out = truncate_body(&body);
+        assert!(
+            out.len() <= MAX_PRESERVED_BODY + 4,
+            "truncated body must stay under the cap plus the marker, got len {}",
+            out.len()
+        );
+        assert!(
+            out.ends_with('…'),
+            "truncation marker must be appended to signal the clip"
+        );
+    }
+
+    #[test]
+    fn truncate_body_respects_utf8_boundaries() {
+        // Multi-byte chars must not be split — pad with a 3-byte char so
+        // the naive byte-slice would land in the middle.
+        let mut body = "a".repeat(MAX_PRESERVED_BODY - 1);
+        body.push('€'); // 3 bytes: 0xE2 0x82 0xAC
+        body.push_str(&"b".repeat(MAX_PRESERVED_BODY));
+        let out = truncate_body(&body);
+        // Must be valid UTF-8 (the format! call would panic otherwise).
+        assert!(out.is_char_boundary(out.len() - '…'.len_utf8()));
     }
 }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -992,4 +992,143 @@ mod tests {
         // Must be valid UTF-8 (the format! call would panic otherwise).
         assert!(out.is_char_boundary(out.len() - '…'.len_utf8()));
     }
+
+    // ────────────────────────────────────────────────────────────────
+    // wiremock-based tests: exercise the real reqwest path through
+    // `PhotosSession::post` to prove that CloudKit error bodies
+    // actually end up on `HttpStatusError.body`. The unit-level tests
+    // above only cover `truncate_body`; these tests close the loop
+    // between "server returned a body" and "caller can read it".
+    // ────────────────────────────────────────────────────────────────
+
+    use wiremock::matchers::method as wm_method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The FIDO failure mode from issue #221: CloudKit returns 401 with
+    /// `"no auth method found"` in the JSON body. A real reqwest client
+    /// posting to a wiremock endpoint must surface that body on the
+    /// resulting `HttpStatusError` so the library.rs mapping can log
+    /// the security-key hint.
+    #[tokio::test]
+    async fn wiremock_401_preserves_body_in_http_status_error() {
+        let server = MockServer::start().await;
+        let body = r#"{"serverErrorCode":"AUTHENTICATION_FAILED","reason":"no auth method found"}"#;
+        Mock::given(wm_method("POST"))
+            .respond_with(ResponseTemplate::new(401).set_body_string(body))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let err = PhotosSession::post(
+            &client,
+            &format!("{}/records/query", server.uri()),
+            "{}".to_string(),
+            &[],
+        )
+        .await
+        .expect_err("401 must propagate as an error");
+        let http_err = err
+            .downcast_ref::<HttpStatusError>()
+            .expect("expected HttpStatusError");
+        assert_eq!(http_err.status, 401);
+        let preserved = http_err
+            .body
+            .as_deref()
+            .expect("401 body must be preserved for downstream FIDO/auth diagnostics");
+        assert!(
+            preserved.contains("no auth method found"),
+            "preserved body must include the FIDO-indicating signal, got: {preserved}"
+        );
+    }
+
+    /// A 503 body (transient error) is preserved too, so the retry
+    /// path's warnings can include server-provided detail. Guards
+    /// against a refactor that accidentally scopes body preservation
+    /// to 401 only.
+    #[tokio::test]
+    async fn wiremock_5xx_preserves_body_in_http_status_error() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("service unavailable"))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let err = PhotosSession::post(
+            &client,
+            &format!("{}/records/query", server.uri()),
+            "{}".to_string(),
+            &[],
+        )
+        .await
+        .expect_err("503 must propagate as an error");
+        let http_err = err.downcast_ref::<HttpStatusError>().unwrap();
+        assert_eq!(http_err.status, 503);
+        assert_eq!(http_err.body.as_deref(), Some("service unavailable"));
+    }
+
+    /// An empty error body yields `body: None`, not `Some("")`. Guards
+    /// the downstream check `http_err.body.as_deref()` from having to
+    /// special-case "" vs absent.
+    #[tokio::test]
+    async fn wiremock_empty_body_stays_none() {
+        let server = MockServer::start().await;
+        Mock::given(wm_method("POST"))
+            .respond_with(ResponseTemplate::new(403)) // no body
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let err = PhotosSession::post(
+            &client,
+            &format!("{}/records/query", server.uri()),
+            "{}".to_string(),
+            &[],
+        )
+        .await
+        .expect_err("403 must propagate");
+        let http_err = err.downcast_ref::<HttpStatusError>().unwrap();
+        assert_eq!(http_err.status, 403);
+        assert!(
+            http_err.body.is_none(),
+            "empty response body must be None, not Some(\"\"), got: {:?}",
+            http_err.body
+        );
+    }
+
+    /// An oversized body is truncated with the `…` marker so a
+    /// pathological CloudKit response (HTML error page, stack trace)
+    /// can't blow up the error path.
+    #[tokio::test]
+    async fn wiremock_oversized_body_is_truncated() {
+        let server = MockServer::start().await;
+        let huge = "x".repeat(MAX_PRESERVED_BODY * 3);
+        Mock::given(wm_method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_string(huge))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let err = PhotosSession::post(
+            &client,
+            &format!("{}/records/query", server.uri()),
+            "{}".to_string(),
+            &[],
+        )
+        .await
+        .expect_err("500 must propagate");
+        let http_err = err.downcast_ref::<HttpStatusError>().unwrap();
+        let preserved = http_err.body.as_deref().unwrap();
+        assert!(
+            preserved.ends_with('…'),
+            "oversized body must be clipped with the truncation marker, got (len {}): {}",
+            preserved.len(),
+            preserved
+        );
+        assert!(
+            preserved.len() <= MAX_PRESERVED_BODY + '…'.len_utf8(),
+            "truncated body must stay under the cap plus the marker, got len {}",
+            preserved.len()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Apple IDs with hardware security keys (YubiKey, passkey) completed SRP + 2FA but then got rejected by CloudKit with `HTTP 401 AUTHENTICATION_FAILED "no auth method found"` and looped through re-auth until `AUTH_ERROR_THRESHOLD` stopped the sync.
- SRP now inspects the `/signin/complete` 409 body for `fsaChallenge` / `keyNames` and bails with a typed `AuthError::FidoNotSupported { key_names }` before prompting for a 2FA code the user can't complete headless. The error names the registered keys and points to the settings path to remove them.
- Defense-in-depth: `HttpStatusError` preserves a truncated copy of the CloudKit error body, and a 401 with "no auth method found" now logs a WARN naming security keys as the likely cause so future flow changes still surface the right diagnostic.

## How it works

Apple's `/signin/complete` returns 409 with the 2FA challenge metadata. When security keys are on the account, the body adds an `fsaChallenge` object and (usually) a `keyNames` array. `authType` stays `"hsa2"`, so existing checks don't distinguish this case. The new `TwoFactorChallenge` struct in `auth/responses.rs` captures those two fields; `srp.rs` checks `requires_fido()` on the parsed body and returns `AuthError::FidoNotSupported` with the key names verbatim. An unparsable body falls through to the existing 2FA path, so a transient parse miss doesn't incorrectly bail legitimate device-push flows.

The CloudKit-side fallback is narrow: `icloud/photos/session.rs` preserves up to 1 KiB of the error body in `HttpStatusError`, and `icloud/photos/library.rs` logs the security-key hint when a 401 carries "no auth method found". The 401 still routes to `SessionExpired` (the existing re-auth contract), so `AUTH_ERROR_THRESHOLD` continues to bound the loop when some other flow change bypasses the up-front detection.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bin kei` (1285 passed)
- [x] `cargo test --test cli` (95 passed)
- [x] `cargo test --test behavioral` (103 passed)
- [x] `cargo doc --no-deps --all-features`
- [x] New unit coverage: `TwoFactorChallenge` parsing (5 cases, including `fsaChallenge`, `keyNames` alone, device-only 2FA, empty body, default), SRP 409 FIDO branch (4 cases), `AuthError::FidoNotSupported` Display with/without key names + non-transient classification, `truncate_body` bounds + UTF-8 boundary, library.rs 401-with-FIDO-body routing

## Notes

- `AUTHENTICATION_FAILED` was already in `SERVICE_NOT_ACTIVATED_ERRORS`, but only for CloudKit JSON bodies (HTTP 200 + error code). The FIDO failure arrives as a bare HTTP 401, which went through `HttpStatusError -> SessionExpired` and missed that branch.
- icloudpd upstream (#583) doesn't detect this either. The fsaChallenge signal is confirmed by pyicloud, icloud3, and iCloud-Drive-Downloader.
- No new dependencies.