### PR TITLE
Fix ghost asset loop on filter and album-scope changes (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Ghost asset loop on filter / album-scope changes.** Assets the DB knew about but the current sync didn't re-enumerate (filter excluded, album scope changed, upstream record deleted) were promoted to `failed` at sync end. `prepare_for_retry` then reset them to `pending` on the next sync, and the cycle repeated. `kei status --failed` filled with `Not resolved during sync` entries that weren't failures. `promote_pending_to_failed` now promotes only pending assets the producer dispatched this sync (`last_seen_at >= sync_started_at`) that the consumer never finalized. Filtered or out-of-scope assets keep their stale `last_seen_at` and are left alone. ([#211])
+
+### Added
+
+- **`kei status --pending` and `--downloaded`.** Parallel to the existing `--failed` flag, these list assets in the requested state with filename, ID, and last-seen time (pending) or local path (downloaded). ([#211])
+
+[#211]: https://github.com/rhoopr/kei/issues/211
+
+---
+
 ## [0.9.1] - 2026-04-18
 
 ### Fixed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1895,6 +1895,45 @@ mod tests {
         let cli = Cli::try_parse_from(["kei", "status", "--failed"]).unwrap();
         if let Some(Command::Status(args)) = cli.command {
             assert!(args.failed);
+            assert!(!args.pending);
+            assert!(!args.downloaded);
+        } else {
+            panic!("Expected Status command");
+        }
+    }
+
+    #[test]
+    fn test_status_with_pending_flag() {
+        let cli = Cli::try_parse_from(["kei", "status", "--pending"]).unwrap();
+        if let Some(Command::Status(args)) = cli.command {
+            assert!(!args.failed);
+            assert!(args.pending);
+            assert!(!args.downloaded);
+        } else {
+            panic!("Expected Status command");
+        }
+    }
+
+    #[test]
+    fn test_status_with_downloaded_flag() {
+        let cli = Cli::try_parse_from(["kei", "status", "--downloaded"]).unwrap();
+        if let Some(Command::Status(args)) = cli.command {
+            assert!(!args.failed);
+            assert!(!args.pending);
+            assert!(args.downloaded);
+        } else {
+            panic!("Expected Status command");
+        }
+    }
+
+    #[test]
+    fn test_status_flags_combine() {
+        let cli = Cli::try_parse_from(["kei", "status", "--failed", "--pending", "--downloaded"])
+            .unwrap();
+        if let Some(Command::Status(args)) = cli.command {
+            assert!(args.failed);
+            assert!(args.pending);
+            assert!(args.downloaded);
         } else {
             panic!("Expected Status command");
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -238,6 +238,16 @@ pub struct StatusArgs {
     /// Show failed assets with error messages
     #[arg(long)]
     pub failed: bool,
+
+    /// Show pending assets (known to the DB, not yet finalized this sync).
+    /// Includes assets the current sync scope excludes via filters or album
+    /// selection.
+    #[arg(long)]
+    pub pending: bool,
+
+    /// Show downloaded assets
+    #[arg(long)]
+    pub downloaded: bool,
 }
 
 /// Arguments for the import-existing command.

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,7 +1,7 @@
 use crate::cli;
 use crate::config;
 use crate::state;
-use crate::state::StateDb;
+use crate::state::{AssetRecord, StateDb};
 
 /// Run the status command.
 pub(crate) async fn run_status(
@@ -47,17 +47,64 @@ pub(crate) async fn run_status(
         println!("Failed assets:");
         let failed = db.get_failed().await?;
         for asset in failed {
-            let last_seen = asset.last_seen_at.format("%Y-%m-%d %H:%M:%S");
-            println!(
-                "  {} ({}) - {} (attempts: {}, last seen: {})",
-                asset.filename,
-                asset.id,
-                asset.last_error.as_deref().unwrap_or("unknown error"),
-                asset.download_attempts,
-                last_seen
-            );
+            print_failed(&asset);
+        }
+    }
+
+    if args.pending && summary.pending > 0 {
+        println!();
+        println!("Pending assets:");
+        let pending = db.get_pending().await?;
+        for asset in pending {
+            print_pending(&asset);
+        }
+    }
+
+    if args.downloaded && summary.downloaded > 0 {
+        println!();
+        println!("Downloaded assets:");
+        let page_size: u32 = 500;
+        let mut offset: u64 = 0;
+        loop {
+            let page = db.get_downloaded_page(offset, page_size).await?;
+            if page.is_empty() {
+                break;
+            }
+            for asset in &page {
+                print_downloaded(asset);
+            }
+            offset += page.len() as u64;
         }
     }
 
     Ok(())
+}
+
+fn print_failed(asset: &AssetRecord) {
+    let last_seen = asset.last_seen_at.format("%Y-%m-%d %H:%M:%S");
+    println!(
+        "  {} ({}) - {} (attempts: {}, last seen: {})",
+        asset.filename,
+        asset.id,
+        asset.last_error.as_deref().unwrap_or("unknown error"),
+        asset.download_attempts,
+        last_seen
+    );
+}
+
+fn print_pending(asset: &AssetRecord) {
+    let last_seen = asset.last_seen_at.format("%Y-%m-%d %H:%M:%S");
+    println!(
+        "  {} ({}) - attempts: {}, last seen: {}",
+        asset.filename, asset.id, asset.download_attempts, last_seen
+    );
+}
+
+fn print_downloaded(asset: &AssetRecord) {
+    let local = asset
+        .local_path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<no path>".into());
+    println!("  {} ({}) -> {}", asset.filename, asset.id, local);
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -101,10 +101,13 @@ fn print_pending(asset: &AssetRecord) {
 }
 
 fn print_downloaded(asset: &AssetRecord) {
-    let local = asset
-        .local_path
-        .as_ref()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| "<no path>".into());
+    // status='downloaded' rows are written with local_path by mark_downloaded,
+    // so a missing path here means a state-DB invariant violation (manual
+    // edit, partial migration, upsert after mark_downloaded without path).
+    // Surface it clearly rather than hiding it.
+    let local = asset.local_path.as_ref().map_or_else(
+        || "<MISSING local_path>".to_string(),
+        |p| p.display().to_string(),
+    );
     println!("  {} ({}) -> {}", asset.filename, asset.id, local);
 }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -2343,18 +2343,24 @@ mod tests {
     async fn ghost_loop_regression_filtered_pending_asset_survives_sync() {
         use crate::download::DownloadConfig;
         use crate::icloud::photos::PhotoAsset;
-        use crate::state::{AssetStatus, MediaType, SqliteStateDb, StateDb};
+        use crate::state::{MediaType, SqliteStateDb, StateDb};
         use chrono::TimeZone;
         use futures_util::stream;
         use std::sync::Arc;
 
-        // File-backed DB so we can reach in with a raw rusqlite connection
-        // to backdate last_seen_at without exposing `acquire_lock`.
-        let tmp = TempDir::new().unwrap();
-        let db_path = tmp.path().join("state.db");
-        let db = Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+        fn ghost_asset() -> PhotoAsset {
+            TestPhotoAsset::new("GHOST")
+                .filename("ghost.mov")
+                .item_type("com.apple.quicktime-movie")
+                .orig_file_type("com.apple.quicktime-movie")
+                .orig_size(4096)
+                .orig_url("http://127.0.0.1:1/ghost.mov")
+                .orig_checksum("ck_ghost")
+                .build()
+        }
 
-        // ── Prior sync: pending video row, backdated last_seen_at ───────
+        let db = Arc::new(SqliteStateDb::open_in_memory().unwrap());
+
         let prior_seen_at = chrono::Utc::now().timestamp() - 86400;
         let record = AssetRecord::new_pending(
             "GHOST".into(),
@@ -2367,17 +2373,8 @@ mod tests {
             MediaType::Video,
         );
         db.upsert_seen(&record).await.unwrap();
-        {
-            // Backdate to simulate a sync that happened yesterday.
-            let raw = rusqlite::Connection::open(&db_path).unwrap();
-            raw.execute(
-                "UPDATE assets SET last_seen_at = ?1 WHERE id = 'GHOST'",
-                rusqlite::params![prior_seen_at],
-            )
-            .unwrap();
-        }
+        db.backdate_last_seen("GHOST", prior_seen_at);
 
-        // ── Current sync: --skip-videos excludes the asset ──────────────
         let dir = TempDir::new().unwrap();
         let mut config = DownloadConfig::test_default();
         config.directory = dir.path().to_path_buf();
@@ -2385,59 +2382,29 @@ mod tests {
         config.state_db = Some(db.clone());
         let config = Arc::new(config);
 
-        // Stream yields the same video asset the producer filtered last time.
-        let asset = TestPhotoAsset::new("GHOST")
-            .filename("ghost.mov")
-            .item_type("com.apple.quicktime-movie")
-            .orig_file_type("com.apple.quicktime-movie")
-            .orig_size(4096)
-            .orig_url("http://127.0.0.1:1/ghost.mov")
-            .orig_checksum("ck_ghost")
-            .build();
-        let asset_stream = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]);
-
         let client = reqwest::Client::new();
-        let shutdown_token = CancellationToken::new();
         let sync_started_at = chrono::Utc::now().timestamp();
-
-        stream_and_download_from_stream(&client, asset_stream, &config, 1, shutdown_token)
+        let stream1 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(ghost_asset())]);
+        stream_and_download_from_stream(&client, stream1, &config, 1, CancellationToken::new())
             .await
             .expect("sync must complete");
 
-        // The producer must not have touched last_seen_at. The row is still
-        // pending, last_seen_at still stamped at the prior sync.
         let pending = db.get_pending().await.unwrap();
         assert_eq!(pending.len(), 1, "asset must remain the only pending row");
         assert_eq!(pending[0].id, "GHOST");
-        assert_eq!(
-            pending[0].status,
-            AssetStatus::Pending,
-            "status must remain pending"
-        );
         assert_eq!(
             pending[0].last_seen_at.timestamp(),
             prior_seen_at,
             "producer must NOT bump last_seen_at on a filtered asset"
         );
 
-        // And promote_pending_to_failed at sync end leaves it alone.
         let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
         assert_eq!(promoted, 0, "filtered asset must not be promoted");
 
-        // Second sync cycle with the same filter: state stays stable
-        // (locks in "no ghost loop across repeated syncs").
-        let asset2 = TestPhotoAsset::new("GHOST")
-            .filename("ghost.mov")
-            .item_type("com.apple.quicktime-movie")
-            .orig_file_type("com.apple.quicktime-movie")
-            .orig_size(4096)
-            .orig_url("http://127.0.0.1:1/ghost.mov")
-            .orig_checksum("ck_ghost")
-            .build();
-        let stream2 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset2)]);
-        let shutdown_token2 = CancellationToken::new();
+        // Second cycle locks in stability across repeated syncs.
         let sync_2_start = chrono::Utc::now().timestamp();
-        stream_and_download_from_stream(&client, stream2, &config, 1, shutdown_token2)
+        let stream2 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(ghost_asset())]);
+        stream_and_download_from_stream(&client, stream2, &config, 1, CancellationToken::new())
             .await
             .expect("second sync must complete");
         let promoted2 = db.promote_pending_to_failed(sync_2_start).await.unwrap();

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -2333,4 +2333,118 @@ mod tests {
             "Expected producer panic error, got: {err}"
         );
     }
+
+    /// End-to-end regression for issue #211. A pending row carried over from
+    /// a prior sync, combined with a filter that excludes the asset in the
+    /// current sync, must not have its `last_seen_at` bumped by the producer.
+    /// Combined with the flipped `promote_pending_to_failed` gate, this
+    /// guarantees the ghost loop (pending -> failed -> pending) can't recur.
+    #[tokio::test]
+    async fn ghost_loop_regression_filtered_pending_asset_survives_sync() {
+        use crate::download::DownloadConfig;
+        use crate::icloud::photos::PhotoAsset;
+        use crate::state::{AssetStatus, MediaType, SqliteStateDb, StateDb};
+        use chrono::TimeZone;
+        use futures_util::stream;
+        use std::sync::Arc;
+
+        // File-backed DB so we can reach in with a raw rusqlite connection
+        // to backdate last_seen_at without exposing `acquire_lock`.
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("state.db");
+        let db = Arc::new(SqliteStateDb::open(&db_path).await.unwrap());
+
+        // ── Prior sync: pending video row, backdated last_seen_at ───────
+        let prior_seen_at = chrono::Utc::now().timestamp() - 86400;
+        let record = AssetRecord::new_pending(
+            "GHOST".into(),
+            VersionSizeKey::Original,
+            "ck_ghost".into(),
+            "ghost.mov".into(),
+            chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            None,
+            4096,
+            MediaType::Video,
+        );
+        db.upsert_seen(&record).await.unwrap();
+        {
+            // Backdate to simulate a sync that happened yesterday.
+            let raw = rusqlite::Connection::open(&db_path).unwrap();
+            raw.execute(
+                "UPDATE assets SET last_seen_at = ?1 WHERE id = 'GHOST'",
+                rusqlite::params![prior_seen_at],
+            )
+            .unwrap();
+        }
+
+        // ── Current sync: --skip-videos excludes the asset ──────────────
+        let dir = TempDir::new().unwrap();
+        let mut config = DownloadConfig::test_default();
+        config.directory = dir.path().to_path_buf();
+        config.skip_videos = true;
+        config.state_db = Some(db.clone());
+        let config = Arc::new(config);
+
+        // Stream yields the same video asset the producer filtered last time.
+        let asset = TestPhotoAsset::new("GHOST")
+            .filename("ghost.mov")
+            .item_type("com.apple.quicktime-movie")
+            .orig_file_type("com.apple.quicktime-movie")
+            .orig_size(4096)
+            .orig_url("http://127.0.0.1:1/ghost.mov")
+            .orig_checksum("ck_ghost")
+            .build();
+        let asset_stream = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset)]);
+
+        let client = reqwest::Client::new();
+        let shutdown_token = CancellationToken::new();
+        let sync_started_at = chrono::Utc::now().timestamp();
+
+        stream_and_download_from_stream(&client, asset_stream, &config, 1, shutdown_token)
+            .await
+            .expect("sync must complete");
+
+        // The producer must not have touched last_seen_at. The row is still
+        // pending, last_seen_at still stamped at the prior sync.
+        let pending = db.get_pending().await.unwrap();
+        assert_eq!(pending.len(), 1, "asset must remain the only pending row");
+        assert_eq!(pending[0].id, "GHOST");
+        assert_eq!(
+            pending[0].status,
+            AssetStatus::Pending,
+            "status must remain pending"
+        );
+        assert_eq!(
+            pending[0].last_seen_at.timestamp(),
+            prior_seen_at,
+            "producer must NOT bump last_seen_at on a filtered asset"
+        );
+
+        // And promote_pending_to_failed at sync end leaves it alone.
+        let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
+        assert_eq!(promoted, 0, "filtered asset must not be promoted");
+
+        // Second sync cycle with the same filter: state stays stable
+        // (locks in "no ghost loop across repeated syncs").
+        let asset2 = TestPhotoAsset::new("GHOST")
+            .filename("ghost.mov")
+            .item_type("com.apple.quicktime-movie")
+            .orig_file_type("com.apple.quicktime-movie")
+            .orig_size(4096)
+            .orig_url("http://127.0.0.1:1/ghost.mov")
+            .orig_checksum("ck_ghost")
+            .build();
+        let stream2 = stream::iter(vec![Ok::<PhotoAsset, anyhow::Error>(asset2)]);
+        let shutdown_token2 = CancellationToken::new();
+        let sync_2_start = chrono::Utc::now().timestamp();
+        stream_and_download_from_stream(&client, stream2, &config, 1, shutdown_token2)
+            .await
+            .expect("second sync must complete");
+        let promoted2 = db.promote_pending_to_failed(sync_2_start).await.unwrap();
+        assert_eq!(promoted2, 0, "second sync must also leave row untouched");
+
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.failed, 0);
+    }
 }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -566,9 +566,15 @@ where
                     let tasks =
                         filter_asset_to_tasks(&asset, config, &mut claimed_paths, &mut dir_cache);
                     if tasks.is_empty() {
-                        // Asset was enumerated but produced no tasks (files on
-                        // disk or dedup'd). Update last_seen_at so
-                        // promote_pending_to_failed knows this asset was seen.
+                        // Asset enumerated but produced no tasks (on-disk
+                        // dedup, claimed-path collision, etc). Rows reached
+                        // here are almost always status='downloaded', where
+                        // touching last_seen_at is a no-op for the promote
+                        // gate. A row left status='pending' by a prior
+                        // interrupted sync will be promoted to failed at
+                        // sync end (see upsert_seen / touch_last_seen /
+                        // promote_pending_to_failed docs and issue #211) -
+                        // that's the intended stuck-pipeline recovery.
                         if let Some(db) = &producer_state_db {
                             if let Err(e) = db.touch_last_seen(asset.id()).await {
                                 tracing::debug!(error = %e, asset_id = asset.id(), "Failed to touch last_seen for on-disk asset");

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -1979,6 +1979,9 @@ mod tests {
         async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
             unimplemented!()
         }
+        async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+            unimplemented!()
+        }
         async fn get_summary(&self) -> Result<SyncSummary, StateError> {
             unimplemented!()
         }

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -566,15 +566,10 @@ where
                     let tasks =
                         filter_asset_to_tasks(&asset, config, &mut claimed_paths, &mut dir_cache);
                     if tasks.is_empty() {
-                        // Asset enumerated but produced no tasks (on-disk
-                        // dedup, claimed-path collision, etc). Rows reached
-                        // here are almost always status='downloaded', where
-                        // touching last_seen_at is a no-op for the promote
-                        // gate. A row left status='pending' by a prior
+                        // No-op for status='downloaded' rows (the common
+                        // case). A row left status='pending' by a prior
                         // interrupted sync will be promoted to failed at
-                        // sync end (see upsert_seen / touch_last_seen /
-                        // promote_pending_to_failed docs and issue #211) -
-                        // that's the intended stuck-pipeline recovery.
+                        // sync end as stuck-pipeline recovery.
                         if let Some(db) = &producer_state_db {
                             if let Err(e) = db.touch_last_seen(asset.id()).await {
                                 tracing::debug!(error = %e, asset_id = asset.id(), "Failed to touch last_seen for on-disk asset");

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -40,9 +40,21 @@ pub trait StateDb: Send + Sync {
         local_path: &Path,
     ) -> Result<bool, StateError>;
 
-    /// Insert or update an asset record after seeing it during sync.
+    /// Insert or update an asset record after the producer commits it for
+    /// download.
     ///
     /// Updates `last_seen_at` and preserves existing download status.
+    ///
+    /// **Invariant (see issue #211):** Call only from the producer dispatch
+    /// path, after an asset has passed every filter and skip check and a
+    /// download task has been created. `promote_pending_to_failed` treats
+    /// `last_seen_at >= sync_started_at` as "the producer handed this off to
+    /// the consumer this sync", so any call that bumps `last_seen_at` without
+    /// a matching consumer finalization (`mark_downloaded` / `mark_failed`)
+    /// will cause the asset to be promoted to `failed`. If you need to touch
+    /// `last_seen_at` for an asset the consumer will not finalize (trust-state
+    /// fast-skip, on-disk dedup, filtered-out, etc.), use `touch_last_seen`
+    /// on rows that already have a terminal status, not `upsert_seen`.
     async fn upsert_seen(&self, record: &AssetRecord) -> Result<(), StateError>;
 
     /// Mark an asset as successfully downloaded.
@@ -65,6 +77,9 @@ pub trait StateDb: Send + Sync {
 
     /// Get all failed assets.
     async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError>;
+
+    /// Get all pending assets.
+    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError>;
 
     /// Get a summary of the database state.
     async fn get_summary(&self) -> Result<SyncSummary, StateError>;
@@ -97,11 +112,19 @@ pub trait StateDb: Send + Sync {
     /// (failed_reset, pending_reset, total_pending).
     async fn prepare_for_retry(&self) -> Result<(u64, u64, u64), StateError>;
 
-    /// Promote stale pending assets to failed.
+    /// Promote stuck pending assets to failed.
     ///
-    /// Called at the end of a non-interrupted sync run. Only promotes pending
-    /// assets whose `last_seen_at` is before `seen_since` - assets seen
-    /// during this sync (including on-disk skips) are left alone.
+    /// Called at the end of a non-interrupted sync run. Promotes pending
+    /// assets that the producer dispatched this sync (`last_seen_at >=
+    /// seen_since`) but that the consumer never finalized via
+    /// `mark_downloaded` or `mark_failed`. These are stuck-pipeline cases,
+    /// not filter or album-scope exclusions.
+    ///
+    /// Assets whose `last_seen_at` predates this sync (filtered out, album
+    /// scope changed, remotely deleted, or otherwise not re-enumerated) are
+    /// left alone - they are not failures, and promoting them causes the
+    /// pending -> failed -> pending ghost loop documented in issue #211.
+    ///
     /// Returns the number of assets promoted.
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError>;
 
@@ -143,6 +166,12 @@ pub trait StateDb: Send + Sync {
 
     /// Update `last_seen_at` for all versions of an asset without requiring
     /// full metadata. Used by the early skip path to avoid path resolution.
+    ///
+    /// Safe to call for assets the consumer will not finalize (trust-state
+    /// fast-skip, on-disk dedup, etc.) only when the row already has a
+    /// terminal status (`downloaded` or `failed`). Touching a `pending` row
+    /// will cause `promote_pending_to_failed` to promote it to `failed` at
+    /// sync end - see `upsert_seen` docs and issue #211.
     async fn touch_last_seen(&self, asset_id: &str) -> Result<(), StateError>;
 
     /// Sample up to `limit` local paths of downloaded assets.
@@ -427,6 +456,24 @@ impl StateDb for SqliteStateDb {
         Ok(records)
     }
 
+    async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
+        let conn = self.acquire_lock("get_pending")?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, downloaded_at, local_path, last_seen_at, download_attempts, last_error, local_checksum FROM assets WHERE status = 'pending' ORDER BY last_seen_at DESC",
+            )
+            .map_err(|e| StateError::query("get_pending", e))?;
+
+        let records = stmt
+            .query_map([], row_to_asset_record)
+            .map_err(|e| StateError::query("get_pending", e))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| StateError::query("get_pending", e))?;
+
+        Ok(records)
+    }
+
     async fn get_summary(&self) -> Result<SyncSummary, StateError> {
         let conn = self.acquire_lock("get_summary")?;
 
@@ -582,10 +629,14 @@ impl StateDb for SqliteStateDb {
     async fn promote_pending_to_failed(&self, seen_since: i64) -> Result<u64, StateError> {
         let conn = self.acquire_lock("promote_pending_to_failed")?;
 
+        // Only promote assets the producer dispatched this sync (last_seen_at
+        // was bumped by upsert_seen at or after sync_started_at) that never
+        // reached mark_downloaded or mark_failed. See the trait doc comment
+        // and issue #211 for the rationale.
         let promoted =
             conn.execute(
                 "UPDATE assets SET status = 'failed', last_error = 'Not resolved during sync' \
-                 WHERE status = 'pending' AND (last_seen_at IS NULL OR last_seen_at < ?1)",
+                 WHERE status = 'pending' AND last_seen_at >= ?1",
                 rusqlite::params![seen_since],
             )
             .map_err(|e| StateError::query("promote_pending_to_failed", e))? as u64;
@@ -1877,7 +1928,7 @@ mod tests {
             .await
             .unwrap();
 
-        // 2 pending (should be promoted to failed)
+        // 2 pending dispatched this sync (should be promoted to failed)
         for i in 0..2 {
             let id = format!("APending{i}");
             let record = TestAssetRecord::new(&id)
@@ -1904,9 +1955,11 @@ mod tests {
         assert_eq!(before.pending, 2);
         assert_eq!(before.failed, 1);
 
-        // Use a future timestamp so all pending assets are considered stale
-        let future = chrono::Utc::now().timestamp() + 3600;
-        let promoted = db.promote_pending_to_failed(future).await.unwrap();
+        // Gate is `last_seen_at >= seen_since`. Use a timestamp in the past
+        // so every pending asset seen in this test counts as "dispatched
+        // this sync" and gets promoted.
+        let past = chrono::Utc::now().timestamp() - 3600;
+        let promoted = db.promote_pending_to_failed(past).await.unwrap();
         assert_eq!(promoted, 2);
 
         let after = db.get_summary().await.unwrap();
@@ -2096,21 +2149,23 @@ mod tests {
         );
     }
 
-    // ── Gap: promote_pending_to_failed boundary -- seen assets preserved ──
+    // Promote: only the asset the producer touched this sync is a candidate.
+    // Anything with a stale last_seen_at is filtered / out of scope and must
+    // stay pending. See issue #211.
 
     #[tokio::test]
-    async fn promote_pending_to_failed_preserves_recently_seen() {
+    async fn promote_pending_to_failed_skips_stale_last_seen() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        // Insert an "old" asset with last_seen_at far in the past
+        // OLD_ASSET: upserted before this sync (last_seen_at 1 hour ago).
+        // Stands in for filtered-out / out-of-scope / remotely deleted assets
+        // whose last_seen_at didn't get refreshed this sync.
         let old_record = TestAssetRecord::new("OLD_ASSET")
             .checksum("ck_old")
             .filename("old.jpg")
             .size(1000)
             .build();
         db.upsert_seen(&old_record).await.unwrap();
-
-        // Manually backdate OLD_ASSET's last_seen_at to 1 hour ago
         {
             let conn = db.acquire_lock("test_setup").unwrap();
             let old_ts = chrono::Utc::now().timestamp() - 3600;
@@ -2121,7 +2176,9 @@ mod tests {
             .unwrap();
         }
 
-        // Insert a "new" asset -- its last_seen_at will be now()
+        // NEW_ASSET: producer called upsert_seen this sync, consumer never
+        // finalized. This is the stuck-pipeline case the function exists
+        // to catch.
         let new_record = TestAssetRecord::new("NEW_ASSET")
             .checksum("ck_new")
             .filename("new.jpg")
@@ -2129,51 +2186,74 @@ mod tests {
             .build();
         db.upsert_seen(&new_record).await.unwrap();
 
-        // Boundary: 30 minutes ago -- OLD_ASSET (1h ago) is before,
-        // NEW_ASSET (now) is after
-        let boundary = chrono::Utc::now().timestamp() - 1800;
-        let promoted = db.promote_pending_to_failed(boundary).await.unwrap();
+        // sync_started_at: 30 minutes ago. OLD_ASSET (1h ago) is before the
+        // boundary and must be left alone. NEW_ASSET (now) is after and
+        // must be promoted.
+        let sync_started_at = chrono::Utc::now().timestamp() - 1800;
+        let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
 
         let summary = db.get_summary().await.unwrap();
         assert_eq!(
             promoted, 1,
-            "only OLD_ASSET (seen before boundary) should be promoted"
+            "only NEW_ASSET (dispatched this sync) should be promoted"
         );
-        assert_eq!(summary.pending, 1, "NEW_ASSET should remain pending");
-        assert_eq!(summary.failed, 1, "OLD_ASSET should be failed");
+        assert_eq!(summary.pending, 1, "OLD_ASSET should remain pending");
+        assert_eq!(summary.failed, 1, "NEW_ASSET should be failed");
+
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].id, "NEW_ASSET");
     }
 
-    // ── Gap: promote_pending_to_failed with very old last_seen_at ────
+    // Regression test for #211: a pending asset the producer didn't enumerate
+    // this sync (because a filter excluded it, the album scope changed, or
+    // the upstream record was deleted) must not be promoted to failed.
+    // Previously, prepare_for_retry + unseen + promote would loop this asset
+    // between pending and failed on every sync.
 
     #[tokio::test]
-    async fn promote_pending_to_failed_promotes_stale_last_seen() {
-        // Assets with last_seen_at from a previous sync cycle (e.g., epoch)
-        // should be promoted when the boundary is recent.
+    async fn promote_pending_to_failed_does_not_loop_filtered_asset() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
-        let record = TestAssetRecord::new("STALE_ASSET")
-            .checksum("ck_stale")
-            .filename("stale.jpg")
-            .size(1000)
+        // Sync 1: asset enumerated, upsert_seen, then never got finalized
+        // and was subsequently "lost" from the enumeration scope (e.g. user
+        // added --skip-videos). We simulate that by backdating last_seen_at.
+        let record = TestAssetRecord::new("GHOST")
+            .checksum("ck_ghost")
+            .filename("ghost.mov")
+            .size(4096)
             .build();
         db.upsert_seen(&record).await.unwrap();
-
-        // Backdate to epoch
         {
             let conn = db.acquire_lock("test_setup").unwrap();
+            let one_day_ago = chrono::Utc::now().timestamp() - 86400;
             conn.execute(
-                "UPDATE assets SET last_seen_at = 0 WHERE id = 'STALE_ASSET'",
-                [],
+                "UPDATE assets SET last_seen_at = ?1 WHERE id = 'GHOST'",
+                rusqlite::params![one_day_ago],
             )
             .unwrap();
         }
 
-        let now = chrono::Utc::now().timestamp();
-        let promoted = db.promote_pending_to_failed(now).await.unwrap();
-        assert_eq!(
-            promoted, 1,
-            "asset with epoch last_seen_at should be promoted"
-        );
+        // Sync 2 begins now. The asset is filtered out - no upsert_seen, no
+        // touch_last_seen. last_seen_at stays at one_day_ago.
+        let sync_2_start = chrono::Utc::now().timestamp();
+        let promoted = db.promote_pending_to_failed(sync_2_start).await.unwrap();
+        assert_eq!(promoted, 0, "filtered asset must not be promoted");
+
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.failed, 0);
+
+        // Sync 3, 4, 5: same filter still applied. Assert the state is
+        // stable across repeated calls.
+        for _ in 0..3 {
+            let start = chrono::Utc::now().timestamp();
+            let promoted = db.promote_pending_to_failed(start).await.unwrap();
+            assert_eq!(promoted, 0, "stable: filtered asset stays pending");
+        }
+        let summary = db.get_summary().await.unwrap();
+        assert_eq!(summary.pending, 1);
+        assert_eq!(summary.failed, 0);
     }
 
     // ── Gap: upsert_seen preserves downloaded status across updates ───

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -830,6 +830,23 @@ impl StateDb for SqliteStateDb {
     }
 }
 
+#[cfg(test)]
+impl SqliteStateDb {
+    /// Overwrite `last_seen_at` for a specific asset. Used by tests that need
+    /// to simulate a pending row carried over from a prior sync. Callable
+    /// from any test module in the crate so cross-module state tests (e.g.
+    /// pipeline-level ghost-loop regression) don't have to reach for raw
+    /// `rusqlite::Connection` plumbing.
+    pub(crate) fn backdate_last_seen(&self, asset_id: &str, ts: i64) {
+        let conn = self.acquire_lock("test_backdate_last_seen").unwrap();
+        conn.execute(
+            "UPDATE assets SET last_seen_at = ?1 WHERE id = ?2",
+            rusqlite::params![ts, asset_id],
+        )
+        .unwrap();
+    }
+}
+
 /// Column list for every `SELECT ... FROM assets` that feeds `row_to_asset_record`.
 /// Keep this in sync with the indices read in `row_to_asset_record`.
 const ASSET_COLUMNS: &str = "id, version_size, checksum, filename, created_at, \
@@ -891,17 +908,6 @@ mod tests {
 
     fn test_dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
-    }
-
-    /// Overwrite `last_seen_at` for a specific asset row. Used by tests that
-    /// need to simulate a pending row carried over from a prior sync.
-    fn backdate_last_seen(db: &SqliteStateDb, asset_id: &str, ts: i64) {
-        let conn = db.acquire_lock("test_setup").unwrap();
-        conn.execute(
-            "UPDATE assets SET last_seen_at = ?1 WHERE id = ?2",
-            rusqlite::params![ts, asset_id],
-        )
-        .unwrap();
     }
 
     #[tokio::test]
@@ -1055,9 +1061,9 @@ mod tests {
         }
 
         // Force a deterministic order by backdating.
-        backdate_last_seen(&db, "OLDEST", 1_000);
-        backdate_last_seen(&db, "MIDDLE", 2_000);
-        backdate_last_seen(&db, "NEWEST", 3_000);
+        db.backdate_last_seen("OLDEST", 1_000);
+        db.backdate_last_seen("MIDDLE", 2_000);
+        db.backdate_last_seen("NEWEST", 3_000);
 
         let failed = db.get_failed().await.unwrap();
         let ids: Vec<&str> = failed.iter().map(|r| r.id.as_str()).collect();
@@ -1081,9 +1087,9 @@ mod tests {
             db.upsert_seen(&record).await.unwrap();
         }
 
-        backdate_last_seen(&db, "OLD", 1_000);
-        backdate_last_seen(&db, "MID", 2_000);
-        backdate_last_seen(&db, "NEW", 3_000);
+        db.backdate_last_seen("OLD", 1_000);
+        db.backdate_last_seen("MID", 2_000);
+        db.backdate_last_seen("NEW", 3_000);
 
         let pending = db.get_pending().await.unwrap();
         let ids: Vec<&str> = pending.iter().map(|r| r.id.as_str()).collect();
@@ -2244,7 +2250,7 @@ mod tests {
             .size(1000)
             .build();
         db.upsert_seen(&old_record).await.unwrap();
-        backdate_last_seen(&db, "OLD_ASSET", chrono::Utc::now().timestamp() - 3600);
+        db.backdate_last_seen("OLD_ASSET", chrono::Utc::now().timestamp() - 3600);
 
         // NEW_ASSET: producer called upsert_seen this sync, consumer never
         // finalized. This is the stuck-pipeline case the function exists
@@ -2294,7 +2300,7 @@ mod tests {
             .size(4096)
             .build();
         db.upsert_seen(&record).await.unwrap();
-        backdate_last_seen(&db, "GHOST", chrono::Utc::now().timestamp() - 86400);
+        db.backdate_last_seen("GHOST", chrono::Utc::now().timestamp() - 86400);
 
         // Sync 2 begins now. The asset is filtered out - no upsert_seen, no
         // touch_last_seen. last_seen_at stays at one_day_ago.
@@ -2335,11 +2341,7 @@ mod tests {
             .size(1000)
             .build();
         db.upsert_seen(&record).await.unwrap();
-        backdate_last_seen(
-            &db,
-            "PENDING_CARRYOVER",
-            chrono::Utc::now().timestamp() - 86400,
-        );
+        db.backdate_last_seen("PENDING_CARRYOVER", chrono::Utc::now().timestamp() - 86400);
 
         // Capture sync_started_at BEFORE touch_last_seen runs.
         let sync_started_at = chrono::Utc::now().timestamp();

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -431,7 +431,10 @@ impl StateDb for SqliteStateDb {
             tracing::warn!(
                 id,
                 version_size,
-                "mark_failed matched 0 rows — asset may not have been recorded via upsert_seen"
+                "mark_failed matched 0 rows: caller violated the producer-dispatch \
+                 invariant (see upsert_seen docs). The asset was never recorded, so \
+                 the failure is not persisted. Find the mark_failed call path that \
+                 didn't run upsert_seen first"
             );
         }
 

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -1041,6 +1041,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_failed_orders_by_last_seen_desc() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        for id in &["OLDEST", "MIDDLE", "NEWEST"] {
+            let record = TestAssetRecord::new(id)
+                .checksum(&format!("ck_{id}"))
+                .filename(&format!("{}.jpg", id.to_lowercase()))
+                .size(100)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+            db.mark_failed(id, "original", "boom").await.unwrap();
+        }
+
+        // Force a deterministic order by backdating.
+        backdate_last_seen(&db, "OLDEST", 1_000);
+        backdate_last_seen(&db, "MIDDLE", 2_000);
+        backdate_last_seen(&db, "NEWEST", 3_000);
+
+        let failed = db.get_failed().await.unwrap();
+        let ids: Vec<&str> = failed.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["NEWEST", "MIDDLE", "OLDEST"],
+            "get_failed must sort last_seen_at DESC"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_pending_orders_by_last_seen_desc() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        for id in &["OLD", "MID", "NEW"] {
+            let record = TestAssetRecord::new(id)
+                .checksum(&format!("ck_{id}"))
+                .filename(&format!("{}.jpg", id.to_lowercase()))
+                .size(100)
+                .build();
+            db.upsert_seen(&record).await.unwrap();
+        }
+
+        backdate_last_seen(&db, "OLD", 1_000);
+        backdate_last_seen(&db, "MID", 2_000);
+        backdate_last_seen(&db, "NEW", 3_000);
+
+        let pending = db.get_pending().await.unwrap();
+        let ids: Vec<&str> = pending.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["NEW", "MID", "OLD"],
+            "get_pending must sort last_seen_at DESC"
+        );
+    }
+
+    #[tokio::test]
     async fn test_reset_failed() {
         let db = SqliteStateDb::open_in_memory().unwrap();
 
@@ -2262,6 +2316,46 @@ mod tests {
         let summary = db.get_summary().await.unwrap();
         assert_eq!(summary.pending, 1);
         assert_eq!(summary.failed, 0);
+    }
+
+    // Canary for the touch_last_seen contract: if a caller bumps
+    // last_seen_at on a pending row, promote_pending_to_failed WILL promote
+    // it. The touch_last_seen trait docs warn against this. This test locks
+    // in that behavior so a silent regression (e.g. an unsafe touch added
+    // to a skip path) is caught.
+
+    #[tokio::test]
+    async fn touch_last_seen_on_pending_row_causes_promotion_at_sync_end() {
+        let db = SqliteStateDb::open_in_memory().unwrap();
+
+        // A pending row carried over from a prior sync (backdated).
+        let record = TestAssetRecord::new("PENDING_CARRYOVER")
+            .checksum("ck_p")
+            .filename("pending.jpg")
+            .size(1000)
+            .build();
+        db.upsert_seen(&record).await.unwrap();
+        backdate_last_seen(
+            &db,
+            "PENDING_CARRYOVER",
+            chrono::Utc::now().timestamp() - 86400,
+        );
+
+        // Capture sync_started_at BEFORE touch_last_seen runs.
+        let sync_started_at = chrono::Utc::now().timestamp();
+
+        // Caller violates the contract: bumps last_seen_at on a pending row.
+        db.touch_last_seen("PENDING_CARRYOVER").await.unwrap();
+
+        let promoted = db.promote_pending_to_failed(sync_started_at).await.unwrap();
+        assert_eq!(
+            promoted, 1,
+            "touch_last_seen on a pending row must cause promotion at sync end"
+        );
+
+        let failed = db.get_failed().await.unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].id, "PENDING_CARRYOVER");
     }
 
     // ── Gap: upsert_seen preserves downloaded status across updates ───

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -441,10 +441,12 @@ impl StateDb for SqliteStateDb {
     async fn get_failed(&self) -> Result<Vec<AssetRecord>, StateError> {
         let conn = self.acquire_lock("get_failed")?;
 
+        let sql = format!(
+            "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'failed' \
+             ORDER BY last_seen_at DESC",
+        );
         let mut stmt = conn
-            .prepare(
-                "SELECT id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, downloaded_at, local_path, last_seen_at, download_attempts, last_error, local_checksum FROM assets WHERE status = 'failed'",
-            )
+            .prepare(&sql)
             .map_err(|e| StateError::query("get_failed", e))?;
 
         let records = stmt
@@ -459,10 +461,12 @@ impl StateDb for SqliteStateDb {
     async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
         let conn = self.acquire_lock("get_pending")?;
 
+        let sql = format!(
+            "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'pending' \
+             ORDER BY last_seen_at DESC",
+        );
         let mut stmt = conn
-            .prepare(
-                "SELECT id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, downloaded_at, local_path, last_seen_at, download_attempts, last_error, local_checksum FROM assets WHERE status = 'pending' ORDER BY last_seen_at DESC",
-            )
+            .prepare(&sql)
             .map_err(|e| StateError::query("get_pending", e))?;
 
         let records = stmt
@@ -539,10 +543,12 @@ impl StateDb for SqliteStateDb {
     ) -> Result<Vec<AssetRecord>, StateError> {
         let conn = self.acquire_lock("get_downloaded_page")?;
 
+        let sql = format!(
+            "SELECT {ASSET_COLUMNS} FROM assets WHERE status = 'downloaded' \
+             ORDER BY rowid LIMIT ?1 OFFSET ?2",
+        );
         let mut stmt = conn
-            .prepare(
-                "SELECT id, version_size, checksum, filename, created_at, added_at, size_bytes, media_type, status, downloaded_at, local_path, last_seen_at, download_attempts, last_error, local_checksum FROM assets WHERE status = 'downloaded' ORDER BY rowid LIMIT ?1 OFFSET ?2",
-            )
+            .prepare(&sql)
             .map_err(|e| StateError::query("get_downloaded_page", e))?;
 
         let records = stmt
@@ -823,6 +829,12 @@ impl StateDb for SqliteStateDb {
     }
 }
 
+/// Column list for every `SELECT ... FROM assets` that feeds `row_to_asset_record`.
+/// Keep this in sync with the indices read in `row_to_asset_record`.
+const ASSET_COLUMNS: &str = "id, version_size, checksum, filename, created_at, \
+     added_at, size_bytes, media_type, status, downloaded_at, local_path, \
+     last_seen_at, download_attempts, last_error, local_checksum";
+
 /// Convert a database row to an `AssetRecord`.
 ///
 /// Returns `rusqlite::Error` on column extraction failures instead of silently
@@ -878,6 +890,17 @@ mod tests {
 
     fn test_dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    /// Overwrite `last_seen_at` for a specific asset row. Used by tests that
+    /// need to simulate a pending row carried over from a prior sync.
+    fn backdate_last_seen(db: &SqliteStateDb, asset_id: &str, ts: i64) {
+        let conn = db.acquire_lock("test_setup").unwrap();
+        conn.execute(
+            "UPDATE assets SET last_seen_at = ?1 WHERE id = ?2",
+            rusqlite::params![ts, asset_id],
+        )
+        .unwrap();
     }
 
     #[tokio::test]
@@ -2166,15 +2189,7 @@ mod tests {
             .size(1000)
             .build();
         db.upsert_seen(&old_record).await.unwrap();
-        {
-            let conn = db.acquire_lock("test_setup").unwrap();
-            let old_ts = chrono::Utc::now().timestamp() - 3600;
-            conn.execute(
-                "UPDATE assets SET last_seen_at = ?1 WHERE id = 'OLD_ASSET'",
-                rusqlite::params![old_ts],
-            )
-            .unwrap();
-        }
+        backdate_last_seen(&db, "OLD_ASSET", chrono::Utc::now().timestamp() - 3600);
 
         // NEW_ASSET: producer called upsert_seen this sync, consumer never
         // finalized. This is the stuck-pipeline case the function exists
@@ -2224,15 +2239,7 @@ mod tests {
             .size(4096)
             .build();
         db.upsert_seen(&record).await.unwrap();
-        {
-            let conn = db.acquire_lock("test_setup").unwrap();
-            let one_day_ago = chrono::Utc::now().timestamp() - 86400;
-            conn.execute(
-                "UPDATE assets SET last_seen_at = ?1 WHERE id = 'GHOST'",
-                rusqlite::params![one_day_ago],
-            )
-            .unwrap();
-        }
+        backdate_last_seen(&db, "GHOST", chrono::Utc::now().timestamp() - 86400);
 
         // Sync 2 begins now. The asset is filtered out - no upsert_seen, no
         // touch_last_seen. last_seen_at stays at one_day_ago.

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -431,10 +431,8 @@ impl StateDb for SqliteStateDb {
             tracing::warn!(
                 id,
                 version_size,
-                "mark_failed matched 0 rows: caller violated the producer-dispatch \
-                 invariant (see upsert_seen docs). The asset was never recorded, so \
-                 the failure is not persisted. Find the mark_failed call path that \
-                 didn't run upsert_seen first"
+                "mark_failed matched 0 rows; caller must upsert_seen before mark_failed \
+                 (producer-dispatch invariant). Failure not persisted"
             );
         }
 

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2815,6 +2815,146 @@ fn status_pending_empty_when_none_pending() {
     assert!(!stdout.contains("Pending assets:"), "stdout: {stdout}");
 }
 
+#[test]
+fn status_downloaded_with_null_local_path_surfaces_missing_marker() {
+    // Covers the `<MISSING local_path>` display path in print_downloaded.
+    // A downloaded row without a local_path is a state-DB invariant
+    // violation; status must not silently hide it.
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+
+    // Directly insert a downloaded row with NULL local_path. insert_asset
+    // helper would still pass None through, so we use it with explicit
+    // Option::None for local_path.
+    insert_asset(&conn, "a1", "downloaded", "broken.jpg", None, None, None);
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "status",
+            "--downloaded",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("<MISSING local_path>"),
+        "missing-path marker not surfaced: {stdout}"
+    );
+    assert!(stdout.contains("broken.jpg"), "stdout: {stdout}");
+}
+
+#[test]
+fn status_all_three_flags_render_all_sections() {
+    // End-to-end coverage for --failed --pending --downloaded combined.
+    // Locks in the three-section rendering and proves the flags are
+    // orthogonal in the actual binary (not just clap parsing).
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+
+    insert_asset(
+        &conn,
+        "dl1",
+        "downloaded",
+        "dl.jpg",
+        Some("/p/dl.jpg"),
+        None,
+        None,
+    );
+    insert_asset(&conn, "pend1", "pending", "pend.jpg", None, None, None);
+    insert_asset(
+        &conn,
+        "fail1",
+        "failed",
+        "fail.jpg",
+        None,
+        Some("timeout"),
+        None,
+    );
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "status",
+            "--failed",
+            "--pending",
+            "--downloaded",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Failed assets:"), "stdout: {stdout}");
+    assert!(stdout.contains("fail.jpg"), "stdout: {stdout}");
+    assert!(stdout.contains("Pending assets:"), "stdout: {stdout}");
+    assert!(stdout.contains("pend.jpg"), "stdout: {stdout}");
+    assert!(stdout.contains("Downloaded assets:"), "stdout: {stdout}");
+    assert!(stdout.contains("dl.jpg"), "stdout: {stdout}");
+}
+
+#[test]
+fn status_downloaded_paginates_past_500_records() {
+    // Covers the pagination loop in run_status for --downloaded when the
+    // result set exceeds page_size (500). Uses 600 rows to require at
+    // least two page fetches.
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+
+    for i in 0..600 {
+        let id = format!("dl{i:04}");
+        let filename = format!("photo_{i:04}.jpg");
+        let local = format!("/p/photo_{i:04}.jpg");
+        insert_asset(
+            &conn,
+            &id,
+            "downloaded",
+            &filename,
+            Some(&local),
+            None,
+            None,
+        );
+    }
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "status",
+            "--downloaded",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Downloaded: 600"), "stdout: {stdout}");
+    // First and last rows across the page boundary must both appear.
+    assert!(stdout.contains("photo_0000.jpg"), "first row missing");
+    assert!(stdout.contains("photo_0499.jpg"), "boundary row missing");
+    assert!(
+        stdout.contains("photo_0500.jpg"),
+        "post-boundary row missing"
+    );
+    assert!(stdout.contains("photo_0599.jpg"), "last row missing");
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Config env vars in TOML (KEI_CONFIG, KEI_DATA_DIR)
 // ═══════════════════════════════════════════════════════════════════════

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -2689,6 +2689,122 @@ fn dry_run_creates_no_state_db() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
+// Status: --pending and --downloaded (issue #211)
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn status_pending_shows_pending_assets() {
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+
+    insert_asset(&conn, "a1", "pending", "photo1.jpg", None, None, None);
+    insert_asset(&conn, "a2", "pending", "photo2.jpg", None, None, None);
+    insert_asset(
+        &conn,
+        "a3",
+        "downloaded",
+        "photo3.jpg",
+        Some("/p/photo3.jpg"),
+        None,
+        None,
+    );
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "status",
+            "--pending",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Pending assets:"), "stdout: {stdout}");
+    assert!(stdout.contains("photo1.jpg"), "stdout: {stdout}");
+    assert!(stdout.contains("photo2.jpg"), "stdout: {stdout}");
+    // Downloaded asset must not appear in the pending listing
+    assert!(!stdout.contains("photo3.jpg"), "stdout: {stdout}");
+}
+
+#[test]
+fn status_downloaded_shows_downloaded_assets() {
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+
+    insert_asset(
+        &conn,
+        "a1",
+        "downloaded",
+        "photo1.jpg",
+        Some("/p/photo1.jpg"),
+        None,
+        None,
+    );
+    insert_asset(&conn, "a2", "pending", "photo2.jpg", None, None, None);
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "status",
+            "--downloaded",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Downloaded assets:"), "stdout: {stdout}");
+    assert!(stdout.contains("photo1.jpg"), "stdout: {stdout}");
+    assert!(stdout.contains("/p/photo1.jpg"), "stdout: {stdout}");
+    // Pending asset must not appear in the downloaded listing
+    assert!(!stdout.contains("photo2.jpg"), "stdout: {stdout}");
+}
+
+#[test]
+fn status_pending_empty_when_none_pending() {
+    let dir = tempfile::tempdir().unwrap();
+    let username = "test@example.com";
+    let conn = create_state_db(dir.path(), username);
+    insert_asset(
+        &conn,
+        "a1",
+        "downloaded",
+        "photo1.jpg",
+        Some("/p/photo1.jpg"),
+        None,
+        None,
+    );
+    drop(conn);
+
+    let out = clean_cmd()
+        .args([
+            "status",
+            "--pending",
+            "--username",
+            username,
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.contains("Pending assets:"), "stdout: {stdout}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
 // Config env vars in TOML (KEI_CONFIG, KEI_DATA_DIR)
 // ═══════════════════════════════════════════════════════════════════════
 

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -36,8 +36,14 @@ fn sanitize_username(username: &str) -> String {
         .collect()
 }
 
-/// Create a state DB at the expected path for the given username inside `data_dir`.
+/// Create a state DB at the expected path for the given username inside
+/// `data_dir`. Mirrors the latest schema from `src/state/schema.rs` so
+/// callers don't rely on the binary's migration path to fill in columns
+/// added after v1. Bump `SCHEMA_VERSION` and the DDL below together whenever
+/// schema.rs changes.
 fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Connection {
+    const SCHEMA_VERSION: i32 = 4;
+
     let db_name = format!("{}.db", sanitize_username(username));
     let db_path = data_dir.join(db_name);
     let conn = rusqlite::Connection::open(&db_path).unwrap();
@@ -59,8 +65,12 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
             download_attempts INTEGER DEFAULT 0,
             last_error TEXT,
             local_checksum TEXT,
+            download_checksum TEXT,
             PRIMARY KEY (id, version_size)
         );
+        CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status);
+        CREATE INDEX IF NOT EXISTS idx_assets_local_path ON assets(local_path);
+        CREATE INDEX IF NOT EXISTS idx_assets_checksum ON assets(checksum);
         CREATE TABLE IF NOT EXISTS sync_runs (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             started_at INTEGER NOT NULL,
@@ -77,7 +87,8 @@ fn create_state_db(data_dir: &std::path::Path, username: &str) -> rusqlite::Conn
         ",
     )
     .unwrap();
-    conn.pragma_update(None, "user_version", 3).unwrap();
+    conn.pragma_update(None, "user_version", SCHEMA_VERSION)
+        .unwrap();
     conn
 }
 

--- a/tests/run-docker-live.sh
+++ b/tests/run-docker-live.sh
@@ -235,6 +235,34 @@ check "password-file auth works in container" "$?"
 rm -rf "$SECRETS_DIR" "$PWFILE_PHOTOS"
 
 echo ""
+echo "--- Test 13: kei status --downloaded inside container ---"
+# Test 1's sync wrote downloaded rows into $DOCKER_CONFIG. The --downloaded
+# flag should list them.
+STATUS_OUT=$(docker run --rm \
+    -v "$DOCKER_CONFIG:/config" \
+    "$IMAGE" status \
+        --username "$ICLOUD_USERNAME" \
+        --data-dir /config \
+        --downloaded \
+    2>&1)
+echo "$STATUS_OUT" | tail -5
+echo "$STATUS_OUT" | grep -q "Downloaded assets:"
+check "--downloaded listing renders inside container" "$?"
+
+echo ""
+echo "--- Test 14: kei status --pending --failed --downloaded combined ---"
+# All three flags should render (or be silently absent if that status has
+# zero rows). Exit code must be 0 regardless.
+docker run --rm \
+    -v "$DOCKER_CONFIG:/config" \
+    "$IMAGE" status \
+        --username "$ICLOUD_USERNAME" \
+        --data-dir /config \
+        --pending --failed --downloaded \
+    >/dev/null 2>&1
+check "--pending --failed --downloaded combined exits 0" "$?"
+
+echo ""
 echo "==========================================="
 echo "  DOCKER LIVE TEST RESULTS: $PASS pass, $FAIL fail"
 echo "==========================================="

--- a/tests/run-docker-live.sh
+++ b/tests/run-docker-live.sh
@@ -251,16 +251,22 @@ check "--downloaded listing renders inside container" "$?"
 
 echo ""
 echo "--- Test 14: kei status --pending --failed --downloaded combined ---"
-# All three flags should render (or be silently absent if that status has
-# zero rows). Exit code must be 0 regardless.
-docker run --rm \
+# Test 1's sync produced downloaded rows, so the downloaded section must
+# render. Pending/failed sections are only emitted when their counts are > 0,
+# so we don't require them here - the downloaded header is the load-bearing
+# check, and the full invocation must exit 0.
+COMBINED_OUT=$(docker run --rm \
     -v "$DOCKER_CONFIG:/config" \
     "$IMAGE" status \
         --username "$ICLOUD_USERNAME" \
         --data-dir /config \
         --pending --failed --downloaded \
-    >/dev/null 2>&1
-check "--pending --failed --downloaded combined exits 0" "$?"
+    2>&1)
+COMBINED_EC=$?
+echo "$COMBINED_OUT" | grep -q "Downloaded assets:"
+HAS_DOWNLOADED=$?
+check "--pending --failed --downloaded combined exits 0" "$COMBINED_EC"
+check "combined flags render Downloaded section" "$HAS_DOWNLOADED"
 
 echo ""
 echo "==========================================="


### PR DESCRIPTION
Fixes #211.

## Summary

- `promote_pending_to_failed` used `last_seen_at < sync_started_at` to find stuck pending assets, but `upsert_seen` short-circuits on `is_asset_filtered`, so filtered assets also never got `last_seen_at` bumped. Any filter toggle (`--skip-videos`), album swap, or upstream record deletion caused the known-asset pool to loop between `pending` and `failed` on every sync, polluting `kei status --failed`.
- Flipped the gate to `last_seen_at >= sync_started_at`. The function now promotes only pending assets the producer dispatched this sync (via `upsert_seen`) that the consumer never finalized. Filtered and out-of-scope assets keep their stale `last_seen_at` and are left alone. The original bug this function was written to catch (stuck-pipeline pending assets) still gets caught.
- No schema migration. The change is one SQL condition plus doc comments on `upsert_seen` and `touch_last_seen` pinning the dispatch-path invariant so future callers don't silently break the gate.
- Added `kei status --pending` and `--downloaded` listings (parallel to the existing `--failed`).
- Remote-deletion handling (`SoftDeleted` / `HardDeleted` events from `changes/zone`) is out of scope here and tracked in #230.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bin kei` (1295 passed)
- [x] `cargo test --test behavioral` (106 passed)
- [x] `cargo test --test cli` (95 passed)
- [x] New unit tests:
  - `promote_pending_to_failed_only_affects_pending` (updated for new semantics)
  - `promote_pending_to_failed_skips_stale_last_seen`
  - `promote_pending_to_failed_does_not_loop_filtered_asset` (regression for #211)
- [x] New behavioral tests:
  - `status_pending_shows_pending_assets`
  - `status_downloaded_shows_downloaded_assets`
  - `status_pending_empty_when_none_pending`