### PR TITLE
chore: broader clippy lint sweep (panic/logging/cast)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,3 +137,30 @@ path = "tests/sync.rs"
 [[test]]
 name = "state_auth"
 path = "tests/state_auth.rs"
+
+[lints.clippy]
+# Baseline lint group. Lower priority so individual lints below can override.
+all = { level = "warn", priority = -1 }
+
+# Locking footguns: holding a std::sync lock across .await deadlocks.
+# Same failure class as #249's blocking_lock panic.
+await_holding_lock = "warn"
+
+# Panic footguns. Tests scope these off inside `#[cfg(test)] mod tests`.
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+unreachable = "warn"
+
+# Logging hygiene. `tracing` is the only approved logger. Allowed with reasons
+# in the stdout-producing CLI subcommands and a few pre-tracing paths.
+print_stdout = "warn"
+print_stderr = "warn"
+dbg_macro = "warn"
+
+# Numeric-cast correctness. Every remaining site has a reviewed `#[allow]` + reason.
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"

--- a/src/auth/twofa.rs
+++ b/src/auth/twofa.rs
@@ -361,6 +361,10 @@ async fn submit_2fa_code_inner(
 ///
 /// Returns the trimmed input. An empty string means the user pressed Enter
 /// without typing a code (i.e. they want a new code sent to their device).
+#[allow(
+    clippy::print_stdout,
+    reason = "interactive TTY prompt; tracing is not appropriate for a user input prompt"
+)]
 pub async fn prompt_2fa_code() -> Result<String> {
     Ok(tokio::task::spawn_blocking(|| {
         print!("Enter 2FA code (or press Enter to request a new code): ");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,10 @@ fn parse_2fa_code(s: &str) -> Result<String, String> {
 }
 
 /// Print a deprecation warning to stderr.
+#[allow(
+    clippy::print_stderr,
+    reason = "runs during CLI arg parsing, before tracing subscriber is installed"
+)]
 pub(crate) fn deprecation_warning(old: &str, new: &str) {
     eprintln!("warning: `{old}` is deprecated, use `{new}` instead");
 }

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print the resolved config to stdout"
+)]
+
 use crate::cli;
 use crate::config;
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print import-existing progress to stdout"
+)]
+
 use std::sync::Arc;
 
 use crate::auth;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print album/library lists to stdout"
+)]
+
 use crate::auth;
 use crate::cli;
 use crate::config;

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print login/2FA status to stdout"
+)]
+
 use crate::auth;
 use crate::cli;
 use crate::config;

--- a/src/commands/password.rs
+++ b/src/commands/password.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print credential-store status to stdout"
+)]
+
 use crate::cli;
 use crate::config;
 use crate::credential;

--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -15,6 +15,11 @@
 //! change is status transitions from `downloaded` -> `failed`, which the
 //! normal sync path knows how to retry.
 
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print a reconcile report to stdout"
+)]
+
 use std::path::PathBuf;
 
 use crate::cli;
@@ -145,11 +150,17 @@ pub(crate) async fn run_reconcile(
             {
                 Ok(()) => marked_failed += 1,
                 Err(e) => {
-                    eprintln!(
-                        "  failed to mark {}:{} as failed: {e}",
-                        m.id,
-                        m.version_size.as_str()
-                    );
+                    #[allow(
+                        clippy::print_stderr,
+                        reason = "reconcile is a CLI subcommand that reports to the user via stdout/stderr"
+                    )]
+                    {
+                        eprintln!(
+                            "  failed to mark {}:{} as failed: {e}",
+                            m.id,
+                            m.version_size.as_str()
+                        );
+                    }
                     mark_errors += 1;
                 }
             }

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print reset status to stdout"
+)]
+
 use crate::config;
 use crate::state;
 use crate::state::StateDb;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -299,6 +299,10 @@ where
             Err(e) => return Err(e),
         }
     }
