### PR TITLE
Add -a all and smart {album} expansion (fixes #215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`--bandwidth-limit` flag to cap total download throughput.** Accepts human-readable values (`10M`, `500K`, `2Mi`, bare integer = bytes/sec). The cap is global across all concurrent downloads, so total throughput stays within budget regardless of `--threads-num`. Also configurable via `[download] bandwidth_limit` in the TOML config and `KEI_BANDWIDTH_LIMIT` env var. When set without an explicit `--threads-num`, concurrency defaults to 1 so the capped budget isn't fragmented across many starved connections. ([#53])
 
+- **`-a all` to sync every user-created album in one run.** Case-insensitive, works as a CLI flag, `KEI_ALBUM` env var, or `filters.albums = ["all"]` in TOML. Apple's smart folders (Favorites, Screenshots, Videos, Hidden, Recently Deleted, etc.) are skipped - list them explicitly with `-a Favorites` if you want them. Combining `-a all` with specific names is rejected with "cannot combine 'all' with specific album names". ([#215])
+
+- **Smart `{album}` auto-expansion in `--folder-structure`.** When the template contains `{album}` and no `-a` flag is passed, kei implicitly runs `-a all`. In either mode (explicit `-a all` or implicit via template), using `{album}` in the template adds a library-wide pass for photos that aren't in any user-created album - `{album}` collapses to empty for those, so `{album}/%Y/%m/%d` puts unfiled photos at `%Y/%m/%d/`. Without `{album}` in the template, `-a all` skips unfiled photos entirely. Photos that belong to multiple albums are copied into each album folder. ([#215])
+
+- **`{album}` placement validation.** `{album}` must be the first path segment in `--folder-structure` and may only appear once. `{album}/%Y/%m` is fine; `Photos/{album}/%Y`, `%Y/{album}/%m`, and `{album}/%Y/{album}` are rejected at startup with a quoted error message. The restriction keeps unfiled-photo paths stable - without it, collapsing `{album}` shifts segments around and the unfiled tree no longer matches the album tree. ([#215])
+
+### Known limitations
+
+- The state DB tracks a single download path per asset. A photo copied to multiple album folders under `{album}/...` has all copies on disk, but the DB records only the most recently written path. Re-running sync stays idempotent because kei's filesystem-exists check is path-aware - it won't re-download files it already put on disk, regardless of which path the DB currently holds.
+
 [#53]: https://github.com/rhoopr/kei/issues/53
+[#215]: https://github.com/rhoopr/kei/issues/215
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,7 +105,10 @@ pub struct SyncArgs {
     #[arg(short = 'd', long, env = "KEI_DIRECTORY", value_parser = non_empty_string)]
     pub directory: Option<String>,
 
-    /// Album(s) to download
+    /// Album(s) to download. Use `-a all` to sync every user-created album
+    /// in one run (Apple's smart folders like "Favorites" are skipped —
+    /// name them explicitly if you want them). `-a all` cannot be combined
+    /// with specific album names.
     #[arg(short = 'a', long = "album", env = "KEI_ALBUM", value_parser = non_empty_string)]
     pub albums: Vec<String>,
 
@@ -165,7 +168,11 @@ pub struct SyncArgs {
     #[arg(long, env = "KEI_FORCE_SIZE", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub force_size: Option<bool>,
 
-    /// Folder structure for organizing downloads (e.g., "%Y/%m/%d", "{album}/%Y/%B", "none")
+    /// Folder structure for organizing downloads (e.g., "%Y/%m/%d",
+    /// "{album}/%Y/%B", "none"). `{album}` must be the first segment and
+    /// may only appear once. When `{album}` is used without `-a`, kei
+    /// auto-syncs every user-created album plus a library-wide pass for
+    /// unfiled photos (where `{album}` collapses to empty).
     #[arg(long, env = "KEI_FOLDER_STRUCTURE")]
     pub folder_structure: Option<String>,
 
@@ -1849,6 +1856,15 @@ mod tests {
     fn test_albums_empty_by_default() {
         let cli = parse(&base_args());
         assert!(cli.sync.albums.is_empty());
+    }
+
+    #[test]
+    fn test_album_all_accepted() {
+        let mut args = base_args();
+        args.extend(["-a", "all"]);
+        let cli = parse(&args);
+        // CLI layer stays dumb: Config::build interprets "all".
+        assert_eq!(cli.sync.albums, vec!["all"]);
     }
 
     // ── Input validation ───────────────────────────────────────────

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use password::run_password;
 pub(crate) use reset::{run_reset_state, run_reset_sync_token};
 pub(crate) use service::{
     attempt_reauth, init_photos_service, resolve_albums, resolve_libraries, wait_and_retry_2fa,
-    MAX_REAUTH_ATTEMPTS,
+    AlbumPass, AlbumPlan, MAX_REAUTH_ATTEMPTS,
 };
 pub(crate) use status::run_status;
 pub(crate) use verify::run_verify;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -447,8 +447,9 @@ pub(crate) async fn resolve_albums(
             })
         }
         config::AlbumSelection::Named(names) => {
-            // Dedup names so callers passing the same album twice get a
-            // single download pass, not an error.
+            // Dedup names: passing the same album twice should collapse to
+            // a single pass, not error out after the first remove()
+            // drained the map.
             let mut album_map = library.albums().await?;
             let mut passes = Vec::new();
             let mut seen = rustc_hash::FxHashSet::default();
@@ -473,12 +474,11 @@ pub(crate) async fn resolve_albums(
             Ok(AlbumPlan { passes })
         }
         config::AlbumSelection::All => {
-            // Filter smart folders (Favorites, Screenshots, Videos, etc.)
-            // out of the expansion. The issue requester wanted "my albums",
-            // meaning user-created folders — surfacing Apple's smart folders
-            // as download targets would be surprising and create confusing
-            // directories like "Recently Deleted" or "Hidden". Users who
-            // explicitly want a smart folder can still name it: `-a Favorites`.
+            // Smart folders (Favorites, Recently Deleted, Hidden, etc.) are
+            // skipped: the feature request asked for user-created albums,
+            // and surfacing Apple's system folders as download targets
+            // creates confusing trees. Users who want one can still name
+            // it explicitly via `-a Favorites`.
             let smart_folder_names: rustc_hash::FxHashSet<&'static str> =
                 icloud::photos::smart_folders::smart_folders()
                     .into_iter()
@@ -492,25 +492,20 @@ pub(crate) async fn resolve_albums(
                 .collect();
             let has_album_token = folder_structure.contains("{album}");
 
-            // Pre-compute the "in any user album" set BEFORE consuming the
-            // map, so the unfiled pass (if any) can skip anything that
-            // already belongs to a concrete user album — including albums
-            // excluded via --exclude-album (the user explicitly asked to
-            // skip those photos, so they must not fall through to unfiled).
+            // Collect every user album's members (including --exclude-album
+            // ones) into the unfiled exclusion set before consuming the
+            // map. Excluded albums must contribute too, otherwise their
+            // photos would leak out through the library-wide unfiled pass.
             let mut in_any_album: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
             if has_album_token {
                 for (name, album) in &album_map {
-                    tracing::debug!(
-                        album = name,
-                        "Pre-fetching album asset IDs for unfiled exclusion set"
-                    );
+                    tracing::debug!(album = name, "Pre-fetching IDs for unfiled exclusion set");
                     collect_album_asset_ids(album, &mut in_any_album).await?;
                 }
             }
 
-            // Sort by name for deterministic ordering — HashMap iteration
-            // order is not stable and users inspecting logs or dry-run
-            // output want consistency across runs.
+            // Sort by name — HashMap iteration is non-deterministic and
+            // logs/dry-run output should be stable across runs.
             let mut named_albums: Vec<(String, icloud::photos::PhotoAlbum)> =
                 album_map.into_iter().collect();
             named_albums.sort_by(|a, b| a.0.cmp(&b.0));

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -403,19 +403,19 @@ async fn collect_album_asset_ids(
 /// The returned [`AlbumPlan`] contains one or more passes, each paired with
 /// its own exclude-asset-ids set:
 ///
-/// - [`AlbumSelection::LibraryOnly`] returns a single library-wide pass.
+/// - [`config::AlbumSelection::LibraryOnly`] returns a single library-wide pass.
 ///   `--exclude-album X` without `--album` populates the pass's exclude set
 ///   with X's members so they don't leak through the library-wide stream.
-/// - [`AlbumSelection::Named`] returns one pass per matched album, minus
+/// - [`config::AlbumSelection::Named`] returns one pass per matched album, minus
 ///   anything in `exclude_albums`. Missing names are a hard error.
-/// - [`AlbumSelection::All`] returns one pass per discovered album (minus
+/// - [`config::AlbumSelection::All`] returns one pass per discovered album (minus
 ///   `exclude_albums`). When `{album}` is in `folder_structure`, an extra
 ///   library-wide "unfiled" pass is appended; its exclude set is the union
 ///   of every discovered album's members (including excluded ones — users
 ///   explicitly asked to skip those, so they must not fall through to the
 ///   unfiled pass either).
 ///
-/// `folder_structure` is consulted only for `AlbumSelection::All`, to decide
+/// `folder_structure` is consulted only for `config::AlbumSelection::All`, to decide
 /// whether to add the unfiled pass.
 pub(crate) async fn resolve_albums(
     library: &icloud::photos::PhotoLibrary,

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -341,77 +341,208 @@ pub(crate) async fn resolve_libraries(
     }
 }
 
-/// Resolve which albums to download from, plus any asset IDs to exclude.
+/// One pass through a specific album (or the library-wide pseudo-album).
 ///
-/// When no `--album` names are specified, returns `library.all()` (a cheap
-/// in-memory construction, no API call). When names are given, calls
-/// `library.albums().await` to discover user-created albums from iCloud.
+/// `exclude_ids` is the per-pass set of asset IDs to filter out. Most passes
+/// carry an empty set; the library-wide pass may pre-populate it with every
+/// album member (for the `-a all` + `{album}` unfiled pass) or with excluded
+/// albums' members (for `--exclude-album` without `--album`).
+pub(crate) struct AlbumPass {
+    pub album: icloud::photos::PhotoAlbum,
+    pub exclude_ids: std::sync::Arc<rustc_hash::FxHashSet<String>>,
+}
+
+/// Ordered list of download passes for a single library.
+#[derive(Debug)]
+pub(crate) struct AlbumPlan {
+    pub passes: Vec<AlbumPass>,
+}
+
+impl std::fmt::Debug for AlbumPass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlbumPass")
+            .field("album_name", &self.album.name)
+            .field("exclude_ids_len", &self.exclude_ids.len())
+            .finish()
+    }
+}
+
+fn empty_exclude_ids() -> std::sync::Arc<rustc_hash::FxHashSet<String>> {
+    std::sync::Arc::new(rustc_hash::FxHashSet::default())
+}
+
+/// Enumerate every asset ID in an album into `into`. Used both for the
+/// legacy `--exclude-album` pre-fetch and for computing the "already in
+/// some album" set that gates the `-a all` + `{album}` unfiled pass.
+async fn collect_album_asset_ids(
+    album: &icloud::photos::PhotoAlbum,
+    into: &mut rustc_hash::FxHashSet<String>,
+) -> anyhow::Result<()> {
+    use futures_util::StreamExt;
+    let count = album.len().await.unwrap_or(0);
+    let (stream, _token_rx) = album.photo_stream_with_token(None, Some(count), 1);
+    tokio::pin!(stream);
+    while let Some(result) = stream.next().await {
+        let asset = result?;
+        into.insert(asset.id().to_string());
+    }
+    Ok(())
+}
+
+/// Resolve the full download plan for a library.
 ///
-/// The returned `FxHashSet<String>` contains asset IDs from excluded albums
-/// that should be filtered out at download time. This is only populated when
-/// `--exclude-album` is set without `--album`, because the all-photos stream
-/// doesn't carry album membership per asset.
+/// The returned [`AlbumPlan`] contains one or more passes, each paired with
+/// its own exclude-asset-ids set:
+///
+/// - [`AlbumSelection::LibraryOnly`] returns a single library-wide pass.
+///   `--exclude-album X` without `--album` populates the pass's exclude set
+///   with X's members so they don't leak through the library-wide stream.
+/// - [`AlbumSelection::Named`] returns one pass per matched album, minus
+///   anything in `exclude_albums`. Missing names are a hard error.
+/// - [`AlbumSelection::All`] returns one pass per discovered album (minus
+///   `exclude_albums`). When `{album}` is in `folder_structure`, an extra
+///   library-wide "unfiled" pass is appended; its exclude set is the union
+///   of every discovered album's members (including excluded ones — users
+///   explicitly asked to skip those, so they must not fall through to the
+///   unfiled pass either).
+///
+/// `folder_structure` is consulted only for `AlbumSelection::All`, to decide
+/// whether to add the unfiled pass.
 pub(crate) async fn resolve_albums(
     library: &icloud::photos::PhotoLibrary,
-    album_names: &[String],
+    selection: &config::AlbumSelection,
     exclude_albums: &[String],
-) -> anyhow::Result<(
-    Vec<icloud::photos::PhotoAlbum>,
-    rustc_hash::FxHashSet<String>,
-)> {
-    use futures_util::StreamExt;
+    folder_structure: &str,
+) -> anyhow::Result<AlbumPlan> {
+    let empty = empty_exclude_ids();
 
-    let empty_ids = rustc_hash::FxHashSet::default();
-
-    if album_names.is_empty() && exclude_albums.is_empty() {
-        return Ok((vec![library.all()], empty_ids));
-    }
-
-    if album_names.is_empty() {
-        // No --album but --exclude-album is set: use library.all() as the
-        // base (all photos) and pre-collect asset IDs from excluded albums
-        // so they can be filtered at download time. This avoids silently
-        // dropping photos that aren't in any named album.
-        let album_map = library.albums().await?;
-        let mut exclude_ids = rustc_hash::FxHashSet::default();
-        for name in exclude_albums {
-            if let Some(album) = album_map.get(name.as_str()) {
-                let count = album.len().await.unwrap_or(0);
-                tracing::debug!(album = name, count, "Pre-fetching excluded album asset IDs");
-                let (stream, _token_rx) = album.photo_stream_with_token(None, Some(count), 1);
-                tokio::pin!(stream);
-                while let Some(Ok(asset)) = stream.next().await {
-                    exclude_ids.insert(asset.id().to_string());
-                }
-            } else {
-                tracing::warn!(album = name, "Excluded album not found, ignoring");
+    match selection {
+        config::AlbumSelection::LibraryOnly => {
+            if exclude_albums.is_empty() {
+                return Ok(AlbumPlan {
+                    passes: vec![AlbumPass {
+                        album: library.all(),
+                        exclude_ids: empty,
+                    }],
+                });
             }
+            // Legacy: --exclude-album without --album. Pre-collect IDs so
+            // they're filtered from the library-wide stream.
+            let album_map = library.albums().await?;
+            let mut exclude_ids = rustc_hash::FxHashSet::default();
+            for name in exclude_albums {
+                if let Some(album) = album_map.get(name.as_str()) {
+                    tracing::debug!(album = name, "Pre-fetching excluded album asset IDs");
+                    collect_album_asset_ids(album, &mut exclude_ids).await?;
+                } else {
+                    tracing::warn!(album = name, "Excluded album not found, ignoring");
+                }
+            }
+            tracing::debug!(count = exclude_ids.len(), "Collected excluded asset IDs");
+            Ok(AlbumPlan {
+                passes: vec![AlbumPass {
+                    album: library.all(),
+                    exclude_ids: std::sync::Arc::new(exclude_ids),
+                }],
+            })
         }
-        tracing::debug!(count = exclude_ids.len(), "Collected excluded asset IDs");
-        return Ok((vec![library.all()], exclude_ids));
-    }
+        config::AlbumSelection::Named(names) => {
+            // Dedup names so callers passing the same album twice get a
+            // single download pass, not an error.
+            let mut album_map = library.albums().await?;
+            let mut passes = Vec::new();
+            let mut seen = rustc_hash::FxHashSet::default();
+            for name in names {
+                if !seen.insert(name.as_str()) {
+                    continue;
+                }
+                if exclude_albums.iter().any(|e| e == name) {
+                    tracing::debug!(album = name, "Album excluded by --exclude-album");
+                    continue;
+                }
+                if let Some(album) = album_map.remove(name.as_str()) {
+                    passes.push(AlbumPass {
+                        album,
+                        exclude_ids: std::sync::Arc::clone(&empty),
+                    });
+                } else {
+                    let available: Vec<&String> = album_map.keys().collect();
+                    anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+                }
+            }
+            Ok(AlbumPlan { passes })
+        }
+        config::AlbumSelection::All => {
+            // Filter smart folders (Favorites, Screenshots, Videos, etc.)
+            // out of the expansion. The issue requester wanted "my albums",
+            // meaning user-created folders — surfacing Apple's smart folders
+            // as download targets would be surprising and create confusing
+            // directories like "Recently Deleted" or "Hidden". Users who
+            // explicitly want a smart folder can still name it: `-a Favorites`.
+            let smart_folder_names: rustc_hash::FxHashSet<&'static str> =
+                icloud::photos::smart_folders::smart_folders()
+                    .into_iter()
+                    .map(|(name, _)| name)
+                    .collect();
+            let album_map: std::collections::HashMap<String, icloud::photos::PhotoAlbum> = library
+                .albums()
+                .await?
+                .into_iter()
+                .filter(|(name, _)| !smart_folder_names.contains(name.as_str()))
+                .collect();
+            let has_album_token = folder_structure.contains("{album}");
 
-    // Explicit --album list: resolve and exclude. Dedup names so callers
-    // passing the same album twice get one download pass, not an error.
-    let mut album_map = library.albums().await?;
-    let mut matched = Vec::new();
-    let mut seen = rustc_hash::FxHashSet::default();
-    for name in album_names {
-        if !seen.insert(name.as_str()) {
-            continue;
-        }
-        if exclude_albums.iter().any(|e| e == name) {
-            tracing::debug!(album = name, "Album excluded by --exclude-album");
-            continue;
-        }
-        if let Some(album) = album_map.remove(name.as_str()) {
-            matched.push(album);
-        } else {
-            let available: Vec<&String> = album_map.keys().collect();
-            anyhow::bail!("Album '{name}' not found. Available albums: {available:?}");
+            // Pre-compute the "in any user album" set BEFORE consuming the
+            // map, so the unfiled pass (if any) can skip anything that
+            // already belongs to a concrete user album — including albums
+            // excluded via --exclude-album (the user explicitly asked to
+            // skip those photos, so they must not fall through to unfiled).
+            let mut in_any_album: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+            if has_album_token {
+                for (name, album) in &album_map {
+                    tracing::debug!(
+                        album = name,
+                        "Pre-fetching album asset IDs for unfiled exclusion set"
+                    );
+                    collect_album_asset_ids(album, &mut in_any_album).await?;
+                }
+            }
+
+            // Sort by name for deterministic ordering — HashMap iteration
+            // order is not stable and users inspecting logs or dry-run
+            // output want consistency across runs.
+            let mut named_albums: Vec<(String, icloud::photos::PhotoAlbum)> =
+                album_map.into_iter().collect();
+            named_albums.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let mut passes: Vec<AlbumPass> = Vec::new();
+            let mut excluded_count = 0usize;
+            for (name, album) in named_albums {
+                if exclude_albums.iter().any(|e| e == &name) {
+                    excluded_count += 1;
+                    tracing::debug!(album = %name, "Album excluded by --exclude-album");
+                    continue;
+                }
+                passes.push(AlbumPass {
+                    album,
+                    exclude_ids: std::sync::Arc::clone(&empty),
+                });
+            }
+            tracing::info!(
+                count = passes.len(),
+                excluded = excluded_count,
+                unfiled_pass = has_album_token,
+                "Expanded '-a all' to every user-created album (smart folders skipped)"
+            );
+            if has_album_token {
+                passes.push(AlbumPass {
+                    album: library.all(),
+                    exclude_ids: std::sync::Arc::new(in_any_album),
+                });
+            }
+            Ok(AlbumPlan { passes })
         }
     }
-    Ok((matched, empty_ids))
 }
 
 #[cfg(test)]
@@ -538,26 +669,46 @@ mod tests {
         })
     }
 
+    // Shortcut for building an AlbumSelection::Named from string literals.
+    fn named(names: &[&str]) -> config::AlbumSelection {
+        config::AlbumSelection::Named(names.iter().map(|s| (*s).to_string()).collect())
+    }
+
     #[tokio::test]
     async fn resolve_albums_no_album_no_exclude() {
         let mock = MockPhotosSession::new();
         let library = stub_library(mock);
-        let (albums, exclude_ids) = resolve_albums(&library, &[], &[]).await.unwrap();
-        assert_eq!(albums.len(), 1, "should return library.all()");
-        assert!(exclude_ids.is_empty());
+        let plan = resolve_albums(
+            &library,
+            &config::AlbumSelection::LibraryOnly,
+            &[],
+            "%Y/%m/%d",
+        )
+        .await
+        .unwrap();
+        assert_eq!(plan.passes.len(), 1, "should return library.all()");
+        assert!(plan.passes[0].exclude_ids.is_empty());
     }
 
     #[tokio::test]
     async fn resolve_albums_exclude_not_found_warns() {
-        // fetch_folders returns one album "Vacation", but we exclude "Nonexistent"
-        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": []})); // fetch_folders: no user albums
+        // fetch_folders returns no albums, but we exclude "Nonexistent"
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": []}));
         let library = stub_library(mock);
 
-        let (albums, exclude_ids) = resolve_albums(&library, &[], &["Nonexistent".to_string()])
-            .await
-            .unwrap();
-        assert_eq!(albums.len(), 1, "should return library.all()");
-        assert!(exclude_ids.is_empty(), "non-existent album produces no IDs");
+        let plan = resolve_albums(
+            &library,
+            &config::AlbumSelection::LibraryOnly,
+            &["Nonexistent".to_string()],
+            "%Y/%m/%d",
+        )
+        .await
+        .unwrap();
+        assert_eq!(plan.passes.len(), 1, "should return library.all()");
+        assert!(
+            plan.passes[0].exclude_ids.is_empty(),
+            "non-existent album produces no IDs"
+        );
     }
 
     #[tokio::test]
@@ -568,19 +719,19 @@ mod tests {
         ]}));
         let library = stub_library(mock);
 
-        let (albums, exclude_ids) = resolve_albums(&library, &["Vacation".to_string()], &[])
+        let plan = resolve_albums(&library, &named(&["Vacation"]), &[], "%Y/%m/%d")
             .await
             .unwrap();
-        assert_eq!(albums.len(), 1);
-        assert!(exclude_ids.is_empty());
+        assert_eq!(plan.passes.len(), 1);
+        assert!(plan.passes[0].exclude_ids.is_empty());
     }
 
     #[tokio::test]
     async fn resolve_albums_explicit_album_not_found_errors() {
-        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": []})); // no user albums
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": []}));
         let library = stub_library(mock);
 
-        let result = resolve_albums(&library, &["DoesNotExist".to_string()], &[]).await;
+        let result = resolve_albums(&library, &named(&["DoesNotExist"]), &[], "%Y/%m/%d").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -594,14 +745,10 @@ mod tests {
         ]}));
         let library = stub_library(mock);
 
-        let (albums, _) = resolve_albums(
-            &library,
-            &["Vacation".to_string(), "Vacation".to_string()],
-            &[],
-        )
-        .await
-        .unwrap();
-        assert_eq!(albums.len(), 1, "duplicate names dedup to 1");
+        let plan = resolve_albums(&library, &named(&["Vacation", "Vacation"]), &[], "%Y/%m/%d")
+            .await
+            .unwrap();
+        assert_eq!(plan.passes.len(), 1, "duplicate names dedup to 1");
     }
 
     #[tokio::test]
@@ -613,20 +760,21 @@ mod tests {
         ]}));
         let library = stub_library(mock);
 
