### PR TITLE
Add --bandwidth-limit flag (fixes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`--bandwidth-limit` flag to cap total download throughput.** Accepts human-readable values (`10M`, `500K`, `2Mi`, bare integer = bytes/sec). The cap is global across all concurrent downloads, so total throughput stays within budget regardless of `--threads-num`. Also configurable via `[download] bandwidth_limit` in the TOML config and `KEI_BANDWIDTH_LIMIT` env var. When set without an explicit `--threads-num`, concurrency defaults to 1 so the capped budget isn't fragmented across many starved connections. ([#53])
+
+[#53]: https://github.com/rhoopr/kei/issues/53
+
+---
+
 ## [0.9.2] - 2026-04-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-speed-limit"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c1688bb8e4eb3dcd68a8b0e5a81deae887c67362bb482a902b785e83ac2edc"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-timer",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1463,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "assert_cmd",
+ "async-speed-limit",
  "async-trait",
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ tokio-stream = "0.1"
 tokio-util = "0.7"
 cookie = "0.18"
 
+# Bandwidth throttling (token-bucket for global download rate cap)
+async-speed-limit = "0.4"
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ kei sync --library all
 # Keep syncing every hour
 kei sync --watch-with-interval 3600
 
+# Cap total download throughput (global across all workers)
+kei sync --bandwidth-limit 5M
+
 # --- Inspection ---
 
 # Print filenames to stdout (useful for piping)
@@ -144,6 +147,7 @@ State lives in a SQLite database alongside your session data (see `--data-dir`).
 - Multi-library sync (`--library all` for personal + shared)
 - Flexible password sources: prompt, env var, file, shell command, OS keyring
 - Content filtering: live photo mode, filename globs, album exclusions, date ranges, `--recent N`
+- Bandwidth cap with `--bandwidth-limit` (e.g. `10M`, `500K`, `2Mi`) - global across all concurrent downloads
 - Flexible folder structure with `{album}` token and full strftime support, EXIF datetime stamping
 - Multi-arch Docker images (amd64/arm64) with headless 2FA
 - Notification scripts on events (2FA required, sync complete, failures)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,51 @@ fn non_empty_string(s: &str) -> Result<String, String> {
     }
 }
 
+/// Parse a human-readable byte-rate into bytes per second.
+///
+/// Accepts a leading positive integer followed by an optional unit suffix:
+/// decimal `K`/`M`/`G` (×1000) or binary `Ki`/`Mi`/`Gi` (×1024). Suffix is
+/// case-insensitive. No suffix means bytes/sec. Zero is rejected.
+pub(crate) fn parse_bandwidth_limit(s: &str) -> Result<u64, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err("value must not be empty".to_string());
+    }
+    let digit_end = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    if digit_end == 0 {
+        return Err(format!(
+            "invalid bandwidth value `{s}`: must start with a number"
+        ));
+    }
+    let (num_str, suffix) = trimmed.split_at(digit_end);
+    let n: u64 = num_str
+        .parse()
+        .map_err(|_| format!("invalid bandwidth number `{num_str}`"))?;
+    let multiplier: u64 = match suffix.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "k" | "kb" => 1_000,
+        "m" | "mb" => 1_000_000,
+        "g" | "gb" => 1_000_000_000,
+        "ki" | "kib" => 1_024,
+        "mi" | "mib" => 1_024 * 1_024,
+        "gi" | "gib" => 1_024 * 1_024 * 1_024,
+        other => {
+            return Err(format!(
+                "invalid bandwidth unit `{other}`: expected one of K, M, G, Ki, Mi, Gi"
+            ));
+        }
+    };
+    let bytes_per_sec = n
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("bandwidth value `{s}` overflows u64 bytes/sec"))?;
+    if bytes_per_sec == 0 {
+        return Err("bandwidth limit must be greater than zero".to_string());
+    }
+    Ok(bytes_per_sec)
+}
+
 /// Strip non-digit characters and validate that the result is exactly 6 digits.
 /// Accepts "123456", "123 456", "123-456", etc.
 fn parse_2fa_code(s: &str) -> Result<String, String> {
@@ -91,6 +136,14 @@ pub struct SyncArgs {
     /// Number of concurrent download threads (default: 10)
     #[arg(long = "threads-num", env = "KEI_THREADS_NUM", value_parser = clap::value_parser!(u16).range(1..))]
     pub threads_num: Option<u16>,
+
+    /// Cap total download throughput across all concurrent downloads.
+    /// Accepts human-readable values: `10M` (10 MB/s), `500K` (500 KB/s),
+    /// `1Mi` (1 MiB/s), bare integer = bytes/s. When set without an explicit
+    /// `--threads-num`, concurrency defaults to 1 to avoid fragmenting the
+    /// capped pipe across many starved connections.
+    #[arg(long = "bandwidth-limit", env = "KEI_BANDWIDTH_LIMIT", value_parser = parse_bandwidth_limit)]
+    pub bandwidth_limit: Option<u64>,
 
     /// Don't download videos (pass `false` to override config file)
     #[arg(long, env = "KEI_SKIP_VIDEOS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
@@ -556,6 +609,9 @@ impl SyncArgs {
         }
         if self.threads_num.is_none() {
             self.threads_num = fallback.threads_num;
+        }
+        if self.bandwidth_limit.is_none() {
+            self.bandwidth_limit = fallback.bandwidth_limit;
         }
         if self.skip_videos.is_none() {
             self.skip_videos = fallback.skip_videos;
@@ -1424,6 +1480,54 @@ mod tests {
         let mut args = base_args();
         args.extend(["--threads-num", "0"]);
         assert!(Cli::try_parse_from(&args).is_err());
+    }
+
+    #[test]
+    fn test_bandwidth_limit_bare_bytes() {
+        let mut args = base_args();
+        args.extend(["--bandwidth-limit", "1500000"]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.bandwidth_limit, Some(1_500_000));
+    }
+
+    #[test]
+    fn test_bandwidth_limit_decimal_suffixes() {
+        let mut args = base_args();
+        args.extend(["--bandwidth-limit", "10M"]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.bandwidth_limit, Some(10_000_000));
+    }
+
+    #[test]
+    fn test_bandwidth_limit_binary_suffix() {
+        let mut args = base_args();
+        args.extend(["--bandwidth-limit", "2Mi"]);
+        let cli = parse(&args);
+        assert_eq!(cli.sync.bandwidth_limit, Some(2 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_bandwidth_limit_case_insensitive() {
+        assert_eq!(parse_bandwidth_limit("500k"), Ok(500_000));
+        assert_eq!(parse_bandwidth_limit("500K"), Ok(500_000));
+        assert_eq!(parse_bandwidth_limit("1gib"), Ok(1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_bandwidth_limit_rejects_zero() {
+        let mut args = base_args();
+        args.extend(["--bandwidth-limit", "0"]);
+        assert!(Cli::try_parse_from(&args).is_err());
+        assert!(parse_bandwidth_limit("0K").is_err());
+    }
+
+    #[test]
+    fn test_bandwidth_limit_rejects_invalid() {
+        assert!(parse_bandwidth_limit("").is_err());
+        assert!(parse_bandwidth_limit("abc").is_err());
+        assert!(parse_bandwidth_limit("10X").is_err());
+        assert!(parse_bandwidth_limit("-5M").is_err());
+        assert!(parse_bandwidth_limit("1.5M").is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3290,6 +3290,40 @@ mod tests {
         assert!(toml.photos.as_ref().unwrap().live_photo_mode.is_none());
     }
 
+    #[test]
+    fn test_to_toml_roundtrip_bandwidth_limit() {
+        let mut sync = default_sync();
+        sync.bandwidth_limit = Some(5_000_000);
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        let serialized = cfg.to_toml();
+        assert_eq!(
+            serialized
+                .download
+                .as_ref()
+                .unwrap()
+                .bandwidth_limit
+                .as_deref(),
+            Some("5000000")
+        );
+
+        let reparsed = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(serialized),
+        )
+        .unwrap();
+        assert_eq!(reparsed.bandwidth_limit, Some(5_000_000));
+    }
+
+    #[test]
+    fn test_to_toml_bandwidth_limit_none_omitted() {
+        let cfg =
+            Config::build(&default_globals(), default_password(), default_sync(), None).unwrap();
+        let toml = cfg.to_toml();
+        assert!(toml.download.as_ref().unwrap().bandwidth_limit.is_none());
+    }
+
     // ── TOML-only skip_live_photos legacy path ──────────────────────
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,7 @@ pub(crate) struct TomlDownload {
     pub directory: Option<String>,
     pub folder_structure: Option<String>,
     pub threads_num: Option<u16>,
+    pub bandwidth_limit: Option<String>,
     pub temp_suffix: Option<String>,
     pub set_exif_datetime: Option<bool>,
     pub no_progress_bar: Option<bool>,
@@ -210,6 +211,9 @@ pub struct Config {
     // 4-byte primitives
     pub recent: Option<u32>,
     pub max_retries: u32,
+
+    // 8-byte primitives (cont.)
+    pub bandwidth_limit: Option<u64>,
 
     // 2-byte primitives
     pub threads_num: u16,
@@ -505,7 +509,32 @@ impl Config {
             toml_dl.and_then(|d| d.folder_structure.clone()),
             "%Y/%m/%d".to_string(),
         );
-        let threads_num = resolve(sync.threads_num, toml_dl.and_then(|d| d.threads_num), 10);
+        // Resolve bandwidth limit (CLI bytes/sec > TOML human-readable string > None).
+        let bandwidth_limit: Option<u64> = if let Some(n) = sync.bandwidth_limit {
+            Some(n)
+        } else if let Some(s) = toml_dl.and_then(|d| d.bandwidth_limit.as_ref()) {
+            Some(crate::cli::parse_bandwidth_limit(s).map_err(|e| {
+                anyhow::anyhow!("invalid [download].bandwidth_limit in config: {e}")
+            })?)
+        } else {
+            None
+        };
+
+        // When a bandwidth limit is set without an explicit --threads-num,
+        // default concurrency to 1: many connections starving for a capped
+        // total budget just fragments downloads and adds connection overhead.
+        let threads_explicitly_set =
+            sync.threads_num.is_some() || toml_dl.and_then(|d| d.threads_num).is_some();
+        let threads_default = if bandwidth_limit.is_some() && !threads_explicitly_set {
+            1
+        } else {
+            10
+        };
+        let threads_num = resolve(
+            sync.threads_num,
+            toml_dl.and_then(|d| d.threads_num),
+            threads_default,
+        );
         anyhow::ensure!(
             threads_num >= 1,
             "threads_num must be >= 1, got {threads_num}"
@@ -710,6 +739,7 @@ impl Config {
             retry_delay_secs,
             recent,
             max_retries,
+            bandwidth_limit,
             threads_num,
             size,
             live_photo_size,
@@ -770,6 +800,7 @@ impl Config {
                 },
                 folder_structure: Some(self.folder_structure.clone()),
                 threads_num: Some(self.threads_num),
+                bandwidth_limit: self.bandwidth_limit.map(|n| n.to_string()),
                 temp_suffix: if self.temp_suffix == ".kei-tmp" {
                     None
                 } else {
@@ -945,6 +976,7 @@ pub(crate) fn persist_first_run_config(
             directory: d.directory,
             folder_structure: None,
             threads_num: None,
+            bandwidth_limit: None,
             temp_suffix: None,
             set_exif_datetime: None,
             no_progress_bar: None,
@@ -1360,6 +1392,118 @@ mod tests {
             Config::build(&default_globals(), default_password(), default_sync(), None).unwrap();
         assert_eq!(cfg.threads_num, 10);
         assert!(matches!(cfg.align_raw, RawTreatmentPolicy::Unchanged));
+    }
+
+    #[test]
+    fn test_build_bandwidth_limit_resolution() {
+        struct Case {
+            name: &'static str,
+            cli: Option<u64>,
+            toml_cli_threads: Option<u16>,
+            toml: Option<&'static str>,
+            toml_threads: Option<u16>,
+            want_limit: Option<u64>,
+            want_threads: u16,
+        }
+        let cases = [
+            Case {
+                name: "cli sets limit, threads defaults to 1",
+                cli: Some(5_000_000),
+                toml_cli_threads: None,
+                toml: None,
+                toml_threads: None,
+                want_limit: Some(5_000_000),
+                want_threads: 1,
+            },
+            Case {
+                name: "toml string parses into u64",
+                cli: None,
+                toml_cli_threads: None,
+                toml: Some("2M"),
+                toml_threads: None,
+                want_limit: Some(2_000_000),
+                want_threads: 1,
+            },
+            Case {
+                name: "cli overrides toml",
+                cli: Some(10_000_000),
+                toml_cli_threads: None,
+                toml: Some("1M"),
+                toml_threads: None,
+                want_limit: Some(10_000_000),
+                want_threads: 1,
+            },
+            Case {
+                name: "explicit cli threads overrides auto-1",
+                cli: Some(500_000),
+                toml_cli_threads: Some(4),
+                toml: None,
+                toml_threads: None,
+                want_limit: Some(500_000),
+                want_threads: 4,
+            },
+            Case {
+                name: "toml threads overrides auto-1",
+                cli: None,
+                toml_cli_threads: None,
+                toml: Some("1M"),
+                toml_threads: Some(3),
+                want_limit: Some(1_000_000),
+                want_threads: 3,
+            },
+            Case {
+                name: "no limit keeps default 10 threads",
+                cli: None,
+                toml_cli_threads: None,
+                toml: None,
+                toml_threads: None,
+                want_limit: None,
+                want_threads: 10,
+            },
+        ];
+
+        for case in cases {
+            let toml = match (case.toml, case.toml_threads) {
+                (None, None) => None,
+                (limit, threads) => {
+                    let mut body = "[download]\n".to_string();
+                    if let Some(l) = limit {
+                        body.push_str(&format!("bandwidth_limit = \"{l}\"\n"));
+                    }
+                    if let Some(t) = threads {
+                        body.push_str(&format!("threads_num = {t}\n"));
+                    }
+                    Some(toml::from_str::<TomlConfig>(&body).unwrap())
+                }
+            };
+            let mut sync = default_sync();
+            sync.bandwidth_limit = case.cli;
+            sync.threads_num = case.toml_cli_threads;
+            let cfg = Config::build(&default_globals(), default_password(), sync, toml)
+                .unwrap_or_else(|e| panic!("{}: build failed: {e}", case.name));
+            assert_eq!(cfg.bandwidth_limit, case.want_limit, "{}", case.name);
+            assert_eq!(cfg.threads_num, case.want_threads, "{}", case.name);
+        }
+    }
+
+    #[test]
+    fn test_build_bandwidth_limit_invalid_toml_rejected() {
+        let toml_str = r#"
+            [download]
+            bandwidth_limit = "not_a_value"
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let err = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .expect_err("invalid bandwidth_limit should fail build");
+        assert!(
+            err.to_string().contains("bandwidth_limit"),
+            "error should mention bandwidth_limit: {err}"
+        );
     }
 
     #[test]

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -10,6 +10,7 @@ use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 
 use super::error::DownloadError;
+use super::limiter::BandwidthLimiter;
 use crate::retry::{self, RetryAction, RetryConfig};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -109,6 +110,7 @@ pub(super) async fn download_file<C: DownloadClient>(
     retry_config: &RetryConfig,
     temp_suffix: &str,
     opts: DownloadOpts,
+    bandwidth_limiter: Option<&BandwidthLimiter>,
 ) -> Result<u64, DownloadError> {
     let part_path =
         temp_download_path(download_path, checksum, temp_suffix).map_err(DownloadError::Other)?;
@@ -130,6 +132,7 @@ pub(super) async fn download_file<C: DownloadClient>(
                 &part_path,
                 opts.skip_rename,
                 opts.expected_size,
+                bandwidth_limiter,
             ))
             .await
         },
@@ -152,6 +155,7 @@ async fn attempt_download<C: DownloadClient>(
     part_path: &Path,
     skip_rename: bool,
     expected_size: Option<u64>,
+    bandwidth_limiter: Option<&BandwidthLimiter>,
 ) -> Result<u64, DownloadError> {
     let path_str = download_path.display().to_string();
 
@@ -274,6 +278,9 @@ async fn attempt_download<C: DownloadClient>(
                 content_length,
                 bytes_written,
             })?;
+            if let Some(limiter) = bandwidth_limiter {
+                limiter.consume(chunk.len()).await;
+            }
             file.write_all(&chunk).await?;
             bytes_written += chunk.len() as u64;
         }
@@ -1052,6 +1059,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1076,6 +1084,7 @@ mod tests {
             &download_path,
             &part_path,
             true,
+            None,
             None,
         )
         .await
@@ -1105,6 +1114,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -1131,6 +1141,7 @@ mod tests {
             &part_path,
             false,
             Some(1024),
+            None,
         )
         .await
         .unwrap_err();
@@ -1155,6 +1166,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
         )
         .await
@@ -1182,6 +1194,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
         )
         .await
@@ -1217,6 +1230,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1244,6 +1258,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1268,6 +1283,7 @@ mod tests {
             &part_path,
             false,
             Some(body.len() as u64),
+            None,
         )
         .await
         .unwrap();
@@ -1321,6 +1337,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
         )
         .await
@@ -1416,6 +1433,7 @@ mod tests {
                 skip_rename: false,
                 expected_size: None,
             },
+            None,
         )
         .await;
 
@@ -1476,6 +1494,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -1507,6 +1526,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1527,6 +1547,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1546,6 +1567,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
         )
         .await
@@ -1588,6 +1610,7 @@ mod tests {
                     skip_rename: false,
                     expected_size: None,
                 },
+                None,
             )
             .await;
             (result, download_path, dir)
@@ -1742,11 +1765,71 @@ mod tests {
                     skip_rename: false,
                     expected_size: None,
                 },
+                None,
             )
             .await
             .unwrap();
 
             assert_eq!(std::fs::read(&download_path).unwrap(), full_body);
+        }
+
+        /// End-to-end throttle test: pull a fixed payload through `download_file`
+        /// with a real HTTP server and assert wall-clock elapsed time at least
+        /// approaches what the cap predicts.
+        #[tokio::test]
+        async fn bandwidth_limiter_throttles_download() {
+            use std::time::Instant;
+
+            // 64 KiB at 64 KiB/s -> expect ~1s. Lenient lower bound
+            // (>= expected * 0.6) so CI jitter doesn't flake; overshoot is
+            // fine because it only means the limiter is stricter than required.
+            let body_size = 64 * 1024usize;
+            let body = vec![0xAAu8; body_size];
+            let limit = 64 * 1024u64;
+            let expected_secs = body_size as f64 / limit as f64;
+
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/throttle.bin"))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+                .mount(&server)
+                .await;
+
+            let checksum = base64::engine::general_purpose::STANDARD.encode([0xAAu8; 32]);
+            let dir = TempDir::new().unwrap();
+            let download_path = dir.path().join("throttle.bin");
+            let config = RetryConfig {
+                max_retries: 0,
+                base_delay_secs: 0,
+                max_delay_secs: 0,
+            };
+            let limiter = BandwidthLimiter::new(limit);
+
+            let start = Instant::now();
+            let bytes = download_file(
+                &reqwest::Client::new(),
+                &format!("{}/throttle.bin", server.uri()),
+                &download_path,
+                &checksum,
+                &config,
+                ".kei-tmp",
+                DownloadOpts {
+                    skip_rename: false,
+                    expected_size: Some(body_size as u64),
+                },
+                Some(&limiter),
+            )
+            .await
+            .expect("throttled download succeeds");
+            let elapsed = start.elapsed().as_secs_f64();
+
+            assert_eq!(bytes, body_size as u64);
+            assert!(
+                elapsed >= expected_secs * 0.6,
+                "elapsed {elapsed:.2}s under {limit} B/s cap for {body_size} B \
+                 should be close to expected {expected_secs:.2}s",
+            );
+            assert_eq!(std::fs::read(&download_path).unwrap().len(), body_size);
         }
     }
 
@@ -1914,6 +1997,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap_err();
@@ -1947,6 +2031,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
         )
         .await
@@ -1990,6 +2075,7 @@ mod tests {
             &part_path,
             false,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2020,6 +2106,7 @@ mod tests {
             &part_path,
             false,
             Some(1024), // API says 1024 but download is 8
+            None,
         )
         .await
         .unwrap_err();
@@ -2054,6 +2141,7 @@ mod tests {
             &download_path,
             &part_path,
             false,
+            None,
             None,
         )
         .await

--- a/src/download/limiter.rs
+++ b/src/download/limiter.rs
@@ -13,12 +13,12 @@
 use async_speed_limit::{clock::StandardClock, Limiter};
 
 #[derive(Clone)]
-pub struct BandwidthLimiter {
+pub(crate) struct BandwidthLimiter {
     inner: Limiter<StandardClock>,
 }
 
 impl BandwidthLimiter {
-    pub fn new(bytes_per_sec: u64) -> Self {
+    pub(crate) fn new(bytes_per_sec: u64) -> Self {
         Self {
             inner: <Limiter>::builder(bytes_per_sec as f64).build(),
         }
@@ -28,11 +28,11 @@ impl BandwidthLimiter {
     ///
     /// The underlying limiter handles oversized requests correctly: a chunk
     /// larger than one bucket refill simply waits longer.
-    pub async fn consume(&self, n: usize) {
+    pub(crate) async fn consume(&self, n: usize) {
         self.inner.consume(n).await;
     }
 
-    pub fn bytes_per_sec(&self) -> u64 {
+    pub(crate) fn bytes_per_sec(&self) -> u64 {
         self.inner.speed_limit() as u64
     }
 }

--- a/src/download/limiter.rs
+++ b/src/download/limiter.rs
@@ -1,0 +1,90 @@
+//! Global bandwidth throttle for download streams.
+//!
+//! A single shared token bucket caps total byte throughput across every
+//! concurrent download. Wraps `async_speed_limit::Limiter` so the rest of
+//! the crate can hold a typed newtype rather than depending on that crate
+//! at call sites.
+//!
+//! Build one [`BandwidthLimiter`] per sync, share it by value (it's `Clone`
+//! and the underlying bucket is already shared), and call
+//! [`BandwidthLimiter::consume`] before writing each received chunk. When no
+//! limit is configured, downloads hold `None` and skip the call entirely.
+
+use async_speed_limit::{clock::StandardClock, Limiter};
+
+#[derive(Clone)]
+pub struct BandwidthLimiter {
+    inner: Limiter<StandardClock>,
+}
+
+impl BandwidthLimiter {
+    pub fn new(bytes_per_sec: u64) -> Self {
+        Self {
+            inner: <Limiter>::builder(bytes_per_sec as f64).build(),
+        }
+    }
+
+    /// Block the caller until `n` bytes of budget are available.
+    ///
+    /// The underlying limiter handles oversized requests correctly: a chunk
+    /// larger than one bucket refill simply waits longer.
+    pub async fn consume(&self, n: usize) {
+        self.inner.consume(n).await;
+    }
+
+    pub fn bytes_per_sec(&self) -> u64 {
+        self.inner.speed_limit() as u64
+    }
+}
+
+impl std::fmt::Debug for BandwidthLimiter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BandwidthLimiter")
+            .field("bytes_per_sec", &self.bytes_per_sec())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[tokio::test]
+    async fn consume_under_limit_is_fast() {
+        let limiter = BandwidthLimiter::new(10_000_000);
+        let start = Instant::now();
+        limiter.consume(1_000).await;
+        assert!(
+            start.elapsed().as_millis() < 100,
+            "small consume under a generous limit should not block"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_enforces_rate() {
+        let limit = 64 * 1024;
+        let limiter = BandwidthLimiter::new(limit);
+        let start = Instant::now();
+        let total = 64 * 1024;
+        let chunk = 8 * 1024;
+        let mut remaining = total;
+        while remaining > 0 {
+            let take = remaining.min(chunk);
+            limiter.consume(take).await;
+            remaining -= take;
+        }
+        let elapsed = start.elapsed().as_secs_f64();
+        let expected = total as f64 / limit as f64;
+        assert!(
+            elapsed >= expected * 0.6,
+            "elapsed {elapsed:.2}s should be close to expected {expected:.2}s"
+        );
+    }
+
+    #[test]
+    fn bytes_per_sec_reports_configured_limit() {
+        let limiter = BandwidthLimiter::new(500_000);
+        assert_eq!(limiter.bytes_per_sec(), 500_000);
+    }
+}

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -7,8 +7,11 @@ pub mod error;
 pub mod exif;
 pub mod file;
 pub(crate) mod filter;
+pub(crate) mod limiter;
 pub mod paths;
 pub(crate) mod pipeline;
+
+pub(crate) use limiter::BandwidthLimiter;
 
 use pipeline::{
     build_download_outcome, format_duration, log_sync_summary, run_download_pass,
@@ -391,6 +394,9 @@ pub(crate) struct DownloadConfig {
     pub(crate) exclude_asset_ids: Arc<FxHashSet<String>>,
     /// Maximum download attempts per asset before giving up (0 = unlimited).
     pub(crate) max_download_attempts: u32,
+    /// Shared token-bucket limiter applied across all concurrent download
+    /// streams. `None` = no throughput cap.
+    pub(crate) bandwidth_limiter: Option<BandwidthLimiter>,
 }
 
 impl DownloadConfig {
@@ -410,6 +416,7 @@ impl DownloadConfig {
             state_db: self.state_db.clone(),
             sync_mode: self.sync_mode.clone(),
             exclude_asset_ids: Arc::clone(&self.exclude_asset_ids),
+            bandwidth_limiter: self.bandwidth_limiter.clone(),
             ..*self
         }
     }
@@ -450,6 +457,7 @@ impl std::fmt::Debug for DownloadConfig {
             .field("album_name", &self.album_name)
             .field("exclude_asset_ids_count", &self.exclude_asset_ids.len())
             .field("max_download_attempts", &self.max_download_attempts)
+            .field("bandwidth_limiter", &self.bandwidth_limiter)
             .finish()
     }
 }
@@ -489,6 +497,7 @@ impl DownloadConfig {
             sync_mode: SyncMode::Full,
             album_name: None,
             exclude_asset_ids: std::sync::Arc::new(FxHashSet::default()),
+            bandwidth_limiter: None,
         }
     }
 }
@@ -1283,6 +1292,7 @@ async fn download_photos_incremental(
         temp_suffix: config.temp_suffix.clone(),
         shutdown_token,
         state_db: config.state_db.clone(),
+        bandwidth_limiter: config.bandwidth_limiter.clone(),
     };
     let pass_result = run_download_pass(pass_config, tasks).await;
 
@@ -1801,6 +1811,7 @@ mod tests {
             retry_delay_secs: 5,
             recent: dl_config.recent,
             max_retries: 3,
+            bandwidth_limit: None,
             threads_num: 1,
             size: VersionSize::Original,
             live_photo_size: LivePhotoSize::Original,

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -251,6 +251,7 @@ pub(super) struct PassConfig<'a> {
     pub(super) temp_suffix: String,
     pub(super) shutdown_token: CancellationToken,
     pub(super) state_db: Option<Arc<dyn StateDb>>,
+    pub(super) bandwidth_limiter: Option<super::BandwidthLimiter>,
 }
 
 impl std::fmt::Debug for PassConfig<'_> {
@@ -784,10 +785,12 @@ where
     });
 
     let temp_suffix: Arc<str> = config.temp_suffix.clone().into();
+    let bandwidth_limiter = config.bandwidth_limiter.clone();
     let download_stream = ReceiverStream::new(task_rx)
         .map(|task| {
             let client = download_client.clone();
             let temp_suffix = Arc::clone(&temp_suffix);
+            let bandwidth_limiter = bandwidth_limiter.clone();
             async move {
                 let result = Box::pin(download_single_task(
                     &client,
@@ -795,6 +798,7 @@ where
                     &retry_config,
                     set_exif,
                     &temp_suffix,
+                    bandwidth_limiter.as_ref(),
                 ))
                 .await;
                 (task, result)
@@ -1095,6 +1099,7 @@ pub(super) async fn build_download_outcome(
         temp_suffix: config.temp_suffix.clone(),
         shutdown_token: shutdown_token.clone(),
         state_db: config.state_db.clone(),
+        bandwidth_limiter: config.bandwidth_limiter.clone(),
     };
     let pass_result = run_download_pass(pass_config, fresh_tasks).await;
 
@@ -1179,6 +1184,7 @@ pub(super) async fn run_download_pass(
     let shutdown_token = config.shutdown_token.clone();
     let concurrency = config.concurrency;
     let temp_suffix: Arc<str> = config.temp_suffix.into();
+    let bandwidth_limiter = config.bandwidth_limiter.clone();
 
     type DownloadResult = (
         DownloadTask,
@@ -1189,6 +1195,7 @@ pub(super) async fn run_download_pass(
         .map(|task| {
             let client = client.clone();
             let temp_suffix = Arc::clone(&temp_suffix);
+            let bandwidth_limiter = bandwidth_limiter.clone();
             async move {
                 let result = Box::pin(download_single_task(
                     &client,
@@ -1196,6 +1203,7 @@ pub(super) async fn run_download_pass(
                     retry_config,
                     set_exif,
                     &temp_suffix,
+                    bandwidth_limiter.as_ref(),
                 ))
                 .await;
                 (task, result)
@@ -1308,6 +1316,7 @@ async fn download_single_task(
     retry_config: &RetryConfig,
     set_exif: bool,
     temp_suffix: &str,
+    bandwidth_limiter: Option<&super::BandwidthLimiter>,
 ) -> Result<(bool, String, Option<String>, u64, u64)> {
     if let Some(parent) = task.download_path.parent() {
         tokio::fs::create_dir_all(parent)
@@ -1343,6 +1352,7 @@ async fn download_single_task(
             skip_rename: needs_exif,
             expected_size: if task.size > 0 { Some(task.size) } else { None },
         },
+        bandwidth_limiter,
     ))
     .await?;
 
@@ -1755,6 +1765,7 @@ mod tests {
                             temp_suffix: ".kei-tmp".to_string(),
                             shutdown_token: token,
                             state_db: None,
+                            bandwidth_limiter: None,
                         };
                         let result = run_download_pass(pass_config, tasks).await;
                         assert!(result.failed.is_empty());
@@ -1804,6 +1815,7 @@ mod tests {
                             temp_suffix: ".kei-tmp".to_string(),
                             shutdown_token: token,
                             state_db: None,
+                            bandwidth_limiter: None,
                         };
                         let result = run_download_pass(pass_config, tasks).await;
                         assert_eq!(result.failed.len(), 1);
@@ -2243,6 +2255,7 @@ mod tests {
             sync_mode: SyncMode::Full,
             album_name: None,
             exclude_asset_ids: Arc::new(FxHashSet::default()),
+            bandwidth_limiter: None,
         });
 
         let client = reqwest::Client::builder()
@@ -2313,6 +2326,7 @@ mod tests {
             sync_mode: SyncMode::Full,
             album_name: None,
             exclude_asset_ids: Arc::new(FxHashSet::default()),
+            bandwidth_limiter: None,
         });
         let client = reqwest::Client::new();
         let shutdown_token = CancellationToken::new();

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -359,8 +359,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     let retry_config = api_retry_config;
     let live_photo_size = config.live_photo_size.to_asset_version_size();
     // One shared limiter per sync run so the configured cap applies to
-    // aggregate throughput across every concurrent download. The inner
-    // token bucket is already shared across clones, so no Arc is needed.
+    // aggregate throughput across every concurrent download.
     let bandwidth_limiter = config
         .bandwidth_limit
         .map(download::limiter::BandwidthLimiter::new);

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -358,6 +358,18 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         .map(|d| d.with_timezone(&chrono::Utc));
     let retry_config = api_retry_config;
     let live_photo_size = config.live_photo_size.to_asset_version_size();
+    // One shared limiter per sync run so the configured cap applies to
+    // aggregate throughput across every concurrent download. The inner
+    // token bucket is already shared across clones, so no Arc is needed.
+    let bandwidth_limiter = config
+        .bandwidth_limit
+        .map(download::limiter::BandwidthLimiter::new);
+    if let Some(limiter) = &bandwidth_limiter {
+        tracing::info!(
+            bytes_per_sec = limiter.bytes_per_sec(),
+            "Bandwidth limit enabled"
+        );
+    }
     let build_download_config = |sync_mode: download::SyncMode,
                                  exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>|
      -> Arc<download::DownloadConfig> {
@@ -391,6 +403,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             sync_mode,
             album_name: None,
             exclude_asset_ids,
+            bandwidth_limiter: bandwidth_limiter.clone(),
         })
     };
 


### PR DESCRIPTION
## Summary

- New `--bandwidth-limit` flag caps total download throughput across every concurrent download. Accepts `10M` / `500K` / `2Mi` / bare bytes-per-sec. Also reads `[download].bandwidth_limit` from TOML and `KEI_BANDWIDTH_LIMIT` from env.
- Global token bucket via `async-speed-limit`, built once per sync run. The cap applies to aggregate throughput regardless of `--threads-num`.
- When the flag is set without an explicit `--threads-num`, concurrency defaults to 1 so the capped budget doesn't fragment across many starved connections. Explicit threads (CLI or TOML) always win.
- Throttle applied in the chunk loop of `attempt_download` before each write. Range resume, Content-Length / magic-byte / SHA256 checks, EXIF, and `.part` atomic rename are untouched.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bin kei` (1314 tests pass)
- [x] `cargo test --test cli` (95 tests pass)
- [x] Parser unit tests (`10M`, `500K`, `2Mi`, case-insensitive, reject `0`, reject `abc`/`1.5M`/`-5M`)
- [x] Config resolution table test (CLI only, TOML only, CLI over TOML, explicit CLI threads, explicit TOML threads, no limit default)
- [x] Invalid TOML string rejected with error mentioning `bandwidth_limit`
- [x] Limiter unit tests: under-limit is fast, enforces rate at the configured cap
- [x] Wiremock end-to-end: 64 KiB through a 64 KiB/s cap takes at least ~0.6s, file content matches

Closes #53