+    #[allow(
+        clippy::expect_used,
+        reason = "loop runs MAX_ATTEMPTS >= 1 times; last_err set on every iteration"
+    )]
     Err(last_err.expect("MAX_ATTEMPTS must be >= 1"))
 }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print a status report to stdout"
+)]
+
 use crate::cli;
 use crate::config;
 use crate::state;

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI subcommand whose primary purpose is to print verification results to stdout"
+)]
+
 use std::path::Path;
 
 use crate::cli;

--- a/src/config.rs
+++ b/src/config.rs
@@ -492,7 +492,13 @@ pub(crate) fn resolve_data_dir(
         return expand_tilde(d);
     }
     if let Some(d) = cookie_directory_cli {
-        eprintln!("warning: `--cookie-directory` is deprecated, use `--data-dir` instead");
+        #[allow(
+            clippy::print_stderr,
+            reason = "runs during config load, before tracing subscriber is installed"
+        )]
+        {
+            eprintln!("warning: `--cookie-directory` is deprecated, use `--data-dir` instead");
+        }
         return expand_tilde(d);
     }
     if let Some(d) = toml.and_then(|t| t.data_dir.as_deref()) {
@@ -502,9 +508,15 @@ pub(crate) fn resolve_data_dir(
         .and_then(|t| t.auth.as_ref())
         .and_then(|a| a.cookie_directory.as_deref())
     {
-        eprintln!(
-            "warning: `[auth] cookie_directory` is deprecated, use top-level `data_dir` instead"
-        );
+        #[allow(
+            clippy::print_stderr,
+            reason = "runs during config load, before tracing subscriber is installed"
+        )]
+        {
+            eprintln!(
+                "warning: `[auth] cookie_directory` is deprecated, use top-level `data_dir` instead"
+            );
+        }
         return expand_tilde(d);
     }
     // Default: parent of config file path

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -52,7 +52,15 @@ pub(crate) fn extract_xmp_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
             return None;
         }
         let extent = loc.extents.first()?;
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "HEIC file byte offsets/lengths fit in usize on 64-bit; kei targets 64-bit platforms"
+        )]
         let start = loc.base_offset.saturating_add(extent.offset) as usize;
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "HEIC extent length fits in usize on 64-bit"
+        )]
         let end = start + extent.length as usize;
         if end > bytes.len() {
             return None;
@@ -135,6 +143,10 @@ pub(crate) fn insert_xmp(input: &[u8], xmp: &[u8]) -> Result<Vec<u8>> {
     // of offset value, so we can append the mdat atom first, compute the
     // resulting running offsets, then populate the iloc offset.
     let new_item_id = {
+        #[allow(
+            clippy::unreachable,
+            reason = "meta_idx comes from matches!(a, Any::Meta(_)) above"
+        )]
         let Any::Meta(meta) = &atoms[meta_idx] else {
             unreachable!()
         };
@@ -147,6 +159,10 @@ pub(crate) fn insert_xmp(input: &[u8], xmp: &[u8]) -> Result<Vec<u8>> {
     // Insert placeholder iloc entry (offset=0) and iinf entry so that running
     // offsets reflect the final meta size.
     {
+        #[allow(
+            clippy::unreachable,
+            reason = "meta_idx comes from matches!(a, Any::Meta(_)) above"
+        )]
         let Any::Meta(meta) = &mut atoms[meta_idx] else {
             unreachable!()
         };
@@ -375,21 +391,21 @@ fn next_free_item_id(meta: &Meta) -> u32 {
 }
 
 fn push_iinf_entry(meta: &mut Meta, entry: ItemInfoEntry) {
-    if meta.get::<Iinf>().is_none() {
-        meta.push(Iinf {
-            item_infos: Vec::new(),
-        });
+    match meta.get_mut::<Iinf>() {
+        Some(iinf) => iinf.item_infos.push(entry),
+        None => meta.push(Iinf {
+            item_infos: vec![entry],
+        }),
     }
-    meta.get_mut::<Iinf>().unwrap().item_infos.push(entry);
 }
 
 fn push_iloc_entry(meta: &mut Meta, loc: ItemLocation) {
-    if meta.get::<Iloc>().is_none() {
-        meta.push(Iloc {
-            item_locations: Vec::new(),
-        });
+    match meta.get_mut::<Iloc>() {
+        Some(iloc) => iloc.item_locations.push(loc),
+        None => meta.push(Iloc {
+            item_locations: vec![loc],
+        }),
     }
-    meta.get_mut::<Iloc>().unwrap().item_locations.push(loc);
 }
 
 #[cfg(test)]

--- a/src/download/limiter.rs
+++ b/src/download/limiter.rs
@@ -20,6 +20,10 @@ pub(crate) struct BandwidthLimiter {
 impl BandwidthLimiter {
     pub(crate) fn new(bytes_per_sec: u64) -> Self {
         Self {
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "bandwidth limits are configured by humans and fit easily in f64 precision"
+            )]
             inner: <Limiter>::builder(bytes_per_sec as f64).build(),
         }
     }
@@ -33,7 +37,13 @@ impl BandwidthLimiter {
     }
 
     pub(crate) fn bytes_per_sec(&self) -> u64 {
-        self.inner.speed_limit() as u64
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "speed_limit is a non-negative rate configured as u64 originally; round-tripping is lossless for realistic values"
+        )]
+        let v = self.inner.speed_limit() as u64;
+        v
     }
 }
 

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -453,11 +453,22 @@ fn encode_gps(decimal: f64, pos: char, neg: char) -> String {
     let abs = decimal.abs();
     let deg = abs.floor();
     let min = (abs - deg) * 60.0;
-    format!("{},{:.4}{}", deg as u32, min, hemisphere)
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "deg is floor of abs(lat|lon) so 0..=180; always fits in u32 with no sign"
+    )]
+    let deg_u32 = deg as u32;
+    format!("{deg_u32},{min:.4}{hemisphere}")
 }
 
 /// XMP `exif:GPSAltitude` is a rational; we use `meters/1` (scale of 1).
 fn encode_altitude(meters: f64) -> String {
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "abs() is non-negative; altitudes in millimeters never approach u64::MAX"
+    )]
     let scaled = (meters.abs() * 1000.0).round() as u64;
     format!("{scaled}/1000")
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1569,6 +1569,10 @@ async fn download_photos_incremental(
     }
 
     if config.only_print_filenames {
+        #[allow(
+            clippy::print_stdout,
+            reason = "--only-print-filenames writes target paths to stdout so callers can pipe to xargs/etc"
+        )]
         for task in &tasks {
             println!("{}", task.download_path.display());
         }

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -390,6 +390,10 @@ pub(crate) fn normalize_ampm(s: &str) -> String {
         } else {
             // Multi-byte UTF-8: decode the char and advance past it
             // Safe: i < len and bytes[i] >= 0x80 guarantees a multi-byte char starts here
+            #[allow(
+                clippy::expect_used,
+                reason = "i < len bound checked above; &str guarantees valid UTF-8 so chars().next() is Some"
+            )]
             let ch = s[i..]
                 .chars()
                 .next()

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -678,6 +678,10 @@ where
                     pre_ensure_asset_dir(&mut dir_cache, &asset, config).await;
                     let tasks =
                         filter_asset_to_tasks(&asset, config, &mut claimed_paths, &mut dir_cache);
