### PR TITLE
chore: lint and test hardening after #249 blocking_lock() fix

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,7 @@
 too-many-arguments-threshold = 8
+
+disallowed-methods = [
+    { path = "tokio::sync::Mutex::blocking_lock", reason = "panics inside a tokio runtime; see PR #249. Restructure to async or take the value at construction." },
+    { path = "tokio::sync::RwLock::blocking_read", reason = "panics inside a tokio runtime. Restructure to async or take the value at construction." },
+    { path = "tokio::sync::RwLock::blocking_write", reason = "panics inside a tokio runtime. Restructure to async or take the value at construction." },
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 //! failures.
 
 #![warn(clippy::all)]
+#![warn(clippy::await_holding_lock)]
 
 mod auth;
 mod cli;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1101,8 +1101,12 @@ mod tests {
             .build()
             .unwrap();
 
+        // spawn_server binds to 0.0.0.0; dial via 127.0.0.1 because Windows
+        // treats 0.0.0.0 as AddrNotAvailable on connect.
+        let base = format!("http://127.0.0.1:{}", addr.port());
+
         let metrics_resp = client
-            .get(format!("http://{addr}/metrics"))
+            .get(format!("{base}/metrics"))
             .send()
             .await
             .expect("GET /metrics should succeed");
@@ -1124,7 +1128,7 @@ mod tests {
         );
 
         let healthz_resp = client
-            .get(format!("http://{addr}/healthz"))
+            .get(format!("{base}/healthz"))
             .send()
             .await
             .expect("GET /healthz should succeed");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -449,7 +449,7 @@ pub(crate) fn spawn_server(
     port: u16,
     shutdown_token: CancellationToken,
     staleness_threshold: Option<chrono::Duration>,
-) -> anyhow::Result<(MetricsHandle, tokio::task::JoinHandle<()>)> {
+) -> anyhow::Result<(MetricsHandle, tokio::task::JoinHandle<()>, SocketAddr)> {
     let handle = MetricsHandle::new(staleness_threshold);
     let app = Router::new()
         .route("/metrics", get(handle_metrics))
@@ -459,10 +459,14 @@ pub(crate) fn spawn_server(
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let std_listener = std::net::TcpListener::bind(addr)
         .map_err(|e| anyhow::anyhow!("Failed to bind metrics server on port {port}: {e}"))?;
+    let local_addr = std_listener.local_addr()?;
     std_listener.set_nonblocking(true)?;
     let listener = tokio::net::TcpListener::from_std(std_listener)?;
 
-    tracing::info!(port, "Prometheus metrics server listening");
+    tracing::info!(
+        port = local_addr.port(),
+        "Prometheus metrics server listening"
+    );
 
     let task = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app)
@@ -471,10 +475,13 @@ pub(crate) fn spawn_server(
         {
             tracing::warn!(error = %e, "Metrics server error");
         }
-        tracing::info!(port, "Prometheus metrics server stopped");
+        tracing::info!(
+            port = local_addr.port(),
+            "Prometheus metrics server stopped"
+        );
     });
 
-    Ok((handle, task))
+    Ok((handle, task, local_addr))
 }
 
 #[cfg(test)]
@@ -1071,5 +1078,59 @@ mod tests {
             result.err()
         );
         token.cancel();
+    }
+
+    /// Full end-to-end smoke test: the real axum stack, a real TCP socket, and a
+    /// real HTTP client. Catches regressions anywhere between `spawn_server` and
+    /// the response body that the handler unit tests (which call `handle_*`
+    /// directly against a `State`) cannot see.
+    #[tokio::test]
+    async fn spawn_server_serves_metrics_and_healthz_over_http() {
+        let token = CancellationToken::new();
+        let (handle, task, addr) =
+            spawn_server(0, token.clone(), Some(chrono::Duration::seconds(3600)))
+                .expect("spawn_server should bind and spawn");
+
+        // Push a healthy cycle so /healthz returns 200 instead of the pre-first-cycle 503.
+        handle
+            .update(&SyncStats::default(), &healthy_status(0))
+            .await;
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let metrics_resp = client
+            .get(format!("http://{addr}/metrics"))
+            .send()
+            .await
+            .expect("GET /metrics should succeed");
+        assert_eq!(metrics_resp.status(), reqwest::StatusCode::OK);
+        let ct = metrics_resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            ct.contains("application/openmetrics-text"),
+            "unexpected content-type: {ct}"
+        );
+        let body = metrics_resp.text().await.unwrap();
+        assert!(
+            body.contains("kei_sync_assets_seen_total"),
+            "expected kei_sync_* counters in body:\n{body}"
+        );
+
+        let healthz_resp = client
+            .get(format!("http://{addr}/healthz"))
+            .send()
+            .await
+            .expect("GET /healthz should succeed");
+        assert_eq!(healthz_resp.status(), reqwest::StatusCode::OK);
+
+        token.cancel();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), task).await;
     }
 }

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -491,7 +491,7 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         .metrics_port
         .map(|port| crate::metrics::spawn_server(port, shutdown_token.clone(), staleness_threshold))
         .transpose()?
-        .map_or((None, None), |(h, t)| (Some(h), Some(t)));
+        .map_or((None, None), |(h, t, _addr)| (Some(h), Some(t)));
 
     let mut health = health::HealthStatus::new();
     let mut consecutive_album_refresh_failures = 0u32;


### PR DESCRIPTION
Follow-up to #249 (thanks @billimek) to keep the `blocking_lock()` panic from coming back.

## Changes

1. `clippy.toml` bans `tokio::sync::Mutex::blocking_lock`, `RwLock::blocking_read`, and `RwLock::blocking_write` via `disallowed-methods`. These panic unconditionally inside a tokio runtime, so clippy refuses them now. Existing call sites are already clean.

2. `src/main.rs` enables `clippy::await_holding_lock`. Same failure class as #249: sync-blocking semantics tangled with async. The lint flags holding a `std` `Mutex`/`RwLock`/`RefCell` guard across `.await`, which deadlocks. Matches the CLAUDE.md convention of explicit `drop()` before re-acquiring. No existing call sites violate it.

3. `spawn_server` returns the bound `SocketAddr` alongside the handle and task. Needed so tests can bind port 0 and reach the server at its assigned port. Caller in `sync_loop.rs` updated (one-line destructure).

4. New test `spawn_server_serves_metrics_and_healthz_over_http` drives the real axum stack over a TCP socket with a reqwest client. Asserts:
   - `GET /metrics` returns 200 with `application/openmetrics-text` content-type and the expected `kei_sync_*` counter names.
   - `GET /healthz` returns 200 after a successful cycle.

   Complements the no-panic regression test from #249, which only asserts `spawn_server` returns `Ok`. This one exercises everything downstream - routing, serialization, graceful shutdown.

## Verification

- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo test --bin kei metrics::\` 32 passed