### PR TITLE
docs: align clippy command with CI (--all-targets --all-features)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@
 ## Checklist
 
 - [ ] `cargo fmt -- --check` passes
-- [ ] `cargo clippy -- -D warnings` passes
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
 - [ ] `cargo test --bin kei --test cli --test behavioral` passes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Contributions are welcome. For anything beyond a small fix, open an issue first 
 3. Run the checks:
    ```sh
    cargo fmt -- --check
-   cargo clippy -- -D warnings
+   cargo clippy --all-targets --all-features -- -D warnings
    cargo test --bin kei --test cli --test behavioral
    ```
 4. Open a pull request against `main`.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ State lives in a SQLite database alongside your session data (see `--data-dir`).
 Contributions welcome. Open an issue first if you're planning something big.
 
 ```sh
-cargo fmt -- --check && cargo clippy && cargo test
+cargo fmt -- --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test
 ```
 
 ## License

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@
 ```sh
 # 1. Pre-commit (runs automatically on git commit)
 cargo fmt -- --check
-cargo clippy -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test --bin kei --test cli --test behavioral
 
 # 2. One-time auth setup (interactive, prompts for 2FA)


### PR DESCRIPTION
## Summary

- README, CONTRIBUTING, tests/README, and the PR template all showed weaker clippy commands than CI runs. Contributors could pass the documented command locally and still get flagged by CI.
- Unify on the exact CI behavior: `cargo clippy --all-targets --all-features -- -D warnings`.

## Before

| File | Command |
|---|---|
| `README.md` | `cargo clippy` |
| `CONTRIBUTING.md` | `cargo clippy -- -D warnings` |
| `tests/README.md` | `cargo clippy -- -D warnings` |
| `.github/pull_request_template.md` | `cargo clippy -- -D warnings` |
| CI (`ci.yml`) | `cargo clippy --all-targets --all-features` (with `RUSTFLAGS=-Dwarnings`) |

Without `--all-targets`, clippy skips test code. Without `--all-features`, it skips feature-gated code. Both matter in this repo — we have a growing wiremock test surface.

## After

All docs show `cargo clippy --all-targets --all-features -- -D warnings`, which produces the same outcome as the CI command + `RUSTFLAGS`.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` runs clean on this branch