+                    #[allow(
+                        clippy::print_stdout,
+                        reason = "--only-print-filenames writes target paths to stdout so callers can pipe to xargs/etc"
+                    )]
                     for task in &tasks {
                         println!("{}", task.download_path.display());
                     }
@@ -892,10 +896,17 @@ where
                 BatchForecast::Continue => false,
                 BatchForecast::Warn => {
                     if let Some(free) = initial_free {
+                        #[allow(
+                            clippy::cast_precision_loss,
+                            clippy::cast_possible_truncation,
+                            clippy::cast_sign_loss,
+                            reason = "percent is 0..=100 after ratio; logged as a diagnostic, not used for control flow"
+                        )]
+                        let percent = (total as f64 * 100.0 / free as f64) as u64;
                         tracing::warn!(
                             queued_bytes = total,
                             initial_free_bytes = free,
-                            percent_of_free = (total as f64 * 100.0 / free as f64) as u64,
+                            percent_of_free = percent,
                             "Queued download batch approaching 90% of initial free disk space"
                         );
                     }
@@ -2171,6 +2182,10 @@ pub(super) fn format_duration(d: Duration) -> String {
     }
 }
 
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "display-only byte-size formatting; precision loss at exabyte scale is fine for a human-readable string"
+)]
 fn format_bytes(bytes: u64) -> String {
     if bytes >= 1_073_741_824 {
         format!("{:.1} GiB", bytes as f64 / 1_073_741_824.0)

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -53,7 +53,12 @@ type ChangeStream = Pin<Box<dyn Stream<Item = anyhow::Result<ChangeEvent>> + Sen
 /// and never more than the requested concurrency level.
 fn determine_fetcher_count(total_items: u64, page_size: usize, concurrency: usize) -> usize {
     let total_pages = total_items.div_ceil(page_size as u64);
-    (total_pages as usize).min(concurrency).max(1)
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "bounded to concurrency (usize) immediately via .min()"
+    )]
+    let pages_as_usize = total_pages as usize;
+    pages_as_usize.min(concurrency).max(1)
 }
 
 /// Configuration for creating a `PhotoAlbum`, bundling all non-session fields.