-        let (albums, exclude_ids) = resolve_albums(
+        let plan = resolve_albums(
             &library,
-            &["Vacation".to_string(), "Hidden".to_string()],
+            &named(&["Vacation", "Hidden"]),
             &["Hidden".to_string()],
+            "%Y/%m/%d",
         )
         .await
         .unwrap();
         assert_eq!(
-            albums.len(),
+            plan.passes.len(),
             1,
             "Hidden should be excluded from matched albums"
         );
         assert!(
-            exclude_ids.is_empty(),
+            plan.passes[0].exclude_ids.is_empty(),
             "explicit album path doesn't populate exclude IDs"
         );
     }
@@ -634,31 +782,112 @@ mod tests {
     #[tokio::test]
     async fn resolve_albums_exclude_without_album_collects_ids() {
         // The mock session needs to handle:
-        // 1. fetch_folders (original session) → returns album "Hidden"
-        // 2. album.len() (cloned session) → returns count
-        // 3. photo_stream fetcher (re-cloned session) → returns one asset page
+        // 1. fetch_folders → returns album "Hidden"
+        // 2. album.len() → returns count
+        // 3. photo_stream fetcher → returns one asset page
         // 4. photo_stream fetcher 2nd call → returns empty (end of stream)
         let mock = MockPhotosSession::new()
-            // 1. fetch_folders
             .ok(serde_json::json!({"records": [
                 folder_record("FOLDER_1", "Hidden")
             ]}))
-            // Remaining responses are cloned into the album's session:
-            // 2. album.len() batch query
             .ok(album_count_response(1))
-            // 3. photo_stream fetcher: first page with one asset
             .ok(asset_page("MASTER_1"))
-            // 4. photo_stream fetcher: empty page (end)
             .ok(serde_json::json!({"records": []}));
         let library = stub_library(mock);
 
-        let (albums, exclude_ids) = resolve_albums(&library, &[], &["Hidden".to_string()])
+        let plan = resolve_albums(
+            &library,
+            &config::AlbumSelection::LibraryOnly,
+            &["Hidden".to_string()],
+            "%Y/%m/%d",
+        )
+        .await
+        .unwrap();
+        assert_eq!(plan.passes.len(), 1, "should return library.all()");
+        assert!(
+            plan.passes[0].exclude_ids.contains("MASTER_1"),
+            "should contain the excluded asset ID"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_all_expands_to_every_album() {
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": [
+            folder_record("FOLDER_1", "Vacation"),
+            folder_record("FOLDER_2", "Summer Trip")
+        ]}));
+        let library = stub_library(mock);
+
+        let plan = resolve_albums(&library, &config::AlbumSelection::All, &[], "%Y/%m/%d")
             .await
             .unwrap();
