### PR TITLE
Add DB-backed asset gauges to /metrics endpoint

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -80,6 +80,7 @@ pub(crate) struct MetricsHandle {
     db_assets_total: Family<StatusLabels, Gauge>,
     db_assets_size_bytes: Family<StatusLabels, Gauge>,
     db_last_sync_assets_seen: Gauge,
+    db_summary_read_failures: Counter,
 }
 
 impl MetricsHandle {
@@ -206,6 +207,13 @@ impl MetricsHandle {
             db_last_sync_assets_seen.clone(),
         );
 
+        let db_summary_read_failures = Counter::default();
+        registry.register(
+            "kei_db_summary_read_failures",
+            "Total number of failed attempts to read the DB summary for metrics",
+            db_summary_read_failures.clone(),
+        );
+
         Self {
             registry: Arc::new(registry),
             inner: Arc::new(Mutex::new(Inner {
@@ -228,6 +236,7 @@ impl MetricsHandle {
             db_assets_total,
             db_assets_size_bytes,
             db_last_sync_assets_seen,
+            db_summary_read_failures,
         }
     }
 
@@ -298,19 +307,29 @@ impl MetricsHandle {
             .get_or_create(&StatusLabels {
                 status: "downloaded",
             })
-            .set(summary.downloaded as i64);
+            .set(i64::try_from(summary.downloaded).unwrap_or(i64::MAX));
         self.db_assets_total
             .get_or_create(&StatusLabels { status: "pending" })
-            .set(summary.pending as i64);
+            .set(i64::try_from(summary.pending).unwrap_or(i64::MAX));
         self.db_assets_total
             .get_or_create(&StatusLabels { status: "failed" })
-            .set(summary.failed as i64);
+            .set(i64::try_from(summary.failed).unwrap_or(i64::MAX));
         self.db_assets_size_bytes
             .get_or_create(&StatusLabels {
                 status: "downloaded",
             })
-            .set(summary.downloaded_bytes as i64);
-        self.db_last_sync_assets_seen.set(assets_seen as i64);
+            .set(i64::try_from(summary.downloaded_bytes).unwrap_or(i64::MAX));
+        self.db_last_sync_assets_seen
+            .set(i64::try_from(assets_seen).unwrap_or(i64::MAX));
+    }
+
+    /// Increment the counter for failed DB summary reads.
+    ///
+    /// Call this whenever [`get_summary`](crate::state::StateDb::get_summary)
+    /// returns an error during a metrics update so the failure is visible in
+    /// the `/metrics` output rather than only in the log.
+    pub(crate) fn record_db_summary_failure(&self) {
+        self.db_summary_read_failures.inc();
     }
 
     async fn update_health_gauges(&self, health: &HealthStatus) {
@@ -845,16 +864,16 @@ mod tests {
 
         let output = render_metrics(&handle).await;
         assert!(
-            output.contains(r#"status="downloaded""#) && output.contains("100"),
-            "downloaded count missing:\n{output}"
+            output.contains(r#"kei_db_assets_total{status="downloaded"} 100"#),
+            "downloaded count missing or wrong:\n{output}"
         );
         assert!(
-            output.contains(r#"status="pending""#) && output.contains("5"),
-            "pending count missing:\n{output}"
+            output.contains(r#"kei_db_assets_total{status="pending"} 5"#),
+            "pending count missing or wrong:\n{output}"
         );
         assert!(
-            output.contains(r#"status="failed""#) && output.contains("2"),
-            "failed count missing:\n{output}"
+            output.contains(r#"kei_db_assets_total{status="failed"} 2"#),
+            "failed count missing or wrong:\n{output}"
         );
     }
 
@@ -866,7 +885,7 @@ mod tests {
 
         let output = render_metrics(&handle).await;
         assert!(
-            output.contains("kei_db_assets_size_bytes") && output.contains("2048000"),
+            output.contains(r#"kei_db_assets_size_bytes{status="downloaded"} 2048000"#),
             "downloaded_bytes gauge missing or wrong:\n{output}"
         );
     }
@@ -919,6 +938,19 @@ mod tests {
         assert!(
             output.contains("kei_db_last_sync_assets_seen"),
             "kei_db_last_sync_assets_seen missing from /metrics output:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn db_summary_failure_counter_increments() {
+        let handle = MetricsHandle::new();
+        handle.record_db_summary_failure();
+        handle.record_db_summary_failure();
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_db_summary_read_failures_total 2"),
+            "db_summary_read_failures counter missing or wrong:\n{output}"
         );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -295,7 +295,9 @@ impl MetricsHandle {
     /// call site, so no extra DB query is needed for that gauge.
     pub(crate) fn update_db_stats(&self, summary: &SyncSummary, assets_seen: u64) {
         self.db_assets_total
-            .get_or_create(&StatusLabels { status: "downloaded" })
+            .get_or_create(&StatusLabels {
+                status: "downloaded",
+            })
             .set(summary.downloaded as i64);
         self.db_assets_total
             .get_or_create(&StatusLabels { status: "pending" })
@@ -304,7 +306,9 @@ impl MetricsHandle {
             .get_or_create(&StatusLabels { status: "failed" })
             .set(summary.failed as i64);
         self.db_assets_size_bytes
-            .get_or_create(&StatusLabels { status: "downloaded" })
+            .get_or_create(&StatusLabels {
+                status: "downloaded",
+            })
             .set(summary.downloaded_bytes as i64);
         self.db_last_sync_assets_seen.set(assets_seen as i64);
     }
@@ -816,7 +820,12 @@ mod tests {
 
     // ── DB-backed gauges ──────────────────────────────────────────────────────
 
-    fn make_summary(downloaded: u64, pending: u64, failed: u64, downloaded_bytes: u64) -> SyncSummary {
+    fn make_summary(
+        downloaded: u64,
+        pending: u64,
+        failed: u64,
+        downloaded_bytes: u64,
+    ) -> SyncSummary {
         SyncSummary {
             total_assets: downloaded + pending + failed,
             downloaded,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -29,6 +29,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::download::SyncStats;
 use crate::health::HealthStatus;
+use crate::state::types::SyncSummary;
 
 // ── Label types ──────────────────────────────────────────────────────────────
 
@@ -36,6 +37,12 @@ use crate::health::HealthStatus;
 #[derive(Clone, Debug, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
 struct SkipLabels {
     reason: &'static str,
+}
+
+/// Label set for the `kei_db_assets_total` and `kei_db_assets_size_bytes` gauge families.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
+struct StatusLabels {
+    status: &'static str,
 }
 
 // ── State shared between the HTTP handlers and the sync loop ─────────────────
@@ -69,6 +76,10 @@ pub(crate) struct MetricsHandle {
     consecutive_failures: Gauge,
     last_success_timestamp: Gauge<f64, AtomicU64>,
     interrupted_cycles: Counter,
+    // DB-backed gauges (only populated when --metrics-port is set).
+    db_assets_total: Family<StatusLabels, Gauge>,
+    db_assets_size_bytes: Family<StatusLabels, Gauge>,
+    db_last_sync_assets_seen: Gauge,
 }
 
 impl MetricsHandle {
@@ -174,6 +185,27 @@ impl MetricsHandle {
             interrupted_cycles.clone(),
         );
 
+        let db_assets_total: Family<StatusLabels, Gauge> = Family::default();
+        registry.register(
+            "kei_db_assets_total",
+            "Current number of assets in the database, by status",
+            db_assets_total.clone(),
+        );
+
+        let db_assets_size_bytes: Family<StatusLabels, Gauge> = Family::default();
+        registry.register(
+            "kei_db_assets_size_bytes",
+            "Current total size in bytes of assets in the database, by status",
+            db_assets_size_bytes.clone(),
+        );
+
+        let db_last_sync_assets_seen: Gauge = Gauge::default();
+        registry.register(
+            "kei_db_last_sync_assets_seen",
+            "Number of assets enumerated from iCloud in the most recent sync cycle",
+            db_last_sync_assets_seen.clone(),
+        );
+
         Self {
             registry: Arc::new(registry),
             inner: Arc::new(Mutex::new(Inner {
@@ -193,6 +225,9 @@ impl MetricsHandle {
             consecutive_failures,
             last_success_timestamp,
             interrupted_cycles,
+            db_assets_total,
+            db_assets_size_bytes,
+            db_last_sync_assets_seen,
         }
     }
 
@@ -250,6 +285,28 @@ impl MetricsHandle {
     /// session, in addition to the normal health update.
     pub(crate) fn record_session_expiration(&self) {
         self.session_expirations.inc();
+    }
+
+    /// Update DB-backed gauges from the current state database summary.
+    ///
+    /// Call this after [`update`] on every real sync cycle, guarded by a
+    /// `state_db.as_ref()` check so dry-run and metrics-disabled paths are
+    /// no-ops. `assets_seen` comes from [`SyncStats`] already in hand at the
+    /// call site, so no extra DB query is needed for that gauge.
+    pub(crate) fn update_db_stats(&self, summary: &SyncSummary, assets_seen: u64) {
+        self.db_assets_total
+            .get_or_create(&StatusLabels { status: "downloaded" })
+            .set(summary.downloaded as i64);
+        self.db_assets_total
+            .get_or_create(&StatusLabels { status: "pending" })
+            .set(summary.pending as i64);
+        self.db_assets_total
+            .get_or_create(&StatusLabels { status: "failed" })
+            .set(summary.failed as i64);
+        self.db_assets_size_bytes
+            .get_or_create(&StatusLabels { status: "downloaded" })
+            .set(summary.downloaded_bytes as i64);
+        self.db_last_sync_assets_seen.set(assets_seen as i64);
     }
 
     async fn update_health_gauges(&self, health: &HealthStatus) {
@@ -754,6 +811,105 @@ mod tests {
         assert!(
             json.get("last_success_at").is_some(),
             "missing last_success_at"
+        );
+    }
+
+    // ── DB-backed gauges ──────────────────────────────────────────────────────
+
+    fn make_summary(downloaded: u64, pending: u64, failed: u64, downloaded_bytes: u64) -> SyncSummary {
+        SyncSummary {
+            total_assets: downloaded + pending + failed,
+            downloaded,
+            pending,
+            failed,
+            downloaded_bytes,
+            last_sync_completed: None,
+            last_sync_started: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn update_db_stats_sets_asset_count_gauges() {
+        let handle = MetricsHandle::new();
+        let summary = make_summary(100, 5, 2, 1_000_000);
+        handle.update_db_stats(&summary, 107);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains(r#"status="downloaded""#) && output.contains("100"),
+            "downloaded count missing:\n{output}"
+        );
+        assert!(
+            output.contains(r#"status="pending""#) && output.contains("5"),
+            "pending count missing:\n{output}"
+        );
+        assert!(
+            output.contains(r#"status="failed""#) && output.contains("2"),
+            "failed count missing:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_db_stats_sets_size_bytes_gauge() {
+        let handle = MetricsHandle::new();
+        let summary = make_summary(50, 0, 0, 2_048_000);
+        handle.update_db_stats(&summary, 50);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_db_assets_size_bytes") && output.contains("2048000"),
+            "downloaded_bytes gauge missing or wrong:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_db_stats_sets_last_sync_assets_seen_gauge() {
+        let handle = MetricsHandle::new();
+        let summary = make_summary(28_000, 3_000, 71, 0);
+        handle.update_db_stats(&summary, 31_071);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_db_last_sync_assets_seen 31071"),
+            "last_sync_assets_seen gauge missing or wrong:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_db_stats_gauges_reflect_latest_call() {
+        let handle = MetricsHandle::new();
+        handle.update_db_stats(&make_summary(100, 10, 0, 500_000), 110);
+        // Second call should overwrite (gauges, not counters).
+        handle.update_db_stats(&make_summary(105, 5, 0, 525_000), 110);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            !output.contains("kei_db_assets_total{status=\"pending\"} 10"),
+            "stale pending value should not appear:\n{output}"
+        );
+        assert!(
+            output.contains("kei_db_last_sync_assets_seen 110"),
+            "assets_seen gauge wrong:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn db_metric_names_present_in_output() {
+        let handle = MetricsHandle::new();
+        handle.update_db_stats(&make_summary(1, 0, 0, 1024), 1);
+
+        let output = render_metrics(&handle).await;
+        assert!(
+            output.contains("kei_db_assets_total"),
+            "kei_db_assets_total missing from /metrics output:\n{output}"
+        );
+        assert!(
+            output.contains("kei_db_assets_size_bytes"),
+            "kei_db_assets_size_bytes missing from /metrics output:\n{output}"
+        );
+        assert!(
+            output.contains("kei_db_last_sync_assets_seen"),
+            "kei_db_last_sync_assets_seen missing from /metrics output:\n{output}"
         );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -289,7 +289,7 @@ impl MetricsHandle {
 
     /// Update DB-backed gauges from the current state database summary.
     ///
-    /// Call this after [`update`] on every real sync cycle, guarded by a
+    /// Call this after [`Self::update`] on every real sync cycle, guarded by a
     /// `state_db.as_ref()` check so dry-run and metrics-disabled paths are
     /// no-ops. `assets_seen` comes from [`SyncStats`] already in hand at the
     /// call site, so no extra DB query is needed for that gauge.

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -484,7 +484,7 @@ impl StateDb for SqliteStateDb {
 
         let (total_assets, downloaded, pending, failed, downloaded_bytes) = conn
             .query_row(
-                 "SELECT \
+                "SELECT \
                      COUNT(*), \
                      COUNT(CASE WHEN status = 'downloaded' THEN 1 END), \
                      COUNT(CASE WHEN status = 'pending' THEN 1 END), \

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -482,13 +482,14 @@ impl StateDb for SqliteStateDb {
     async fn get_summary(&self) -> Result<SyncSummary, StateError> {
         let conn = self.acquire_lock("get_summary")?;
 
-        let (total_assets, downloaded, pending, failed) = conn
+        let (total_assets, downloaded, pending, failed, downloaded_bytes) = conn
             .query_row(
-                "SELECT \
+                 "SELECT \
                      COUNT(*), \
                      COUNT(CASE WHEN status = 'downloaded' THEN 1 END), \
                      COUNT(CASE WHEN status = 'pending' THEN 1 END), \
-                     COUNT(CASE WHEN status = 'failed' THEN 1 END) \
+                     COUNT(CASE WHEN status = 'failed' THEN 1 END), \
+                     COALESCE(SUM(CASE WHEN status = 'downloaded' THEN size_bytes ELSE 0 END), 0) \
                  FROM assets",
                 [],
                 |row| {
@@ -497,15 +498,17 @@ impl StateDb for SqliteStateDb {
                         row.get::<_, i64>(1)?,
                         row.get::<_, i64>(2)?,
                         row.get::<_, i64>(3)?,
+                        row.get::<_, i64>(4)?,
                     ))
                 },
             )
-            .map(|(t, d, p, f)| {
+            .map(|(t, d, p, f, b)| {
                 (
                     u64::try_from(t).unwrap_or(0),
                     u64::try_from(d).unwrap_or(0),
                     u64::try_from(p).unwrap_or(0),
                     u64::try_from(f).unwrap_or(0),
+                    u64::try_from(b).unwrap_or(0),
                 )
             })
             .map_err(|e| StateError::query("get_summary", e))?;
@@ -532,6 +535,7 @@ impl StateDb for SqliteStateDb {
             downloaded,
             pending,
             failed,
+            downloaded_bytes,
             last_sync_completed,
             last_sync_started,
         })

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -246,6 +246,8 @@ pub struct SyncSummary {
     pub pending: u64,
     /// Number of assets that failed to download.
     pub failed: u64,
+    /// Total size in bytes of downloaded assets.
+    pub downloaded_bytes: u64,
     /// Time of the last completed sync run (if any).
     pub last_sync_completed: Option<DateTime<Utc>>,
     /// Time of the last sync run start (if any).

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -490,6 +490,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                             handle.update_db_stats(&summary, cycle_result.stats.assets_seen);
                         }
                         Err(e) => {
+                            handle.record_db_summary_failure();
                             tracing::warn!(error = %e, "Failed to fetch DB summary for metrics; skipping DB gauge update");
                         }
                     }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -482,6 +482,18 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                     handle.record_session_expiration();
                 }
                 handle.update(&cycle_result.stats, &health).await;
+
+                // Update DB-backed gauges from the state database.
+                if let Some(ref db) = state_db {
+                    match db.get_summary().await {
+                        Ok(summary) => {
+                            handle.update_db_stats(&summary, cycle_result.stats.assets_seen);
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Failed to fetch DB summary for metrics; skipping DB gauge update");
+                        }
+                    }
+                }
             }
 
             // Write JSON report if configured


### PR DESCRIPTION
## Summary

Closes #232.

- The `/metrics` endpoint had no visibility into whether kei has actually synced the library. Pending and failed assets were only visible by querying the database directly, and questions like "how far behind is the local copy?" required manual math.
- Adds three Prometheus gauges backed by the SQLite database, updated once per real sync cycle after `handle.update()` returns:
  - `kei_db_assets_total{status="downloaded|pending|failed"}` -- current count of assets per status
  - `kei_db_assets_size_bytes{status="downloaded"}` -- total bytes of downloaded assets as recorded in the DB
  - `kei_db_last_sync_assets_seen` -- assets enumerated from iCloud in the most recent cycle; the gap between this and `kei_db_assets_total{status="downloaded"}` is the most actionable derived metric
- `SyncSummary` gets a `downloaded_bytes` field; `get_summary()` extends its single existing query with `COALESCE(SUM(CASE WHEN status = 'downloaded' THEN size_bytes ELSE 0 END), 0)`. `COALESCE` is required because `SUM` over an empty table returns SQL `NULL`, which rusqlite cannot coerce to `i64`.
- `MetricsHandle` gets a `StatusLabels` struct (same pattern as the existing `SkipLabels`) and a new `update_db_stats(&self, summary: &SyncSummary, assets_seen: u64)` method. `assets_seen` is already in `SyncStats` at the call site, so no extra DB query is needed for that gauge.
- The wiring in `sync_loop.rs` is guarded by `state_db.as_ref()`, so dry-run mode is a no-op without any special casing. When `--metrics-port` is not set the outer `if let Some(ref handle) = metrics_handle` guard already short-circuits. Errors from `get_summary()` are logged at WARN and do not affect the cycle result.
- No new dependencies.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bin kei` (1307 passed)
- [x] `cargo test --test cli` (95 passed)
- [x] `cargo test --test behavioral` (109 passed)
- [x] New unit tests in `metrics.rs`:
  - `update_db_stats_sets_asset_count_gauges` -- downloaded/pending/failed counts appear with correct label and value
  - `update_db_stats_sets_size_bytes_gauge` -- `downloaded_bytes` surfaces correctly in the output
  - `update_db_stats_sets_last_sync_assets_seen_gauge` -- `kei_db_last_sync_assets_seen` value is set correctly
  - `update_db_stats_gauges_reflect_latest_call` -- gauges overwrite on subsequent calls, not accumulate
  - `db_metric_names_present_in_output` -- smoke test that all three metric names appear in rendered `/metrics` output

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --bin kei --test cli --test behavioral` passes