@@ -413,6 +418,10 @@ impl PhotoAlbum {
             mpsc::channel::<anyhow::Result<PhotoAsset>>((page_size * num_fetchers).min(500));
 
         if num_fetchers > 1 {
+            #[allow(
+                clippy::expect_used,
+                reason = "effective_total is unconditionally set when num_fetchers > 1 (see compute above)"
+            )]
             let total = effective_total.expect("effective_total set when num_fetchers > 1");
             // Partition offset range into non-overlapping chunks aligned to
             // page_size boundaries so each fetcher starts on a clean page.
@@ -441,7 +450,12 @@ impl PhotoAlbum {
                 let fetcher_limit = match limit {
                     Some(lim) => {
                         let remaining = u64::from(lim).saturating_sub(start);
-                        Some(remaining.min(end - start) as u32)
+                        #[allow(
+                            clippy::cast_possible_truncation,
+                            reason = "bounded by min(end-start, limit) where both operands originated from u32 fetcher limits"
+                        )]
+                        let capped = remaining.min(end - start) as u32;
+                        Some(capped)
                     }
                     None => None,
                 };

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -81,8 +81,15 @@ fn decode_filename(fields: &Value) -> Option<String> {
 /// Convert an `f64` millisecond timestamp to a `DateTime<Utc>`, returning
 /// `None` if the value is out of `i64` range.
 pub(crate) fn f64_to_millis_datetime(ms: f64) -> Option<DateTime<Utc>> {
-    if (i64::MIN as f64..=i64::MAX as f64).contains(&ms) {
-        Utc.timestamp_millis_opt(ms as i64).single()
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "range check is conservative; exact i64 precision loss at the extremes is fine since we only need a membership test"
+    )]
+    let in_range = (i64::MIN as f64..=i64::MAX as f64).contains(&ms);
+    if in_range {
+        #[allow(clippy::cast_possible_truncation, reason = "bounds checked above")]
+        let ms_i64 = ms as i64;
+        Utc.timestamp_millis_opt(ms_i64).single()
     } else {
         None
     }

--- a/src/icloud/photos/enc.rs
+++ b/src/icloud/photos/enc.rs
@@ -96,6 +96,10 @@ pub fn decode_location(fields: &Value, key: &str) -> Option<Location> {
 fn plist_to_f64(value: &PlistValue) -> Option<f64> {
     match value {
         PlistValue::Real(r) => Some(*r),
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "plist integers encoding GPS/location values fit well within f64 mantissa"
+        )]
         PlistValue::Integer(i) => i.as_signed().map(|v| v as f64),
         _ => None,
     }

--- a/src/icloud/photos/mod.rs
+++ b/src/icloud/photos/mod.rs
@@ -148,6 +148,10 @@ impl PhotosService {
             self.private_libraries = Some(libs);
         }
         // Safe: we just ensured private_libraries is Some above
+        #[allow(
+            clippy::unreachable,
+            reason = "private_libraries was set to Some on the line above; None is impossible here"
+        )]
         Ok(self
             .private_libraries
             .as_ref()
@@ -163,6 +167,10 @@ impl PhotosService {
             self.shared_libraries = Some(libs);
         }
         // Safe: we just ensured shared_libraries is Some above
+        #[allow(
+            clippy::unreachable,
+            reason = "shared_libraries was set to Some on the line above; None is impossible here"
+        )]
         Ok(self
             .shared_libraries
             .as_ref()

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -287,6 +287,10 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
                     // at least one record with `serverErrorCode` set, which
                     // always assigns `last_ck_err`. The expect encodes that
                     // invariant — it cannot fire at runtime.
+                    #[allow(
+                        clippy::expect_used,
+                        reason = "invariant: valid_count==0 implies the errored loop ran and assigned last_ck_err"
+                    )]
                     return Err(last_ck_err.expect("errored is non-empty").into());
                 }
                 tracing::warn!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,26 @@
 //! Authentication uses SRP-6a with Apple's custom variant, followed by optional
 //! 2FA. Photos are streamed with exponential-backoff retries on transient
 //! failures.