-        assert_eq!(albums.len(), 1, "should return library.all()");
+        assert_eq!(
+            plan.passes.len(),
+            2,
+            "every user-created album becomes a pass, no unfiled pass without {{album}}"
+        );
+        for pass in &plan.passes {
+            assert!(
+                pass.exclude_ids.is_empty(),
+                "concrete album passes carry no exclusion"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_all_with_album_token_adds_unfiled_pass() {
+        // fetch_folders returns one album; then len + stream mocks so the
+        // unfiled exclusion set is populated from that album's member.
+        let mock = MockPhotosSession::new()
+            .ok(serde_json::json!({"records": [folder_record("FOLDER_1", "Vacation")]}))
+            .ok(album_count_response(1))
+            .ok(asset_page("MASTER_1"))
+            .ok(serde_json::json!({"records": []}));
+        let library = stub_library(mock);
+
+        let plan = resolve_albums(
+            &library,
+            &config::AlbumSelection::All,
+            &[],
+            "{album}/%Y/%m/%d",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            plan.passes.len(),
+            2,
+            "concrete album + unfiled pass when {{album}} is in template"
+        );
         assert!(
-            exclude_ids.contains("MASTER_1"),
-            "should contain the excluded asset ID"
+            plan.passes[0].exclude_ids.is_empty(),
+            "concrete pass carries no exclusion"
+        );
+        assert!(
+            plan.passes[1].exclude_ids.contains("MASTER_1"),
+            "unfiled pass excludes assets already in some album"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_albums_all_respects_exclude_albums() {
+        let mock = MockPhotosSession::new().ok(serde_json::json!({"records": [
+            folder_record("FOLDER_1", "Vacation"),
+            folder_record("FOLDER_2", "Hidden Trip")
+        ]}));
+        let library = stub_library(mock);
+
+        let plan = resolve_albums(
+            &library,
+            &config::AlbumSelection::All,
+            &["Hidden Trip".to_string()],
+            "%Y/%m/%d",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            plan.passes.len(),
+            1,
+            "Hidden Trip is filtered out of the concrete passes"
         );
     }
 
@@ -698,15 +927,16 @@ mod tests {
         ]}));
         let library = stub_library(mock);
 
-        let (albums, _) = resolve_albums(
+        let plan = resolve_albums(
             &library,
+            &named(&["Vacation"]),
             &["Vacation".to_string()],
-            &["Vacation".to_string()],
+            "%Y/%m/%d",
         )
         .await
         .unwrap();
         assert!(
-            albums.is_empty(),
+            plan.passes.is_empty(),
             "album present in both --album and --exclude-album should yield zero albums"
         );
     }

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use anyhow::Context;
+
 use crate::auth;
 use crate::config;
 use crate::icloud;
@@ -379,7 +381,14 @@ async fn collect_album_asset_ids(
     into: &mut rustc_hash::FxHashSet<String>,
 ) -> anyhow::Result<()> {
     use futures_util::StreamExt;
-    let count = album.len().await.unwrap_or(0);
+    // Propagate `len()` failures — the count is load-bearing for the
+    // `-a all` + `{album}` unfiled pass: a silent 0 here leaves the
+    // exclusion set incomplete and the unfiled pass re-downloads assets
+    // that are already in some user album.
+    let count = album
+        .len()
+        .await
+        .with_context(|| format!("failed to get asset count for album '{}'", album.name))?;
     let (stream, _token_rx) = album.photo_stream_with_token(None, Some(count), 1);
     tokio::pin!(stream);
     while let Some(result) = stream.next().await {
@@ -496,11 +505,29 @@ pub(crate) async fn resolve_albums(
             // ones) into the unfiled exclusion set before consuming the
             // map. Excluded albums must contribute too, otherwise their
             // photos would leak out through the library-wide unfiled pass.
+            // Fetched in parallel because this runs before the first byte
+            // is downloaded; for libraries with many albums the serial
+            // version added minutes of startup latency.
             let mut in_any_album: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
             if has_album_token {
-                for (name, album) in &album_map {
-                    tracing::debug!(album = name, "Pre-fetching IDs for unfiled exclusion set");
-                    collect_album_asset_ids(album, &mut in_any_album).await?;
+                use futures_util::{StreamExt, TryStreamExt};
+                const EXCLUSION_FETCH_CONCURRENCY: usize = 8;
+                let per_album: Vec<rustc_hash::FxHashSet<String>> =
+                    futures_util::stream::iter(album_map.iter())
+                        .map(|(name, album)| async move {
+                            tracing::debug!(
+                                album = %name,
+                                "Pre-fetching IDs for unfiled exclusion set"
+                            );
+                            let mut set = rustc_hash::FxHashSet::default();
+                            collect_album_asset_ids(album, &mut set).await?;
+                            anyhow::Ok(set)
+                        })
+                        .buffer_unordered(EXCLUSION_FETCH_CONCURRENCY)
+                        .try_collect()
+                        .await?;
+                for set in per_album {
+                    in_any_album.extend(set);
                 }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,23 +210,12 @@ impl std::fmt::Display for AlbumSelection {
     }
 }
 
-/// Strip the Python-style `{:...}` wrapper used in legacy folder-structure
-/// values so validation runs against the same form `expand_album_token`
-/// expands at runtime.
-fn strip_python_wrapper(folder_structure: &str) -> &str {
-    if folder_structure.starts_with("{:") && folder_structure.ends_with('}') {
-        &folder_structure[2..folder_structure.len() - 1]
-    } else {
-        folder_structure
-    }
-}
-
 /// Reject `--folder-structure` values that place `{album}` somewhere other
 /// than the first path segment, or use it more than once. Both cases would
 /// make the "unfiled photos" fallback path shift other segments around
 /// unpredictably when `{album}` collapses to an empty string.
 fn validate_folder_structure(folder_structure: &str) -> anyhow::Result<()> {
-    let stripped = strip_python_wrapper(folder_structure);
+    let stripped = crate::download::paths::strip_python_wrapper(folder_structure);
     let count = stripped.matches("{album}").count();
     if count == 0 {
         return Ok(());
@@ -267,7 +256,7 @@ fn resolve_album_selection(
         // Smart default: bare `{album}` in the folder template implies
         // "every album, plus an unfiled pass" without the user having to
         // also pass `-a all`.
-        if strip_python_wrapper(folder_structure).contains("{album}") {
+        if crate::download::paths::strip_python_wrapper(folder_structure).contains("{album}") {
             return Ok(AlbumSelection::All);
         }
         return Ok(AlbumSelection::LibraryOnly);

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,6 +170,111 @@ impl std::fmt::Display for LibrarySelection {
     }
 }
 
+/// Which albums to sync.
+///
+/// `All` is triggered by explicit `-a all` *or* the smart default: no `-a`
+/// flag passed *and* `{album}` appears in `--folder-structure`. In both
+/// cases, every discovered album is enumerated; an additional library-wide
+/// pass for "unfiled" photos is only added when `{album}` is in the template
+/// (decided at `resolve_albums` time, not stored here).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AlbumSelection {
+    /// No `-a` filter; enumerate the library as a single stream (today's
+    /// default behaviour).
+    LibraryOnly,
+    /// Explicit list of album names to sync.
+    Named(Vec<String>),
+    /// `-a all` (explicit) or the smart default when `{album}` is in the
+    /// folder template: every discovered album.
+    All,
+}
+
+impl AlbumSelection {
+    /// Serialize to a `Vec<String>` for TOML persistence and JSON reports.
+    pub fn to_vec(&self) -> Vec<String> {
+        match self {
+            Self::LibraryOnly => Vec::new(),
+            Self::All => vec!["all".to_string()],
+            Self::Named(v) => v.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for AlbumSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LibraryOnly => f.write_str("<library-only>"),
+            Self::All => f.write_str("all"),
+            Self::Named(names) => f.write_str(&names.join(", ")),
+        }
+    }
+}
+
+/// Strip the Python-style `{:...}` wrapper used in legacy folder-structure
+/// values so validation runs against the same form `expand_album_token`
+/// expands at runtime.
+fn strip_python_wrapper(folder_structure: &str) -> &str {
+    if folder_structure.starts_with("{:") && folder_structure.ends_with('}') {
+        &folder_structure[2..folder_structure.len() - 1]
+    } else {
+        folder_structure
+    }
+}
+
+/// Reject `--folder-structure` values that place `{album}` somewhere other
+/// than the first path segment, or use it more than once. Both cases would
+/// make the "unfiled photos" fallback path shift other segments around
+/// unpredictably when `{album}` collapses to an empty string.
+fn validate_folder_structure(folder_structure: &str) -> anyhow::Result<()> {
+    let stripped = strip_python_wrapper(folder_structure);
+    let count = stripped.matches("{album}").count();
+    if count == 0 {
+        return Ok(());
+    }
+    if count > 1 {
+        anyhow::bail!(
+            "'{{album}}' may only appear once in --folder-structure; got {count} occurrences in \"{folder_structure}\""
+        );
+    }
+    if stripped.split('/').next() != Some("{album}") {
+        anyhow::bail!(
+            "'{{album}}' must be the first path segment of --folder-structure; got \"{folder_structure}\""
+        );
+    }
+    Ok(())
+}
+
+/// Convert a raw `Vec<String>` (from CLI or TOML) into an [`AlbumSelection`],
+/// enforcing that `-a all` is not mixed with specific album names.
+fn resolve_album_selection(
+    raw: Vec<String>,
+    folder_structure: &str,
+) -> anyhow::Result<AlbumSelection> {
+    let has_all = raw.iter().any(|s| s.eq_ignore_ascii_case("all"));
+    if has_all {
+        let non_all: Vec<&String> = raw
+            .iter()
+            .filter(|s| !s.eq_ignore_ascii_case("all"))
+            .collect();
+        anyhow::ensure!(
+            non_all.is_empty(),
+            "'-a all' cannot be combined with other album names; got {raw:?}. \
+             Pass either '-a all' alone or a list of specific names."
+        );
+        return Ok(AlbumSelection::All);
+    }
+    if raw.is_empty() {
+        // Smart default: bare `{album}` in the folder template implies
+        // "every album, plus an unfiled pass" without the user having to
+        // also pass `-a all`.
+        if strip_python_wrapper(folder_structure).contains("{album}") {
+            return Ok(AlbumSelection::All);
+        }
+        return Ok(AlbumSelection::LibraryOnly);
+    }
+    Ok(AlbumSelection::Named(raw))
+}
+
 /// Application configuration.
 ///
 /// Fields are ordered for optimal memory layout:
@@ -189,7 +294,7 @@ pub struct Config {
     pub directory: PathBuf,
     pub cookie_directory: PathBuf,
     pub folder_structure: String,
-    pub albums: Vec<String>,
+    pub albums: AlbumSelection,
     pub exclude_albums: Vec<String>,
     pub filename_exclude: Vec<glob::Pattern>,
     pub library: LibrarySelection,
@@ -509,6 +614,7 @@ impl Config {
             toml_dl.and_then(|d| d.folder_structure.clone()),
             "%Y/%m/%d".to_string(),
         );
+        validate_folder_structure(&folder_structure)?;
         // Resolve bandwidth limit (CLI bytes/sec > TOML human-readable string > None).
         let bandwidth_limit: Option<u64> = if let Some(n) = sync.bandwidth_limit {
             Some(n)
@@ -562,13 +668,14 @@ impl Config {
 
         // Filters
         let library = resolve_library_selection(sync.library, toml_filters);
-        let albums = if sync.albums.is_empty() {
+        let raw_albums = if sync.albums.is_empty() {
             toml_filters
                 .and_then(|f| f.albums.clone())
                 .unwrap_or_default()
         } else {
             sync.albums
         };
+        let albums = resolve_album_selection(raw_albums, &folder_structure)?;
         let skip_videos = resolve_flag(sync.skip_videos, toml_filters.and_then(|f| f.skip_videos));
         let skip_photos = resolve_flag(sync.skip_photos, toml_filters.and_then(|f| f.skip_photos));
         // Resolve live photo mode: --live-photo-mode > --skip-live-photos > TOML photos > TOML filters compat
@@ -823,10 +930,10 @@ impl Config {
             }),
             filters: Some(TomlFilters {
                 library: library_str,
-                albums: if self.albums.is_empty() {
-                    None
-                } else {
-                    Some(self.albums.clone())
+                albums: match &self.albums {
+                    AlbumSelection::LibraryOnly => None,
+                    AlbumSelection::All => Some(vec!["all".to_string()]),
+                    AlbumSelection::Named(v) => Some(v.clone()),
                 },
                 exclude_albums: if self.exclude_albums.is_empty() {
                     None
@@ -1621,7 +1728,10 @@ mod tests {
             Some(toml),
         )
         .unwrap();
-        assert_eq!(cfg.albums, vec!["Favorites", "Vacation"]);
+        assert_eq!(
+            cfg.albums,
+            AlbumSelection::Named(vec!["Favorites".to_string(), "Vacation".to_string()])
+        );
     }
 
     #[test]
@@ -1634,7 +1744,10 @@ mod tests {
         let mut sync = default_sync();
         sync.albums = vec!["Screenshots".to_string()];
         let cfg = Config::build(&default_globals(), default_password(), sync, Some(toml)).unwrap();
-        assert_eq!(cfg.albums, vec!["Screenshots"]);
+        assert_eq!(
+            cfg.albums,
+            AlbumSelection::Named(vec!["Screenshots".to_string()])
+        );
     }
 
     #[test]
@@ -2216,7 +2329,7 @@ mod tests {
             cfg.library,
             LibrarySelection::Single("PrimarySync".to_string())
         );
-        assert!(cfg.albums.is_empty());
+        assert_eq!(cfg.albums, AlbumSelection::LibraryOnly);
         assert!(!cfg.skip_videos);
         assert!(!cfg.skip_photos);
         assert_eq!(cfg.live_photo_mode, LivePhotoMode::Both);
@@ -2969,7 +3082,10 @@ mod tests {
             cfg.library,
             LibrarySelection::Single("SharedSync-FULL".to_string())
         );
-        assert_eq!(cfg.albums, vec!["Album1"]);
+        assert_eq!(
+            cfg.albums,
+            AlbumSelection::Named(vec!["Album1".to_string()])
+        );
         assert!(cfg.skip_videos);
         assert_eq!(cfg.recent, Some(50));
         assert!(matches!(cfg.size, VersionSize::Medium));
@@ -3073,14 +3189,178 @@ mod tests {
             Some(toml),
         )
         .unwrap();
-        assert!(cfg.albums.is_empty());
+        assert_eq!(cfg.albums, AlbumSelection::LibraryOnly);
     }
 
     #[test]
     fn test_build_albums_no_toml_no_cli() {
         let cfg =
             Config::build(&default_globals(), default_password(), default_sync(), None).unwrap();
-        assert!(cfg.albums.is_empty());
+        assert_eq!(cfg.albums, AlbumSelection::LibraryOnly);
+    }
+
+    #[test]
+    fn test_album_selection_to_vec_roundtrip() {
+        assert!(AlbumSelection::LibraryOnly.to_vec().is_empty());
+        assert_eq!(AlbumSelection::All.to_vec(), vec!["all".to_string()]);
+        assert_eq!(
+            AlbumSelection::Named(vec!["A".into(), "B".into()]).to_vec(),
+            vec!["A".to_string(), "B".to_string()]
+        );
+    }
+
+    // ── AlbumSelection resolution tests ────────────────────────────
+
+    #[test]
+    fn test_build_album_all_maps_to_all_variant() {
+        let mut sync = default_sync();
+        sync.albums = vec!["all".to_string()];
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.albums, AlbumSelection::All);
+    }
+
+    #[test]
+    fn test_build_album_all_is_case_insensitive() {
+        for raw in ["all", "ALL", "All", "aLL"] {
+            let mut sync = default_sync();
+            sync.albums = vec![raw.to_string()];
+            let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+            assert_eq!(
+                cfg.albums,
+                AlbumSelection::All,
+                "'{raw}' should resolve to AlbumSelection::All"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_album_all_mixed_with_names_errors() {
+        let mut sync = default_sync();
+        sync.albums = vec!["all".to_string(), "Vacation".to_string()];
+        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'-a all' cannot be combined"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_build_album_all_from_toml() {
+        let toml_str = r#"
+            [filters]
+            albums = ["all"]
+        "#;
+        let toml: TomlConfig = toml::from_str(toml_str).unwrap();
+        let cfg = Config::build(
+            &default_globals(),
+            default_password(),
+            default_sync(),
+            Some(toml),
+        )
+        .unwrap();
+        assert_eq!(cfg.albums, AlbumSelection::All);
+    }
+
+    #[test]
+    fn test_build_album_smart_default_kicks_in_with_album_token() {
+        // No -a passed, but {album} in folder_structure -> implicit All.
+        let mut sync = default_sync();
+        sync.folder_structure = Some("{album}/%Y/%m".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.albums, AlbumSelection::All);
+    }
+
+    #[test]
+    fn test_build_album_smart_default_inactive_without_album_token() {
+        // No -a, no {album} -> LibraryOnly (today's default).
+        let mut sync = default_sync();
+        sync.folder_structure = Some("%Y/%m/%d".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.albums, AlbumSelection::LibraryOnly);
+    }
+
+    #[test]
+    fn test_build_album_named_preserved() {
+        let mut sync = default_sync();
+        sync.albums = vec!["Vacation".to_string(), "Trip".to_string()];
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(
+            cfg.albums,
+            AlbumSelection::Named(vec!["Vacation".to_string(), "Trip".to_string()])
+        );
+    }
+
+    // ── folder_structure {album} placement validation ──────────────
+
+    #[test]
+    fn test_build_album_token_rejected_mid_path() {
+        let mut sync = default_sync();
+        sync.folder_structure = Some("Photos/{album}/%Y".to_string());
+        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("'{album}' must be the first path segment"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_album_token_rejected_after_date() {
+        let mut sync = default_sync();
+        sync.folder_structure = Some("%Y/{album}/%m".to_string());
+        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("'{album}' must be the first path segment"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_album_token_rejected_as_trailing() {
+        let mut sync = default_sync();
+        sync.folder_structure = Some("%Y/%m/{album}".to_string());
+        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
+        assert!(err.to_string().contains("must be the first path segment"));
+    }
+
+    #[test]
+    fn test_build_album_token_rejected_duplicate() {
+        let mut sync = default_sync();
+        sync.folder_structure = Some("{album}/%Y/{album}".to_string());
+        let err = Config::build(&default_globals(), default_password(), sync, None).unwrap_err();
+        assert!(
+            err.to_string().contains("may only appear once"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_album_token_accepted_at_root() {
+        let mut sync = default_sync();
+        sync.albums = vec!["Vacation".to_string()];
+        sync.folder_structure = Some("{album}/%Y/%m".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.folder_structure, "{album}/%Y/%m");
+    }
+
+    #[test]
+    fn test_build_album_token_accepted_alone() {
+        let mut sync = default_sync();
+        sync.albums = vec!["Vacation".to_string()];
+        sync.folder_structure = Some("{album}".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.folder_structure, "{album}");
+    }
+
+    #[test]
+    fn test_build_album_token_accepted_within_python_wrapper() {
+        let mut sync = default_sync();
+        sync.albums = vec!["Vacation".to_string()];
+        sync.folder_structure = Some("{:{album}/%Y/%m}".to_string());
+        let cfg = Config::build(&default_globals(), default_password(), sync, None).unwrap();
+        assert_eq!(cfg.folder_structure, "{:{album}/%Y/%m}");
     }
 
     #[test]

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -410,6 +410,14 @@ pub(crate) struct DownloadConfig {
 }
 
 impl DownloadConfig {
+    /// True when `--folder-structure` contains the `{album}` token. Passes
+    /// in this mode need per-album path expansion and bypass the
+    /// path-blind state-DB fast-skip (the same asset legitimately lives at
+    /// different paths across album folders).
+    pub(crate) fn uses_album_expansion(&self) -> bool {
+        self.folder_structure.contains("{album}")
+    }
+
     /// Clone this config with a different `album_name`, for per-album processing
     /// when `{album}` is in `folder_structure`. Pre-expands the `{album}` token
     /// in `folder_structure` so `local_download_dir` avoids per-asset
@@ -431,10 +439,20 @@ impl DownloadConfig {
         }
     }
 
-    /// Clone this config with a different `exclude_asset_ids` set, for
-    /// per-pass exclusion in multi-pass plans (e.g. the `-a all` + `{album}`
-    /// unfiled pass needs to skip anything already downloaded by a concrete
-    /// album pass).
+    /// Clone this config for a single download pass: pre-expand `{album}`
+    /// and pin the pass's exclude-ids set in one clone. Equivalent to
+    /// `with_album_name(...).with_exclude_ids(...)` but avoids the second
+    /// allocation.
+    fn with_pass(&self, pass: &crate::commands::AlbumPass) -> Self {
+        Self {
+            exclude_asset_ids: Arc::clone(&pass.exclude_ids),
+            ..self.with_album_name(Arc::clone(&pass.album.name))
+        }
+    }
+
+    /// Clone this config with a different `exclude_asset_ids` set. Used
+    /// for the merged (non-`{album}`) full-sync path, where all passes
+    /// share a single config but the exclude set is lifted off the plan.
     fn with_exclude_ids(&self, exclude_ids: Arc<FxHashSet<String>>) -> Self {
         Self {
             directory: self.directory.clone(),
@@ -671,6 +689,21 @@ impl DownloadContext {
     }
 }
 
+/// Pre-compute one `Arc<DownloadConfig>` per pass. Each pass_index maps to
+/// a derived config that pre-expands `{album}` and pins the pass's
+/// exclude-asset-ids set. In `{album}` mode passes may legitimately differ
+/// per entry; outside of it, passes share identical excludes but the per-
+/// pass wrapper is harmless and keeps call sites uniform.
+fn build_pass_configs(
+    passes: &[crate::commands::AlbumPass],
+    base: &DownloadConfig,
+) -> Vec<Arc<DownloadConfig>> {
+    passes
+        .iter()
+        .map(|pass| Arc::new(base.with_pass(pass)))
+        .collect()
+}
+
 /// Eagerly enumerate all albums and build a complete task list.
 ///
 /// Used only by the Phase 2 cleanup pass — re-contacts the API so each call
@@ -680,11 +713,7 @@ async fn build_download_tasks(
     config: &DownloadConfig,
     shutdown_token: CancellationToken,
 ) -> Result<Vec<DownloadTask>> {
-    let uses_album_token = config.folder_structure.contains("{album}");
-    // Per-pass fetches: collect (index -> Vec<PhotoAsset>) so we can pair
-    // each batch back to its source pass for per-pass config derivation.
-    // buffer_unordered preserves the original per-iter index since we emit
-    // (i, album) pairs explicitly.
+    let pass_configs = build_pass_configs(passes, config);
     let pass_results: Vec<Result<(usize, Vec<_>)>> = stream::iter(passes.iter().enumerate())
         .take_while(|_| std::future::ready(!shutdown_token.is_cancelled()))
         .map(|(i, pass)| async move { pass.album.photos(config.recent).await.map(|a| (i, a)) })
@@ -695,37 +724,18 @@ async fn build_download_tasks(
     let mut tasks: Vec<DownloadTask> = Vec::new();
     let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
     let mut dir_cache = paths::DirCache::new();
-    // Cache per-pass configs so repeat assets in the same pass don't
-    // re-allocate. Only populated when per-pass divergence matters
-    // ({album} path or non-empty exclude set).
-    let mut pass_configs: FxHashMap<usize, Arc<DownloadConfig>> = FxHashMap::default();
     for pass_result in pass_results {
         let (pass_index, assets) = pass_result?;
-        let pass = &passes[pass_index];
-
-        let effective_config: Arc<DownloadConfig> = pass_configs
-            .entry(pass_index)
-            .or_insert_with(|| {
-                if uses_album_token {
-                    Arc::new(
-                        config
-                            .with_album_name(pass.album.name.clone())
-                            .with_exclude_ids(Arc::clone(&pass.exclude_ids)),
-                    )
-                } else {
-                    Arc::new(config.with_exclude_ids(Arc::clone(&pass.exclude_ids)))
-                }
-            })
-            .clone();
+        let pass_config = &pass_configs[pass_index];
 
         for asset in &assets {
-            if filter::is_asset_filtered(asset, &effective_config).is_some() {
+            if filter::is_asset_filtered(asset, pass_config).is_some() {
                 continue;
             }
-            pre_ensure_asset_dir(&mut dir_cache, asset, &effective_config).await;
+            pre_ensure_asset_dir(&mut dir_cache, asset, pass_config).await;
             tasks.extend(filter_asset_to_tasks(
                 asset,
-                &effective_config,
+                pass_config,
                 &mut claimed_paths,
                 &mut dir_cache,
             ));
@@ -955,9 +965,8 @@ async fn download_photos_full_with_token(
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
-    let uses_album_token = config.folder_structure.contains("{album}");
+    let uses_album_token = config.uses_album_expansion();
 
-    // Build token-aware streams for each pass
     let mut pass_counts: Vec<u64> = Vec::with_capacity(passes.len());
     for pass in passes {
         pass_counts.push(pass.album.len().await.unwrap_or(0));
@@ -967,31 +976,21 @@ async fn download_photos_full_with_token(
         total = total.min(u64::from(recent));
     }
 
-    // When {album} is in folder_structure, process each pass separately so each
-    // gets its own album-specific path expansion and exclude-ids set (the
-    // unfiled pass uses a non-empty exclude set; concrete passes use empty).
-    // Otherwise, all passes share the same config (invariant: non-{album} plans
-    // have uniform exclude_ids across passes) and streams are merged for
-    // maximum cross-pass download concurrency.
+    // {album} mode processes passes sequentially: each needs its own
+    // album-specific path expansion, so cross-pass download concurrency is
+    // traded off for correct placement. Assets in multiple albums get one
+    // copy per album folder. Non-{album} plans have a uniform exclude set
+    // across passes (LibraryOnly: 1 pass; Named/All-without-{album}: every
+    // pass has empty excludes) so streams merge for maximum concurrency.
     let (streaming_result, token_receivers) = if uses_album_token {
+        let pass_configs = build_pass_configs(passes, config);
         let mut combined_result = StreamingResult::default();
         let mut token_receivers = Vec::with_capacity(passes.len());
 
-        // When {album} is in folder_structure, passes are processed sequentially
-        // so each gets its own per-album path expansion. Cross-album download
-        // concurrency is intentionally sacrificed for correct path placement.
-        // Assets appearing in multiple albums are downloaded once per album,
-        // each to its respective album directory.
-        for (pass, &count) in passes.iter().zip(&pass_counts) {
+        for ((pass, &count), pass_config) in passes.iter().zip(&pass_counts).zip(&pass_configs) {
             if shutdown_token.is_cancelled() {
                 break;
             }
-            let pass_config = Arc::new(
-                config
-                    .with_album_name(pass.album.name.clone())
-                    .with_exclude_ids(Arc::clone(&pass.exclude_ids)),
-            );
-
             let (stream, token_rx) = pass.album.photo_stream_with_token(
                 config.recent,
                 Some(count),
@@ -1002,7 +1001,7 @@ async fn download_photos_full_with_token(
             let result = stream_and_download_from_stream(
                 download_client,
                 stream,
-                &pass_config,
+                pass_config,
                 total,
                 shutdown_token.clone(),
             )
@@ -1020,10 +1019,6 @@ async fn download_photos_full_with_token(
 
         (combined_result, token_receivers)
     } else {
-        // Non-{album} plans have a single exclude set shared across all passes.
-        // Use the first pass's excludes (they're uniform by construction in
-        // resolve_albums: LibraryOnly has one pass; Named/All-without-{album}
-        // have empty excludes).
         let merged_exclude_ids = passes
             .first()
             .map(|p| Arc::clone(&p.exclude_ids))
@@ -1126,14 +1121,12 @@ async fn download_photos_incremental(
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
-    let uses_album_token = config.folder_structure.contains("{album}");
+    let uses_album_token = config.uses_album_expansion();
 
-    // Collect change events from every pass, counting and filtering in a
-    // single pass. Each asset is paired with its source pass index so that
-    // both `{album}` token expansion and per-pass exclusion sets can be
-    // applied correctly (notably, the unfiled pass's exclude set keeps the
-    // same asset from being downloaded twice when it's in both a concrete
-    // album and the library-wide pass).
+    // Each asset is paired with its source pass index so both `{album}`
+    // expansion and per-pass exclusion (notably, the unfiled pass's set
+    // that prevents assets already in some user album from downloading
+    // twice) can be applied downstream.
     let mut downloadable_assets: Vec<(PhotoAsset, usize)> = Vec::new();
     let mut sync_token: Option<String> = None;
     let mut created_count = 0u64;
@@ -1236,25 +1229,10 @@ async fn download_photos_incremental(
     let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
     let mut dir_cache = paths::DirCache::new();
     let mut skip_breakdown = SkipBreakdown::default();
-    let mut pass_configs: FxHashMap<usize, Arc<DownloadConfig>> = FxHashMap::default();
+    let pass_configs = build_pass_configs(passes, config);
 
     for (asset, pass_index) in &downloadable_assets {
-        let pass = &passes[*pass_index];
-        let effective_config: Arc<DownloadConfig> = pass_configs
-            .entry(*pass_index)
-            .or_insert_with(|| {
-                if uses_album_token {
-                    Arc::new(
-                        config
-                            .with_album_name(pass.album.name.clone())
-                            .with_exclude_ids(Arc::clone(&pass.exclude_ids)),
-                    )
-                } else {
-                    Arc::new(config.with_exclude_ids(Arc::clone(&pass.exclude_ids)))
-                }
-            })
-            .clone();
-        let effective_config = &effective_config;
+        let effective_config = &pass_configs[*pass_index];
 
         if let Some(reason) = filter::is_asset_filtered(asset, effective_config) {
             match reason {
@@ -1267,15 +1245,11 @@ async fn download_photos_incremental(
             continue;
         }
 
-        // Fast-skip: if state DB confirms all versions are already downloaded
-        // with matching checksums, skip the filesystem check entirely.
-        //
-        // This fast-path is path-blind: it keys on (asset_id, version_size,
-        // checksum) only. In `{album}` mode, the same asset may target
-        // multiple album folders (one per album it belongs to, plus the
-        // unfiled pass). Trusting the DB here would skip every copy after
-        // the first, leaving later album folders missing their file. Fall
-        // through to the filesystem-exists check, which is path-aware.
+        // `should_download_fast` keys on (asset_id, version_size, checksum)
+        // and is path-blind. In `{album}` mode the same asset may target
+        // multiple album folders; a DB-only skip would leave later copies
+        // missing from disk. Fall through to the path-aware filesystem
+        // check in that case.
         if !uses_album_token {
             let candidates = extract_skip_candidates(asset, effective_config);
             if !candidates.is_empty()

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -410,10 +410,12 @@ pub(crate) struct DownloadConfig {
 }
 
 impl DownloadConfig {
-    /// True when `--folder-structure` contains the `{album}` token. Passes
-    /// in this mode need per-album path expansion and bypass the
-    /// path-blind state-DB fast-skip (the same asset legitimately lives at
-    /// different paths across album folders).
+    /// True when `--folder-structure` contains the `{album}` token.
+    ///
+    /// Only meaningful on the *base* config. A per-pass config produced by
+    /// `with_album_name` / `with_pass` has already had the token expanded
+    /// out of `folder_structure`, so this would always return false there.
+    /// Per-pass code paths should check `album_name.is_some()` instead.
     pub(crate) fn uses_album_expansion(&self) -> bool {
         self.folder_structure.contains("{album}")
     }
@@ -422,6 +424,12 @@ impl DownloadConfig {
     /// when `{album}` is in `folder_structure`. Pre-expands the `{album}` token
     /// in `folder_structure` so `local_download_dir` avoids per-asset
     /// sanitize/escape/replace allocations.
+    ///
+    /// Setting `album_name` on the derived config is load-bearing: the
+    /// fast-skip bypass in the streaming pipeline uses `album_name.is_some()`
+    /// as the "this asset may legitimately land at multiple paths, don't
+    /// trust the DB" signal. An empty name still sets `Some("")`, so the
+    /// unfiled `library.all()` pass inherits the bypass too.
     fn with_album_name(&self, name: Arc<str>) -> Self {
         let album_ref = Some(name.as_ref()).filter(|n: &&str| !n.is_empty());
         let folder_structure = paths::expand_album_token(&self.folder_structure, album_ref);
@@ -993,7 +1001,7 @@ async fn download_photos_full_with_token(
     // so the `zip(&pass_counts)` below stays aligned.
     let pass_counts: Vec<u64> = stream::iter(passes)
         .map(|pass| async move { pass.album.len().await.unwrap_or(0) })
-        .buffered(config.concurrent_downloads.max(1))
+        .buffered(config.concurrent_downloads)
         .collect()
         .await;
     let mut total: u64 = pass_counts.iter().sum();
@@ -2421,42 +2429,6 @@ mod tests {
         assert!(
             !derived.folder_structure.contains('/')
                 || !derived.folder_structure.starts_with("My/Album")
-        );
-    }
-
-    // The fast-skip bypass in `stream_and_download_from_stream` keys on
-    // `album_name.is_some()` as its signal that "this asset may legitimately
-    // land at multiple paths, don't trust the DB". `with_album_name` and
-    // `with_pass` must both preserve that signal; if either left it None, a
-    // photo in multiple albums would download to the first album's folder
-    // only.
-    #[test]
-    fn test_with_album_name_sets_album_name_for_fast_skip_bypass() {
-        let mut config = test_config();
-        config.folder_structure = "{album}/%Y".to_string();
-        config.album_name = None;
-        let derived = config.with_album_name(Arc::from("Vacation"));
-        assert_eq!(
-            derived.album_name.as_deref(),
-            Some("Vacation"),
-            "album_name must be set so the fast-skip bypass fires"
-        );
-    }
-
-    #[test]
-    fn test_with_album_name_empty_name_still_signals_per_album_pass() {
-        // The unfiled pass uses `library.all()` whose name is empty. The
-        // fast-skip bypass still needs to fire for it — an asset in any
-        // concrete album is excluded from the unfiled pass via `exclude_ids`,
-        // but truly-unfiled assets still need path-aware checks.
-        let mut config = test_config();
-        config.folder_structure = "{album}/%Y".to_string();
-        config.album_name = None;
-        let derived = config.with_album_name(Arc::from(""));
-        assert_eq!(
-            derived.album_name.as_deref(),
-            Some(""),
-            "empty album name still signals per-album pass mode"
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -865,6 +865,25 @@ pub async fn download_photos_with_sync(
             )
             .await
         }
+        // In `{album}` mode we have to fall back to full enumeration:
+        // `changes_stream` uses the zone-level `/changes/zone` endpoint, so
+        // it returns the same delta for every album in a zone. Without
+        // per-asset album-membership info on the change events, we can't
+        // route assets to the correct album folder — full enumeration uses
+        // the album-scoped `photo_stream_with_token` and stays correct.
+        SyncMode::Incremental { .. } if config.uses_album_expansion() => {
+            tracing::debug!(
+                "`{{album}}` folder template requires full enumeration for correct \
+                 per-album routing, skipping incremental"
+            );
+            download_photos_full_with_token(
+                download_client,
+                passes,
+                &config,
+                shutdown_token.clone(),
+            )
+            .await
+        }
         // Incremental sync only returns new changes — it won't re-enumerate
         // pending assets from previous syncs. Fall back to full so they get
         // retried. Once everything is downloaded, incremental resumes.
@@ -967,10 +986,16 @@ async fn download_photos_full_with_token(
     let started = Instant::now();
     let uses_album_token = config.uses_album_expansion();
 
-    let mut pass_counts: Vec<u64> = Vec::with_capacity(passes.len());
-    for pass in passes {
-        pass_counts.push(pass.album.len().await.unwrap_or(0));
-    }
+    // `album.len()` is one HTTP call per pass. Serialising it scaled fine
+    // when users typed out a few `-a` flags by hand; with `-a all` it's
+    // routinely 20+ round-trips before the first byte of the first
+    // download. `buffered` (not `buffer_unordered`) preserves pass order
+    // so the `zip(&pass_counts)` below stays aligned.
+    let pass_counts: Vec<u64> = stream::iter(passes)
+        .map(|pass| async move { pass.album.len().await.unwrap_or(0) })
+        .buffered(config.concurrent_downloads.max(1))
+        .collect()
+        .await;
     let mut total: u64 = pass_counts.iter().sum();
     if let Some(recent) = config.recent {
         total = total.min(u64::from(recent));
@@ -2396,6 +2421,42 @@ mod tests {
         assert!(
             !derived.folder_structure.contains('/')
                 || !derived.folder_structure.starts_with("My/Album")
+        );
+    }
+
+    // The fast-skip bypass in `stream_and_download_from_stream` keys on
+    // `album_name.is_some()` as its signal that "this asset may legitimately
+    // land at multiple paths, don't trust the DB". `with_album_name` and
+    // `with_pass` must both preserve that signal; if either left it None, a
+    // photo in multiple albums would download to the first album's folder
+    // only.
+    #[test]
+    fn test_with_album_name_sets_album_name_for_fast_skip_bypass() {
+        let mut config = test_config();
+        config.folder_structure = "{album}/%Y".to_string();
+        config.album_name = None;
+        let derived = config.with_album_name(Arc::from("Vacation"));
+        assert_eq!(
+            derived.album_name.as_deref(),
+            Some("Vacation"),
+            "album_name must be set so the fast-skip bypass fires"
+        );
+    }
+
+    #[test]
+    fn test_with_album_name_empty_name_still_signals_per_album_pass() {
+        // The unfiled pass uses `library.all()` whose name is empty. The
+        // fast-skip bypass still needs to fire for it — an asset in any
+        // concrete album is excluded from the unfiled pass via `exclude_ids`,
+        // but truly-unfiled assets still need path-aware checks.
+        let mut config = test_config();
+        config.folder_structure = "{album}/%Y".to_string();
+        config.album_name = None;
+        let derived = config.with_album_name(Arc::from(""));
+        assert_eq!(
+            derived.album_name.as_deref(),
+            Some(""),
+            "empty album name still signals per-album pass mode"
         );
     }
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -35,7 +35,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use futures_util::stream::{self, StreamExt};
 use tokio_util::sync::CancellationToken;
 
-use crate::icloud::photos::{PhotoAlbum, PhotoAsset, SyncTokenError};
+use crate::icloud::photos::{PhotoAsset, SyncTokenError};
 use crate::retry::RetryConfig;
 use crate::state::{AssetRecord, StateDb, VersionSizeKey};
 use crate::types::{
@@ -326,9 +326,19 @@ pub(crate) fn compute_config_hash(config: &crate::config::Config) -> String {
     // Enumeration-filter fields: changing these affects WHICH assets are
     // fetched from iCloud, so sync tokens must be invalidated to avoid
     // missing assets that are newly eligible under the changed filters.
-    for album in &config.albums {
-        hasher.update(album.as_bytes());
-        hasher.update(b"\0");
+    // Tag byte distinguishes the three selection modes so switching between
+    // them (e.g. `-a A` -> `-a all`) invalidates the sync token even if no
+    // explicit album name changed.
+    match &config.albums {
+        crate::config::AlbumSelection::LibraryOnly => hasher.update([0]),
+        crate::config::AlbumSelection::All => hasher.update([1]),
+        crate::config::AlbumSelection::Named(names) => {
+            hasher.update([2]);
+            for album in names {
+                hasher.update(album.as_bytes());
+                hasher.update(b"\0");
+            }
+        }
     }
     let mut sorted_excludes: Vec<&str> = config
         .exclude_albums
@@ -416,6 +426,25 @@ impl DownloadConfig {
             state_db: self.state_db.clone(),
             sync_mode: self.sync_mode.clone(),
             exclude_asset_ids: Arc::clone(&self.exclude_asset_ids),
+            bandwidth_limiter: self.bandwidth_limiter.clone(),
+            ..*self
+        }
+    }
+
+    /// Clone this config with a different `exclude_asset_ids` set, for
+    /// per-pass exclusion in multi-pass plans (e.g. the `-a all` + `{album}`
+    /// unfiled pass needs to skip anything already downloaded by a concrete
+    /// album pass).
+    fn with_exclude_ids(&self, exclude_ids: Arc<FxHashSet<String>>) -> Self {
+        Self {
+            directory: self.directory.clone(),
+            folder_structure: self.folder_structure.clone(),
+            filename_exclude: self.filename_exclude.clone(),
+            temp_suffix: self.temp_suffix.clone(),
+            state_db: self.state_db.clone(),
+            sync_mode: self.sync_mode.clone(),
+            album_name: self.album_name.clone(),
+            exclude_asset_ids: exclude_ids,
             bandwidth_limiter: self.bandwidth_limiter.clone(),
             ..*self
         }
@@ -647,13 +676,18 @@ impl DownloadContext {
 /// Used only by the Phase 2 cleanup pass — re-contacts the API so each call
 /// yields fresh CDN URLs that haven't expired during a long download session.
 async fn build_download_tasks(
-    albums: &[PhotoAlbum],
+    passes: &[crate::commands::AlbumPass],
     config: &DownloadConfig,
     shutdown_token: CancellationToken,
 ) -> Result<Vec<DownloadTask>> {
-    let album_results: Vec<Result<Vec<_>>> = stream::iter(albums)
+    let uses_album_token = config.folder_structure.contains("{album}");
+    // Per-pass fetches: collect (index -> Vec<PhotoAsset>) so we can pair
+    // each batch back to its source pass for per-pass config derivation.
+    // buffer_unordered preserves the original per-iter index since we emit
+    // (i, album) pairs explicitly.
+    let pass_results: Vec<Result<(usize, Vec<_>)>> = stream::iter(passes.iter().enumerate())
         .take_while(|_| std::future::ready(!shutdown_token.is_cancelled()))
-        .map(|album| async move { album.photos(config.recent).await })
+        .map(|(i, pass)| async move { pass.album.photos(config.recent).await.map(|a| (i, a)) })
         .buffer_unordered(config.concurrent_downloads)
         .collect()
         .await;
@@ -661,17 +695,37 @@ async fn build_download_tasks(
     let mut tasks: Vec<DownloadTask> = Vec::new();
     let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
     let mut dir_cache = paths::DirCache::new();
-    for album_result in album_results {
-        let assets = album_result?;
+    // Cache per-pass configs so repeat assets in the same pass don't
+    // re-allocate. Only populated when per-pass divergence matters
+    // ({album} path or non-empty exclude set).
+    let mut pass_configs: FxHashMap<usize, Arc<DownloadConfig>> = FxHashMap::default();
+    for pass_result in pass_results {
+        let (pass_index, assets) = pass_result?;
+        let pass = &passes[pass_index];
+
+        let effective_config: Arc<DownloadConfig> = pass_configs
+            .entry(pass_index)
+            .or_insert_with(|| {
+                if uses_album_token {
+                    Arc::new(
+                        config
+                            .with_album_name(pass.album.name.clone())
+                            .with_exclude_ids(Arc::clone(&pass.exclude_ids)),
+                    )
+                } else {
+                    Arc::new(config.with_exclude_ids(Arc::clone(&pass.exclude_ids)))
+                }
+            })
+            .clone();
 
         for asset in &assets {
-            if filter::is_asset_filtered(asset, config).is_some() {
+            if filter::is_asset_filtered(asset, &effective_config).is_some() {
                 continue;
             }
-            pre_ensure_asset_dir(&mut dir_cache, asset, config).await;
+            pre_ensure_asset_dir(&mut dir_cache, asset, &effective_config).await;
             tasks.extend(filter_asset_to_tasks(
                 asset,
-                config,
+                &effective_config,
                 &mut claimed_paths,
                 &mut dir_cache,
             ));
@@ -758,7 +812,7 @@ async fn cleanup_orphan_part_files(config: &DownloadConfig) {
 
 pub async fn download_photos_with_sync(
     download_client: &Client,
-    albums: &[PhotoAlbum],
+    passes: &[crate::commands::AlbumPass],
     config: Arc<DownloadConfig>,
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
@@ -795,7 +849,7 @@ pub async fn download_photos_with_sync(
         SyncMode::Full => {
             download_photos_full_with_token(
                 download_client,
-                albums,
+                passes,
                 &config,
                 shutdown_token.clone(),
             )
@@ -811,7 +865,7 @@ pub async fn download_photos_with_sync(
             );
             download_photos_full_with_token(
                 download_client,
-                albums,
+                passes,
                 &config,
                 shutdown_token.clone(),
             )
@@ -821,7 +875,7 @@ pub async fn download_photos_with_sync(
             let token = zone_sync_token.clone();
             match download_photos_incremental(
                 download_client,
-                albums,
+                passes,
                 &config,
                 &token,
                 shutdown_token.clone(),
@@ -854,7 +908,7 @@ pub async fn download_photos_with_sync(
                         );
                         download_photos_full_with_token(
                             download_client,
-                            albums,
+                            passes,
                             &config,
                             shutdown_token.clone(),
                         )
@@ -896,42 +950,49 @@ pub async fn download_photos_with_sync(
 /// is returned alongside the download outcome.
 async fn download_photos_full_with_token(
     download_client: &Client,
-    albums: &[PhotoAlbum],
+    passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
     shutdown_token: CancellationToken,
 ) -> Result<SyncResult> {
     let started = Instant::now();
     let uses_album_token = config.folder_structure.contains("{album}");
 
-    // Build token-aware streams for each album
-    let mut album_counts: Vec<u64> = Vec::with_capacity(albums.len());
-    for album in albums {
-        album_counts.push(album.len().await.unwrap_or(0));
+    // Build token-aware streams for each pass
+    let mut pass_counts: Vec<u64> = Vec::with_capacity(passes.len());
+    for pass in passes {
+        pass_counts.push(pass.album.len().await.unwrap_or(0));
     }
-    let mut total: u64 = album_counts.iter().sum();
+    let mut total: u64 = pass_counts.iter().sum();
     if let Some(recent) = config.recent {
         total = total.min(u64::from(recent));
     }
 
-    // When {album} is in folder_structure, process each album separately so that
-    // the album name can be threaded into path expansion. Otherwise, merge all
-    // album streams for maximum download concurrency across albums.
+    // When {album} is in folder_structure, process each pass separately so each
+    // gets its own album-specific path expansion and exclude-ids set (the
+    // unfiled pass uses a non-empty exclude set; concrete passes use empty).
+    // Otherwise, all passes share the same config (invariant: non-{album} plans
+    // have uniform exclude_ids across passes) and streams are merged for
+    // maximum cross-pass download concurrency.
     let (streaming_result, token_receivers) = if uses_album_token {
         let mut combined_result = StreamingResult::default();
-        let mut token_receivers = Vec::with_capacity(albums.len());
+        let mut token_receivers = Vec::with_capacity(passes.len());
 
-        // When {album} is in folder_structure, albums are processed sequentially
+        // When {album} is in folder_structure, passes are processed sequentially
         // so each gets its own per-album path expansion. Cross-album download
         // concurrency is intentionally sacrificed for correct path placement.
         // Assets appearing in multiple albums are downloaded once per album,
         // each to its respective album directory.
-        for (album, &count) in albums.iter().zip(&album_counts) {
+        for (pass, &count) in passes.iter().zip(&pass_counts) {
             if shutdown_token.is_cancelled() {
                 break;
             }
-            let album_config = Arc::new(config.with_album_name(album.name.clone()));
+            let pass_config = Arc::new(
+                config
+                    .with_album_name(pass.album.name.clone())
+                    .with_exclude_ids(Arc::clone(&pass.exclude_ids)),
+            );
 
-            let (stream, token_rx) = album.photo_stream_with_token(
+            let (stream, token_rx) = pass.album.photo_stream_with_token(
                 config.recent,
                 Some(count),
                 config.concurrent_downloads,
@@ -941,7 +1002,7 @@ async fn download_photos_full_with_token(
             let result = stream_and_download_from_stream(
                 download_client,
                 stream,
-                &album_config,
+                &pass_config,
                 total,
                 shutdown_token.clone(),
             )
@@ -959,12 +1020,25 @@ async fn download_photos_full_with_token(
 
         (combined_result, token_receivers)
     } else {
-        let mut token_receivers = Vec::with_capacity(albums.len());
-        let streams: Vec<_> = albums
+        // Non-{album} plans have a single exclude set shared across all passes.
+        // Use the first pass's excludes (they're uniform by construction in
+        // resolve_albums: LibraryOnly has one pass; Named/All-without-{album}
+        // have empty excludes).
+        let merged_exclude_ids = passes
+            .first()
+            .map(|p| Arc::clone(&p.exclude_ids))
+            .unwrap_or_else(|| Arc::new(FxHashSet::default()));
+        let merged_config = if Arc::ptr_eq(&merged_exclude_ids, &config.exclude_asset_ids) {
+            Arc::clone(config)
+        } else {
+            Arc::new(config.with_exclude_ids(merged_exclude_ids))
+        };
+        let mut token_receivers = Vec::with_capacity(passes.len());
+        let streams: Vec<_> = passes
             .iter()
-            .zip(&album_counts)
-            .map(|(album, &count)| {
-                let (stream, token_rx) = album.photo_stream_with_token(
+            .zip(&pass_counts)
+            .map(|(pass, &count)| {
+                let (stream, token_rx) = pass.album.photo_stream_with_token(
                     config.recent,
                     Some(count),
                     config.concurrent_downloads,
@@ -978,7 +1052,7 @@ async fn download_photos_full_with_token(
         let result = stream_and_download_from_stream(
             download_client,
             combined,
-            config,
+            &merged_config,
             total,
             shutdown_token.clone(),
         )
@@ -1025,7 +1099,7 @@ async fn download_photos_full_with_token(
     // Build the outcome using the same logic as download_photos
     let (outcome, stats) = build_download_outcome(
         download_client,
-        albums,
+        passes,
         config,
         streaming_result,
         started,
@@ -1046,7 +1120,7 @@ async fn download_photos_full_with_token(
 /// downloadable assets, and feeds them through the download pipeline.
 async fn download_photos_incremental(
     download_client: &Client,
-    albums: &[PhotoAlbum],
+    passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
     zone_sync_token: &str,
     shutdown_token: CancellationToken,
@@ -1054,10 +1128,13 @@ async fn download_photos_incremental(
     let started = Instant::now();
     let uses_album_token = config.folder_structure.contains("{album}");
 
-    // Collect change events from all albums, counting and filtering in a single pass.
-    // Each asset is paired with its source album name so that {album} token
-    // expansion works correctly in the incremental path.
-    let mut downloadable_assets: Vec<(PhotoAsset, Arc<str>)> = Vec::new();
+    // Collect change events from every pass, counting and filtering in a
+    // single pass. Each asset is paired with its source pass index so that
+    // both `{album}` token expansion and per-pass exclusion sets can be
+    // applied correctly (notably, the unfiled pass's exclude set keeps the
+    // same asset from being downloaded twice when it's in both a concrete
+    // album and the library-wide pass).
+    let mut downloadable_assets: Vec<(PhotoAsset, usize)> = Vec::new();
     let mut sync_token: Option<String> = None;
     let mut created_count = 0u64;
     let mut soft_deleted_count = 0u64;
@@ -1065,8 +1142,8 @@ async fn download_photos_incremental(
     let mut hidden_count = 0u64;
     let mut total_events = 0u64;
 
-    for album in albums {
-        let (change_stream, token_rx) = album.changes_stream(zone_sync_token);
+    for (pass_index, pass) in passes.iter().enumerate() {
+        let (change_stream, token_rx) = pass.album.changes_stream(zone_sync_token);
         tokio::pin!(change_stream);
 
         while let Some(result) = change_stream.next().await {
@@ -1079,7 +1156,7 @@ async fn download_photos_incremental(
                 ChangeReason::Created => {
                     created_count += 1;
                     if let Some(asset) = event.asset {
-                        downloadable_assets.push((asset, Arc::clone(&album.name)));
+                        downloadable_assets.push((asset, pass_index));
                     }
                 }
                 ChangeReason::SoftDeleted => {
@@ -1097,7 +1174,7 @@ async fn download_photos_incremental(
             }
         }
 
-        // Capture the sync token from this album
+        // Capture the sync token from this pass
         if let Ok(token) = token_rx.await {
             sync_token = Some(token);
         }
@@ -1151,25 +1228,33 @@ async fn download_photos_incremental(
     };
 
     // Convert assets to download tasks, using state DB fast-skip where possible.
-    // When {album} is in folder_structure, create per-album configs so the album
-    // name is threaded into path expansion (mirrors full sync behaviour).
+    // Each pass (concrete album or unfiled) gets its own derived config so
+    // that both album-specific path expansion and per-pass exclude sets are
+    // applied. Configs are cached per pass index to avoid redundant
+    // allocations when many assets flow through the same pass.
     let mut tasks: Vec<DownloadTask> = Vec::new();
     let mut claimed_paths: FxHashMap<NormalizedPath, u64> = FxHashMap::default();
     let mut dir_cache = paths::DirCache::new();
     let mut skip_breakdown = SkipBreakdown::default();
-    let mut album_configs: FxHashMap<Arc<str>, Arc<DownloadConfig>> = FxHashMap::default();
+    let mut pass_configs: FxHashMap<usize, Arc<DownloadConfig>> = FxHashMap::default();
 
-    // In {album} mode, assets in multiple albums are processed once per album,
-    // each downloading to the album-specific directory. Configs are cached per
-    // album name to avoid redundant allocations.
-    for (asset, album_name) in &downloadable_assets {
-        let effective_config: &Arc<DownloadConfig> = if uses_album_token {
-            album_configs
-                .entry(Arc::clone(album_name))
-                .or_insert_with(|| Arc::new(config.with_album_name(Arc::clone(album_name))))
-        } else {
-            config
-        };
+    for (asset, pass_index) in &downloadable_assets {
+        let pass = &passes[*pass_index];
+        let effective_config: Arc<DownloadConfig> = pass_configs
+            .entry(*pass_index)
+            .or_insert_with(|| {
+                if uses_album_token {
+                    Arc::new(
+                        config
+                            .with_album_name(pass.album.name.clone())
+                            .with_exclude_ids(Arc::clone(&pass.exclude_ids)),
+                    )
+                } else {
+                    Arc::new(config.with_exclude_ids(Arc::clone(&pass.exclude_ids)))
+                }
+            })
+            .clone();
+        let effective_config = &effective_config;
 
         if let Some(reason) = filter::is_asset_filtered(asset, effective_config) {
             match reason {
@@ -1184,17 +1269,26 @@ async fn download_photos_incremental(
 
         // Fast-skip: if state DB confirms all versions are already downloaded
         // with matching checksums, skip the filesystem check entirely.
-        let candidates = extract_skip_candidates(asset, effective_config);
-        if !candidates.is_empty()
-            && candidates.iter().all(|&(vs, cs)| {
-                matches!(
-                    download_ctx.should_download_fast(asset.id(), vs, cs, true),
-                    Some(false)
-                )
-            })
-        {
-            skip_breakdown.by_state += 1;
-            continue;
+        //
+        // This fast-path is path-blind: it keys on (asset_id, version_size,
+        // checksum) only. In `{album}` mode, the same asset may target
+        // multiple album folders (one per album it belongs to, plus the
+        // unfiled pass). Trusting the DB here would skip every copy after
+        // the first, leaving later album folders missing their file. Fall
+        // through to the filesystem-exists check, which is path-aware.
+        if !uses_album_token {
+            let candidates = extract_skip_candidates(asset, effective_config);
+            if !candidates.is_empty()
+                && candidates.iter().all(|&(vs, cs)| {
+                    matches!(
+                        download_ctx.should_download_fast(asset.id(), vs, cs, true),
+                        Some(false)
+                    )
+                })
+            {
+                skip_breakdown.by_state += 1;
+                continue;
+            }
         }
 
         pre_ensure_asset_dir(&mut dir_cache, asset, effective_config).await;
@@ -1796,7 +1890,7 @@ mod tests {
             directory: dl_config.directory.clone(),
             cookie_directory: std::path::PathBuf::from("/tmp"),
             folder_structure: dl_config.folder_structure.clone(),
-            albums: vec![],
+            albums: crate::config::AlbumSelection::LibraryOnly,
             exclude_albums: vec![],
             filename_exclude: vec![],
             library: crate::config::LibrarySelection::Single("PrimarySync".into()),
@@ -1843,7 +1937,8 @@ mod tests {
 
         // Verify album changes produce a different hash
         let mut config_with_album = app_config;
-        config_with_album.albums = vec!["Favorites".to_string()];
+        config_with_album.albums =
+            crate::config::AlbumSelection::Named(vec!["Favorites".to_string()]);
         let hash3 = compute_config_hash(&config_with_album);
         assert_ne!(hash1, hash3, "adding an album must change the hash");
     }
@@ -2408,7 +2503,7 @@ mod tests {
         let config = build_config_with(tmp.path(), "/photos", |_| {});
         let hash = compute_config_hash(&config);
         assert_eq!(
-            hash, "3854469db16cc4b3",
+            hash, "3ca58f7e3c69834f",
             "compute_config_hash golden hash changed -- this will invalidate sync tokens"
         );
     }
@@ -2422,7 +2517,7 @@ mod tests {
         });
         let hash = compute_config_hash(&config);
         assert_eq!(
-            hash, "317609ad3f64f1b3",
+            hash, "907facf5394e2fa4",
             "compute_config_hash golden hash changed -- this will invalidate sync tokens"
         );
     }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 
 /// Strip the legacy Python-style `{:%Y/%m/%d}` wrapper, returning the inner
 /// format string. Returns the input unchanged if the wrapper is absent.
-fn strip_python_wrapper(folder_structure: &str) -> &str {
+pub(crate) fn strip_python_wrapper(folder_structure: &str) -> &str {
     if folder_structure.starts_with("{:") && folder_structure.ends_with('}') {
         &folder_structure[2..folder_structure.len() - 1]
     } else {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -320,7 +320,7 @@ where
                     // Fast-skip is path-blind; in `{album}` mode the same
                     // asset legitimately lives at multiple paths, so we'd
                     // under-report the listing if we trusted the DB here.
-                    if !config.folder_structure.contains("{album}") {
+                    if !config.uses_album_expansion() {
                         let candidates = extract_skip_candidates(&asset, config);
                         if !candidates.is_empty()
                             && candidates.iter().all(|&(vs, cs)| {
@@ -550,7 +550,7 @@ where
                     // after the first download would leave later folders
                     // missing their copy. Fall through to the path-aware
                     // filesystem/dir_cache check below.
-                    if trust_state && !config.folder_structure.contains("{album}") {
+                    if trust_state && !config.uses_album_expansion() {
                         let candidates = extract_skip_candidates(&asset, config);
                         if !candidates.is_empty()
                             && candidates.iter().all(|&(vs, cs)| {

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -17,7 +17,6 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
-use crate::icloud::photos::PhotoAlbum;
 use crate::retry::RetryConfig;
 use crate::state::{AssetRecord, StateDb, SyncRunStats};
 
@@ -318,16 +317,21 @@ where
                     if is_asset_filtered(&asset, config).is_some() {
                         continue;
                     }
-                    let candidates = extract_skip_candidates(&asset, config);
-                    if !candidates.is_empty()
-                        && candidates.iter().all(|&(vs, cs)| {
-                            matches!(
-                                download_ctx.should_download_fast(asset.id(), vs, cs, true),
-                                Some(false)
-                            )
-                        })
-                    {
-                        continue;
+                    // Fast-skip is path-blind; in `{album}` mode the same
+                    // asset legitimately lives at multiple paths, so we'd
+                    // under-report the listing if we trusted the DB here.
+                    if !config.folder_structure.contains("{album}") {
+                        let candidates = extract_skip_candidates(&asset, config);
+                        if !candidates.is_empty()
+                            && candidates.iter().all(|&(vs, cs)| {
+                                matches!(
+                                    download_ctx.should_download_fast(asset.id(), vs, cs, true),
+                                    Some(false)
+                                )
+                            })
+                        {
+                            continue;
+                        }
                     }
 
                     pre_ensure_asset_dir(&mut dir_cache, &asset, config).await;
@@ -541,7 +545,12 @@ where
                         continue;
                     }
 
-                    if trust_state {
+                    // Fast-skip is path-blind; in `{album}` mode the same
+                    // asset may target multiple album folders, so skipping
+                    // after the first download would leave later folders
+                    // missing their copy. Fall through to the path-aware
+                    // filesystem/dir_cache check below.
+                    if trust_state && !config.folder_structure.contains("{album}") {
                         let candidates = extract_skip_candidates(&asset, config);
                         if !candidates.is_empty()
                             && candidates.iter().all(|&(vs, cs)| {
@@ -974,7 +983,7 @@ where
 /// `download_photos_full_with_token`.
 pub(super) async fn build_download_outcome(
     download_client: &Client,
-    albums: &[PhotoAlbum],
+    passes: &[crate::commands::AlbumPass],
     config: &Arc<DownloadConfig>,
     streaming_result: StreamingResult,
     started: Instant,
@@ -1083,7 +1092,7 @@ pub(super) async fn build_download_outcome(
         "── Cleanup pass: re-fetching URLs and retrying failed downloads ──"
     );
 
-    let fresh_tasks = super::build_download_tasks(albums, config, shutdown_token.clone()).await?;
+    let fresh_tasks = super::build_download_tasks(passes, config, shutdown_token.clone()).await?;
     tracing::debug!(
         count = fresh_tasks.len(),
         "  Re-fetched tasks with fresh URLs"

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -320,7 +320,10 @@ where
                     // Fast-skip is path-blind; in `{album}` mode the same
                     // asset legitimately lives at multiple paths, so we'd
                     // under-report the listing if we trusted the DB here.
-                    if !config.uses_album_expansion() {
+                    // `album_name.is_some()` is the right signal because by
+                    // the time this runs, `with_album_name` has expanded
+                    // `{album}` out of `folder_structure` entirely.
+                    if config.album_name.is_none() {
                         let candidates = extract_skip_candidates(&asset, config);
                         if !candidates.is_empty()
                             && candidates.iter().all(|&(vs, cs)| {
@@ -549,8 +552,12 @@ where
                     // asset may target multiple album folders, so skipping
                     // after the first download would leave later folders
                     // missing their copy. Fall through to the path-aware
-                    // filesystem/dir_cache check below.
-                    if trust_state && !config.uses_album_expansion() {
+                    // filesystem/dir_cache check below. `album_name.is_some`
+                    // is the right signal here: `with_album_name` has
+                    // already expanded `{album}` out of folder_structure
+                    // by the time this runs, so checking the template
+                    // would always be false.
+                    if trust_state && config.album_name.is_none() {
                         let candidates = extract_skip_candidates(&asset, config);
                         if !candidates.is_empty()
                             && candidates.iter().all(|&(vs, cs)| {

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -8,7 +8,7 @@ pub mod error;
 mod library;
 pub mod queries;
 pub mod session;
-mod smart_folders;
+pub(crate) mod smart_folders;
 pub mod types;
 
 pub use album::PhotoAlbum;

--- a/src/report.rs
+++ b/src/report.rs
@@ -57,7 +57,7 @@ impl RunOptions {
             live_photo_mode: format!("{:?}", config.live_photo_mode).to_lowercase(),
             live_photo_size: format!("{:?}", config.live_photo_size).to_lowercase(),
             file_match_policy: format!("{:?}", config.file_match_policy).to_lowercase(),
-            albums: config.albums.clone(),
+            albums: config.albums.to_vec(),
             library: format!("{:?}", config.library).to_lowercase(),
             skip_videos: config.skip_videos,
             skip_photos: config.skip_photos,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -27,15 +27,14 @@ use crate::state::{self, StateDb};
 use crate::systemd::SystemdNotifier;
 use crate::{available_disk_space, make_password_provider, PartialSyncError, PidFileGuard};
 
-/// Per-library state: zone name, sync token key, and resolved albums.
+/// Per-library state: zone name, sync token key, and resolved album plan.
 struct LibraryState {
     library: crate::icloud::photos::PhotoLibrary,
     zone_name: String,
     sync_token_key: String,
-    albums: Vec<crate::icloud::photos::PhotoAlbum>,
-    /// Asset IDs from excluded albums, used to filter out assets when
-    /// `--exclude-album` is set without explicit `--album`.
-    exclude_asset_ids: Arc<rustc_hash::FxHashSet<String>>,
+    /// Ordered list of download passes. Each pass carries its own
+    /// exclude-asset-ids set. See [`crate::commands::AlbumPlan`].
+    plan: crate::commands::AlbumPlan,
 }
 
 /// Arguments that [`run_sync`] needs from the CLI dispatch layer.
@@ -416,14 +415,18 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
     for library in &libraries {
         let zone_name = library.zone_name().to_string();
         let sync_token_key = format!("sync_token:{zone_name}");
-        let (albums, exclude_ids) =
-            resolve_albums(library, &config.albums, &config.exclude_albums).await?;
+        let plan = resolve_albums(
+            library,
+            &config.albums,
+            &config.exclude_albums,
+            &config.folder_structure,
+        )
+        .await?;
         library_states.push(LibraryState {
             library: library.clone(),
             zone_name,
             sync_token_key,
-            albums,
-            exclude_asset_ids: Arc::new(exclude_ids),
+            plan,
         });
     }
     sd_notifier.notify_ready();
@@ -667,12 +670,16 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             // this is expensive -- consider caching exclude_asset_ids across watch
             // cycles and only refreshing when the album's sync token changes.
             for lib_state in &mut library_states {
-                match resolve_albums(&lib_state.library, &config.albums, &config.exclude_albums)
-                    .await
+                match resolve_albums(
+                    &lib_state.library,
+                    &config.albums,
+                    &config.exclude_albums,
+                    &config.folder_structure,
+                )
+                .await
                 {
-                    Ok((refreshed, exclude_ids)) => {
-                        lib_state.albums = refreshed;
-                        lib_state.exclude_asset_ids = Arc::new(exclude_ids);
+                    Ok(refreshed) => {
+                        lib_state.plan = refreshed;
                         consecutive_album_refresh_failures = 0;
                     }
                     Err(e) => {
@@ -859,12 +866,15 @@ async fn run_cycle(
         };
         tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
 
+        // Each pass carries its own exclude-asset-ids, so the config built
+        // here starts with an empty set; download_photos_with_sync derives
+        // per-pass configs internally via `with_exclude_ids`.
         let download_config =
-            build_download_config(sync_mode, Arc::clone(&lib_state.exclude_asset_ids));
+            build_download_config(sync_mode, Arc::new(rustc_hash::FxHashSet::default()));
         let download_client = shared_session.read().await.download_client();
         let sync_result = download::download_photos_with_sync(
             &download_client,
-            &lib_state.albums,
+            &lib_state.plan.passes,
             download_config,
             shutdown_token.clone(),
         )


### PR DESCRIPTION
## Summary

Adds `-a all` to sync every user-created album in one run, and an implicit variant triggered by `{album}` in `--folder-structure`. Four variants:

| Mode | Behavior |
|---|---|
| `-a all` (no `{album}`) | every user album, no unfiled pass. Photos not in any album are skipped. |
| `-a all` + `{album}` in template | every user album + library-wide pass for unfiled photos (`{album}` collapses to empty). |
| No `-a`, no `{album}` | library-wide (today's default, unchanged). |
| No `-a`, `{album}` in template | implicit `-a all` with unfiled pass. |

- Apple's smart folders (Favorites, Screenshots, Hidden, Recently Deleted, etc.) are skipped from the `-a all` expansion. Users who want one can still name it explicitly (`-a Favorites`).
- `-a all` mixed with specific names errors at startup with "cannot combine 'all' with specific album names".
- `{album}` must be the first path segment of `--folder-structure` and may only appear once. Other placements are rejected with a quoted error.
- Photos that belong to multiple albums are copied into each album folder.
- Known limitation: the state DB tracks a single path per asset. When a photo is copied to multiple album folders, kei records only the most recently written copy. Re-runs stay idempotent because the filesystem-exists check is path-aware.
- Follow-up commit refactors per-pass config derivation to drop a double-clone and a hash lookup (see `7d1a8b1`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --bin kei` (1341 passed)
- [x] `cargo test --test cli` (95 passed)
- [x] `cargo test --test behavioral` (109 passed)
- [x] New unit tests: CLI `-a all` parsing, `Config::build` validation (all / mixed / case-insensitive / smart default / nested `{album}` / duplicate `{album}` / python-wrapper), `resolve_albums` expansion paths (user albums, exclude handling, unfiled pass population), `AlbumSelection::to_vec` roundtrip, `DownloadConfig::with_pass`
- [x] Golden `compute_config_hash` values updated (tag byte added to distinguish selection modes)
- [x] Manual run against a live iCloud account with `-a all` and `-a all --folder-structure "{album}/%Y/%m/%d"`; confirm user albums land under per-album folders and unfiled photos land at the collapsed path
- [x] Manual run confirms `-a all --exclude-album Foo` skips Foo from both album passes and the unfiled set

Closes #215.

