### PR TITLE
ci: post coverage comment via workflow_run for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,10 @@ jobs:
             base_coverage.lcov
           retention-days: 1
 
-  # Aggregates head + base, computes patch coverage, posts the PR comment.
-  # This is the required check; it runs as long as head succeeded.
+  # Aggregates head + base, computes patch coverage, and builds the sticky
+  # comment body. The comment is posted by a separate workflow triggered via
+  # workflow_run so cross-fork PRs (which run with a read-only GITHUB_TOKEN)
+  # can still get comments - this job only builds the artifact.
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -241,7 +243,6 @@ jobs:
     if: always() && needs.coverage-head.result == 'success'
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -265,12 +266,8 @@ jobs:
           fi
           python3 .github/scripts/patch_coverage.py "${args[@]}" > patch_coverage.json
           cat patch_coverage.json
-      - name: Post coverage comment
-        continue-on-error: true
+      - name: Build coverage comment
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
           MARKER: "<!-- coverage-comment -->"
         run: |
           set -euo pipefail
@@ -385,19 +382,30 @@ jobs:
 
           # Mirror to the Actions step summary so the report is visible in the run UI.
           cat comment.md >> "$GITHUB_STEP_SUMMARY"
-
-          # Sticky comment: edit the existing one if our marker is present,
-          # otherwise post a new one. Avoids spamming the PR on each push.
-          EXISTING=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
-            | head -n 1)
-
-          if [ -n "$EXISTING" ]; then
-            jq -Rs '{body: .}' < comment.md \
-              | gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" --input -
-          else
-            gh pr comment "$PR_NUMBER" --body-file comment.md
-          fi
+      - name: Upload coverage comment
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-comment
+          path: comment.md
+          retention-days: 1
+      # PR metadata for the coverage-comment workflow. workflow_run events
+      # don't carry PR context, and looking it up from the head SHA is
+      # unreliable for fork PRs, so we pass it via artifact.
+      - name: Record PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          printf '%s\n' "$PR_NUMBER" > pr_number.txt
+          printf '%s\n' "$PR_HEAD_SHA" > pr_head_sha.txt
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-comment-meta
+          path: |
+            pr_number.txt
+            pr_head_sha.txt
+          retention-days: 1
 
   # Compiles release builds on all platforms to catch platform-specific compile errors
   # Release mode can surface different issues than debug mode (e.g., optimization bugs)

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -16,6 +16,13 @@ on:
     workflows: ["Rust CI"]
     types: [completed]
 
+# Serialize runs for the same head SHA so a CI re-run cancels the
+# in-flight comment from the prior run. Fork PRs don't expose PR number
+# on workflow_run reliably, so head_sha is the stable key.
+concurrency:
+  group: coverage-comment-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,97 @@
+name: Coverage Comment
+
+# Runs after "Rust CI" finishes and posts the sticky coverage comment on
+# the PR. This workflow exists because pull_request events from forks run
+# with a read-only GITHUB_TOKEN, which cannot post comments. workflow_run
+# runs in the context of the base repository on the default branch, so its
+# token can be granted pull-requests: write safely.
+#
+# Security: this workflow must NOT execute or trust any content from the
+# triggering (fork) run. It only consumes the comment body and PR metadata
+# as text, and passes the body through the GitHub API. See:
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+on:
+  workflow_run:
+    workflows: ["Rust CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  post-coverage-comment:
+    name: Post coverage comment
+    runs-on: ubuntu-latest
+    # Only act on PR-triggered CI runs. We don't gate on the workflow's
+    # overall conclusion because we want a coverage comment even when
+    # unrelated jobs (docs, clippy, etc.) fail. Absence of the
+    # coverage-comment artifact is the real signal to skip.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download coverage comment artifact
+        id: comment_artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-comment
+          path: comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true
+      - name: Download PR metadata artifact
+        id: meta_artifact
+        if: steps.comment_artifact.outcome == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-comment-meta
+          path: meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Post or update sticky comment
+        if: steps.comment_artifact.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          MARKER: "<!-- coverage-comment -->"
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="$(tr -d '[:space:]' < meta/pr_number.txt)"
+          ARTIFACT_HEAD_SHA="$(tr -d '[:space:]' < meta/pr_head_sha.txt)"
+
+          # Defensive validation: PR number must be a positive integer, and
+          # the artifact's recorded head SHA must match the workflow_run
+          # head SHA. This keeps a malicious fork from redirecting the
+          # comment at an unrelated PR.
+          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::Invalid PR number in artifact: $PR_NUMBER"
+            exit 1
+          fi
+          if [ "$ARTIFACT_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::Artifact head SHA ($ARTIFACT_HEAD_SHA) does not match workflow_run head SHA ($EXPECTED_HEAD_SHA)"
+            exit 1
+          fi
+
+          # Confirm the PR exists and its head SHA matches.
+          PR_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          if [ "$PR_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "PR #${PR_NUMBER} head has moved (${PR_HEAD_SHA} != ${EXPECTED_HEAD_SHA}); skipping stale comment."
+            exit 0
+          fi
+
+          # Sticky comment: edit the existing one if our marker is present,
+          # otherwise post a new one. Avoids spamming the PR on each push.
+          EXISTING=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+            | head -n 1)
+
+          if [ -n "$EXISTING" ]; then
+            jq -Rs '{body: .}' < comment/comment.md \
+              | gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" --input -
+          else
+            jq -Rs '{body: .}' < comment/comment.md \
+              | gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input -
+          fi


### PR DESCRIPTION
## Problem

PR #234 (from fork `billimek/kei`) didn't get a coverage comment. The coverage job's post step failed with:

```
GraphQL: Resource not accessible by integration (addComment)
Process completed with exit code 1
```

GitHub forces `GITHUB_TOKEN` to read-only for `pull_request` events from forks, no matter what `permissions:` the workflow declares. So `gh pr comment` can't post. The body was still generated and mirrored to the Actions step summary, it just never reached the PR.

## Fix

Split the comment step out to a new workflow that runs on `workflow_run`. `workflow_run` runs in the base repo on the default branch, so its token can be granted `pull-requests: write` safely.

- `ci.yml`: the `coverage` job now only builds `comment.md` and uploads it, plus `pr_number.txt` + `pr_head_sha.txt`, as artifacts. Dropped the `pull-requests: write` permission from this job (no longer needed).
- `coverage-comment.yml` (new): triggered by `workflow_run` on "Rust CI" completion, gated on `event == 'pull_request'`. Downloads the artifacts, posts or updates the sticky marker comment. If the artifact is absent (coverage skipped or failed), the job no-ops.

## Security

`workflow_run` running with write permissions is the documented pattern for this, but it needs care - the artifact comes from a potentially untrusted fork.

- The artifact is only consumed as data. The comment body is piped into `gh api` as a JSON field; no content is executed or evaluated.
- The PR number is validated against `^[1-9][0-9]*$` before use.
- The head SHA recorded in the artifact must match `github.event.workflow_run.head_sha`. This stops a malicious fork from pointing the comment at an unrelated PR.
- Before posting, the workflow re-fetches the PR and confirms its current head SHA still matches. If the PR has since been pushed, the comment is skipped as stale.

## Test plan

- [ ] Open a test PR from a fork; confirm the coverage comment posts.
- [ ] Push a new commit to that PR; confirm the existing comment is edited, not duplicated.
- [ ] Open a same-repo PR; confirm the comment still posts and the sticky upsert still works.
- [ ] Confirm a PR that skips the coverage job (no code changes) produces no comment.