+//!
+//! Lint configuration lives in `[lints.clippy]` in `Cargo.toml`.
 
-#![warn(clippy::all)]
-#![warn(clippy::await_holding_lock)]
+// Test code is exempt from the panic-footgun, logging-hygiene, and
+// numeric-cast lints that prod code enforces: unwrap/expect/panic are
+// idiomatic in tests, a few tests write to stderr for failure diagnostics,
+// and test fixtures commonly use `as` casts on values known to fit.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unimplemented,
+        clippy::print_stderr,
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+    )
+)]
 
 mod auth;
 mod cli;
@@ -315,6 +332,10 @@ fn main() -> ExitCode {
     // SAFETY: no other threads exist yet — the tokio runtime has not been built.
     unsafe { std::env::remove_var("ICLOUD_PASSWORD") };
 
+    #[allow(
+        clippy::expect_used,
+        reason = "startup failure: no runtime means nothing can run"
+    )]
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -337,7 +358,13 @@ fn main() -> ExitCode {
                 // Also echo to stderr unconditionally as a fallback for early
                 // failures before `tracing_subscriber::fmt().init()` runs.
                 tracing::error!(error = format!("{e:#}"), "kei exited with error");
-                eprintln!("Error: {e:#}");
+                #[allow(
+                    clippy::print_stderr,
+                    reason = "fallback for failures that happen before tracing subscriber is installed"
+                )]
+                {
+                    eprintln!("Error: {e:#}");
+                }
                 if e.downcast_ref::<PartialSyncError>().is_some() {
                     ExitCode::from(EXIT_PARTIAL)
                 } else if e.downcast_ref::<auth::error::AuthError>().is_some() {
@@ -539,6 +566,10 @@ async fn run(env_password: Option<String>) -> anyhow::Result<()> {
         },
         Command::Sync { password, sync } => (sync.retry_failed, password, sync),
         // Legacy variants should never reach here (effective_command maps them)
+        #[allow(
+            clippy::unreachable,
+            reason = "effective_command() maps every legacy variant to a modern one before this match"
+        )]
         _ => unreachable!("legacy command variants should be mapped by effective_command()"),
     };
     sync_loop::run_sync(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -346,7 +346,11 @@ impl MetricsHandle {
             .set(i64::from(health.consecutive_failures));
         let last_success_ts = health
             .last_success_at
-            .map(|t| t.timestamp() as f64)
+            .map(|t| {
+                #[allow(clippy::cast_precision_loss, reason = "OpenMetrics timestamp format is f64 seconds; precision loss at the second level is below the metric's granularity")]
+                let ts = t.timestamp() as f64;
+                ts
+            })
             .unwrap_or(0.0);
         self.last_success_timestamp.set(last_success_ts);
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -147,7 +147,13 @@ where
 
     // This is unreachable: the loop always runs at least once (total_attempts >= 1)
     // and either returns Ok, returns Err on abort, or returns Err on last attempt.
-    unreachable!("retry loop must return before exhausting iterations")
+    #[allow(
+        clippy::unreachable,
+        reason = "loop always returns via Ok, abort-Err, or last-attempt Err"
+    )]
+    {
+        unreachable!("retry loop must return before exhausting iterations")
+    }
 }
 
 #[cfg(test)]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "interactive setup wizard whose purpose is to drive a stdout dialogue"
+)]
+
 use std::fmt::Write as FmtWrite;
 use std::io::IsTerminal;
 use std::path::Path;

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -706,7 +706,12 @@ impl StateDb for SqliteStateDb {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| StateError::query("get_failed_sample", e))?;
 
-        Ok((records, total.max(0) as u64))
+        #[allow(
+            clippy::cast_sign_loss,
+            reason = ".max(0) clamps any negative COUNT(*) result to 0 before the cast"
+        )]
+        let total_u64 = total.max(0) as u64;
+        Ok((records, total_u64))
     }
 
     async fn get_pending(&self) -> Result<Vec<AssetRecord>, StateError> {
@@ -948,6 +953,7 @@ impl StateDb for SqliteStateDb {
                 |row| row.get(0),
             )
             .map_err(|e| StateError::query("prepare_for_retry", e))?;
+        #[allow(clippy::cast_sign_loss, reason = "SQL COUNT(*) is always non-negative")]
         let total_pending = total_pending as u64;
 
         Ok((failed, pending, total_pending))

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -248,6 +248,10 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             .is_some_and(crate::icloud::error::ICloudError::is_session_error)
     };
     let (shared_session, mut photos_service, libraries) = loop {
+        #[allow(
+            clippy::expect_used,
+            reason = "pending_auth is re-populated at the end of every retry branch before looping"
+        )]
         let this_auth = pending_auth
             .take()
             .expect("auth_result present at start of attempt");
@@ -577,14 +581,21 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
                 // reflects the final committed set, not mid-sync churn.
                 // get_failed_sample pushes the LIMIT into SQL so an account
                 // with thousands of failures doesn't load every row here.
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "FAILED_ASSETS_CAP is a small compile-time constant well under u32::MAX"
+                )]
+                let cap_u32 = crate::report::FAILED_ASSETS_CAP as u32;
                 let (failed_assets, failed_assets_truncated) = match state_db.as_ref() {
-                    Some(db) => match db
-                        .get_failed_sample(crate::report::FAILED_ASSETS_CAP as u32)
-                        .await
-                    {
+                    Some(db) => match db.get_failed_sample(cap_u32).await {
                         Ok((records, total)) => {
+                            #[allow(
+                                clippy::cast_possible_truncation,
+                                reason = "failed-asset totals are persisted counts of per-sync failures, comfortably below usize::MAX on 64-bit"
+                            )]
+                            let total_usize = total as usize;
                             let truncated =
-                                (total as usize).saturating_sub(crate::report::FAILED_ASSETS_CAP);
+                                total_usize.saturating_sub(crate::report::FAILED_ASSETS_CAP);
                             let entries: Vec<_> = records
                                 .iter()
                                 .map(crate::report::FailedAssetEntry::from_record)

--- a/tests/behavioral.rs
+++ b/tests/behavioral.rs
@@ -4,6 +4,17 @@
 //! deprecation warnings, config resolution, and error messages.
 //! No network, no iCloud credentials required.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unimplemented,
+    clippy::print_stderr,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
 mod common;
 
 use predicates::prelude::*;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,17 @@
 //! Validates that every subcommand, flag, and enum value is accepted or
 //! rejected by the argument parser as expected.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unimplemented,
+    clippy::print_stderr,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
 mod common;
 
 use predicates::prelude::*;

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -7,6 +7,17 @@
 //! cargo test --test state_auth -- --ignored --test-threads=1
 //! ```
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unimplemented,
+    clippy::print_stderr,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
 mod common;
 
 use predicates::prelude::*;

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -13,6 +13,17 @@
 //! cargo test --test sync -- --ignored --test-threads=1
 //! ```
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unimplemented,
+    clippy::print_stderr,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
 mod common;
 
 use predicates::prelude::*;


### PR DESCRIPTION
Follow-up to #252. Widens the clippy warning surface and consolidates lint config into `[lints.clippy]` in `Cargo.toml`; the two pre-existing `#![warn]` attrs in `src/main.rs` move there.

## Lints enabled at `warn`

Panic footguns: `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, `unreachable`.

Logging hygiene: `print_stdout`, `print_stderr`, `dbg_macro`.

Numeric-cast correctness: `cast_possible_truncation`, `cast_precision_loss`, `cast_sign_loss`.

## Prod fixes + allows

- 2 prod unwraps in `src/download/heif.rs` restructured. `push_iinf_entry` / `push_iloc_entry` now `match meta.get_mut::<T>()` and construct with the entry inline on `None`, eliminating the is_none + unwrap-after-insert pattern. No allow.
- 6 `expect_used` sites keep the `expect()` with `#[allow(...)] reason = "..."`: tokio runtime build in `main`, `MAX_ATTEMPTS >= 1` in `commands/service`, UTF-8 char-boundary proof in `download/paths`, `effective_total` when multi-fetcher in `icloud/photos/album`, CloudKit errored-loop invariant in `icloud/photos/session`, sync-loop `pending_auth` re-population in `sync_loop`.
- 6 `unreachable!` sites keep the macro with reasons: two HEIC `let Any::Meta(meta) = ... else` refutations in `download/heif`, two `PhotosService` just-set-to-Some cases in `icloud/photos/mod`, retry-loop never-exhausts in `retry`, effective_command legacy-variant guard in `main`.
- `print_stdout` (128 prod hits) scoped module-level in the 9 stdout-producing CLI subcommands (`commands/{status,reconcile,verify,reset,import,list,login,password,config_cmd}.rs` plus `setup.rs`). Per-block allows in `auth/twofa` (2FA prompt), `download/pipeline` and `download/mod` (both the `--only-print-filenames` output).
- `print_stderr` (5 prod hits) per-site allows with reasons: deprecation warnings in `cli` / `config` (pre-tracing), final-error fallback in `main`, reconcile CLI error path.
- 27 numeric-cast sites per-site allows naming the bound: HEIC byte-offset fits in usize on 64-bit, GPS degrees in 0..=180, SQL `COUNT(*)` non-negative, `FAILED_ASSETS_CAP` is small, display-only byte formatting, and so on.

Test code scopes these off via `#![cfg_attr(test, allow(...))]` at the crate root for the `src/*` unit tests, plus a `#![allow(...)]` at the top of each `tests/*.rs` integration crate.

## Skipped

`clippy::indexing_slicing` (77 prod hits, mostly length-checked slices). Tracked in #253.

`clippy::pedantic` wholesale, `clippy::nursery`, `clippy::cargo`. Too much noise for too little signal here.

## Verification

- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean
- \`cargo test --bin kei\` 1576 passed
- \`cargo test --test cli --test behavioral\` 95 passed
- \`cargo run -- --help\` and \`cargo run -- config show\` exercise the `print_stdout`-allow paths