### PR TITLE
Enable clippy::indexing_slicing in prod (closes #253)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,9 +2382,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,11 +126,6 @@ sha1 = "0.10"
 # tests in the auth layer don't sleep through real wall-clock delays.
 tokio = { version = "1", features = ["test-util"] }
 
-[lints.clippy]
-# Flag `[]` / `[..]` panic footguns so we reach for `.get()` / `.first()` or an
-# explicit, invariant-documenting `#[allow]` at each site.
-indexing_slicing = "warn"
-
 [[test]]
 name = "cli"
 path = "tests/cli.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,11 @@ sha1 = "0.10"
 # tests in the auth layer don't sleep through real wall-clock delays.
 tokio = { version = "1", features = ["test-util"] }
 
+[lints.clippy]
+# Flag `[]` / `[..]` panic footguns so we reach for `.get()` / `.first()` or an
+# explicit, invariant-documenting `#[allow]` at each site.
+indexing_slicing = "warn"
+
 [[test]]
 name = "cli"
 path = "tests/cli.rs"
@@ -164,3 +169,7 @@ dbg_macro = "warn"
 cast_possible_truncation = "warn"
 cast_precision_loss = "warn"
 cast_sign_loss = "warn"
+
+# `[]` / `[..]` panic footguns. Refactor to `.get()` / `.first()` / pattern
+# match, or scope an `#[allow]` with a comment naming the invariant.
+indexing_slicing = "warn"

--- a/src/auth/srp.rs
+++ b/src/auth/srp.rs
@@ -195,8 +195,8 @@ fn compute_m1(
     let h_g = Sha256::digest(&g_padded);
     // XOR the hashes into a fixed array instead of Vec
     let mut h_xor = [0u8; 32];
-    for (i, (a, b)) in h_n.iter().zip(h_g.iter()).enumerate() {
-        h_xor[i] = a ^ b;
+    for ((out, a), b) in h_xor.iter_mut().zip(h_n.iter()).zip(h_g.iter()) {
+        *out = a ^ b;
     }
     let h_username = Sha256::digest(username);
 

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -578,6 +578,9 @@ fn detect_error_sentinel(header: &[u8]) -> Option<&'static str> {
 /// Photos pipeline commonly serves live-photo and HEVC videos in classic
 /// QuickTime format, whose first atom is padding (`wide`) or media data
 /// (`mdat`) rather than `ftyp`.
+// Each match arm slices `header` only after an `n >= N` length guard, where
+// `n == header.len()`. Clippy can't see the proof but every slice is bounded.
+#[allow(clippy::indexing_slicing)]
 fn classify_magic(ext: &str, header: &[u8]) -> Option<bool> {
     let n = header.len();
     match ext {
@@ -616,9 +619,6 @@ fn is_mov_top_atom(atom: &[u8]) -> bool {
 /// since format variants exist (e.g. classic QuickTime MOV without `ftyp` box).
 /// HTML and JSON error-page sentinels are always rejected as hard errors —
 /// Apple's CDN occasionally returns them with HTTP 200.
-// Every slice of `header` below is guarded by an `n >= N` check earlier in
-// the same match arm; the `header = &buf[..n]` narrowing bounds `n <= 16`.
-#[allow(clippy::indexing_slicing)]
 fn validate_downloaded_content(
     part_path: &Path,
     download_path: &Path,
@@ -638,6 +638,8 @@ fn validate_downloaded_content(
         });
     }
 
+    // `n` is bytes read from `buf` so `n <= buf.len() == 16`.
+    #[allow(clippy::indexing_slicing)]
     let header = &buf[..n];
 
     // Reject known-bad error-page sentinels regardless of extension. Apple's
@@ -657,9 +659,12 @@ fn validate_downloaded_content(
         .to_ascii_lowercase();
 
     if classify_magic(&ext, header) == Some(false) {
+        // `n.min(8)` caps the slice at `header.len()`.
+        #[allow(clippy::indexing_slicing)]
+        let preview = &header[..n.min(8)];
         tracing::warn!(
             path = %download_path.display(),
-            header = %format_args!("{:02x?}", &header[..n.min(8)]),
+            header = %format_args!("{preview:02x?}"),
             "File header does not match expected format for .{ext}, saving anyway",
         );
     }

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -481,6 +481,8 @@ pub(crate) async fn compute_sha256(path: &Path) -> anyhow::Result<String> {
             if n == 0 {
                 break;
             }
+            // `n` is bounded by buf.len() because read() returns bytes written.
+            #[allow(clippy::indexing_slicing)]
             sha256.update(&buf[..n]);
         }
         Ok(format!("{:x}", sha256.finalize()))
@@ -530,6 +532,9 @@ fn decode_api_checksum(base64_checksum: &str) -> anyhow::Result<DecodedChecksum>
 /// that e.g. a leading `\n<html>` still fails. These sentinels are never valid
 /// image/video starts — unlike the magic-byte checks further down, which are
 /// only warnings because exotic variants exist.
+// `pos` comes from `header.iter().position(...)` so `header[pos..]` is
+// in-bounds; the prefix slices below are guarded by explicit length checks.
+#[allow(clippy::indexing_slicing)]
 fn detect_error_sentinel(header: &[u8]) -> Option<&'static str> {
     let trimmed = header
         .iter()
@@ -611,6 +616,9 @@ fn is_mov_top_atom(atom: &[u8]) -> bool {
 /// since format variants exist (e.g. classic QuickTime MOV without `ftyp` box).
 /// HTML and JSON error-page sentinels are always rejected as hard errors —
 /// Apple's CDN occasionally returns them with HTTP 200.
+// Every slice of `header` below is guarded by an `n >= N` check earlier in
+// the same match arm; the `header = &buf[..n]` narrowing bounds `n <= 16`.
+#[allow(clippy::indexing_slicing)]
 fn validate_downloaded_content(
     part_path: &Path,
     download_path: &Path,

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -254,6 +254,9 @@ pub(super) struct DownloadTask {
 
 /// Apply the RAW alignment policy by swapping Original and Alternative versions
 /// when appropriate, matching Python's `apply_raw_policy()`.
+// orig_idx / alt_idx are produced by `enumerate()` over `versions`; indexing
+// back into `versions` or its clone is in-bounds by construction.
+#[allow(clippy::indexing_slicing)]
 fn apply_raw_policy(versions: &VersionsMap, policy: RawTreatmentPolicy) -> Cow<'_, VersionsMap> {
     if policy == RawTreatmentPolicy::Unchanged {
         return Cow::Borrowed(versions);

--- a/src/download/heif.rs
+++ b/src/download/heif.rs
@@ -61,11 +61,8 @@ pub(crate) fn extract_xmp_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
             clippy::cast_possible_truncation,
             reason = "HEIC extent length fits in usize on 64-bit"
         )]
-        let end = start + extent.length as usize;
-        if end > bytes.len() {
-            return None;
-        }
-        return Some(bytes[start..end].to_vec());
+        let end = start.checked_add(extent.length as usize)?;
+        return bytes.get(start..end).map(<[u8]>::to_vec);
     }
     None
 }
@@ -78,6 +75,10 @@ pub(crate) fn extract_xmp_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
 /// trailing `mdat` (construction_method 0, file-absolute offsets), so the
 /// encoded image bytes in the original `mdat` stay byte-for-byte identical
 /// even after `meta` grows.
+// meta_idx is produced by .position() over atoms; new_mdat_idx is
+// atoms.len() - 1 after a push; new_positions is built from the same atoms
+// vec. All indexing here is in-bounds by construction.
+#[allow(clippy::indexing_slicing)]
 pub(crate) fn insert_xmp(input: &[u8], xmp: &[u8]) -> Result<Vec<u8>> {
     // Record each top-level atom along with its original byte offset in the
     // input so we can rewrite file-absolute iloc entries correctly — the
@@ -237,6 +238,9 @@ pub(crate) fn insert_xmp(input: &[u8], xmp: &[u8]) -> Result<Vec<u8>> {
 /// Criteria: an iinf entry flagged as `mime` + `application/rdf+xml`, its
 /// iloc entry references a range that lies entirely within a single trailing
 /// mdat atom, and no other iloc entry references into that atom.
+// Indexing by meta_idx (caller-validated) and by idx from atoms.iter().enumerate()
+// (with original_offsets built 1:1 alongside atoms in insert_xmp) is in-bounds.
+#[allow(clippy::indexing_slicing)]
 fn locate_stale_kei_mdat(
     atoms: &[Any],
     original_offsets: &[u64],

--- a/src/download/metadata.rs
+++ b/src/download/metadata.rs
@@ -426,6 +426,8 @@ fn build_xmp_packet(write: &MetadataWrite) -> Result<Vec<u8>> {
 /// EXIF stores datetimes as `"YYYY:MM:DD HH:MM:SS"`; XMP wants ISO 8601
 /// `"YYYY-MM-DDTHH:MM:SS"`. Best-effort conversion — on malformed input we
 /// return the original so XMP Toolkit can reject it with a clear error.
+// Indices 4, 7, 10 are provably in-bounds under the `bytes.len() == 19` guard.
+#[allow(clippy::indexing_slicing)]
 fn exif_datetime_to_iso(s: &str) -> String {
     let bytes = s.as_bytes();
     if bytes.len() == 19 && bytes[4] == b':' && bytes[7] == b':' && bytes[10] == b' ' {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -176,7 +176,9 @@ fn finalize_hash(hasher: sha2::Sha256) -> String {
 
     let hash = hasher.finalize();
     let mut hex = String::with_capacity(16);
-    // First 8 bytes is plenty for collision avoidance in this context
+    // First 8 bytes is plenty for collision avoidance in this context.
+    // SHA-256 output is always 32 bytes; 8 is unconditionally in-bounds.
+    #[allow(clippy::indexing_slicing)]
     for &b in &hash[..8] {
         let _ = Write::write_fmt(&mut hex, format_args!("{b:02x}"));
     }
@@ -862,6 +864,9 @@ async fn build_download_tasks(
     let mut dir_cache = paths::DirCache::new();
     for pass_result in pass_results {
         let (pass_index, assets) = pass_result?;
+        // pass_index comes from enumerate() over `passes`; pass_configs is
+        // built 1:1 from the same slice.
+        #[allow(clippy::indexing_slicing)]
         let pass_config = &pass_configs[pass_index];
 
         for asset in &assets {
@@ -1455,6 +1460,9 @@ async fn download_photos_incremental(
     let pass_configs = build_pass_configs(passes, config);
 
     for (asset, pass_index) in &downloadable_assets {
+        // pass_index was assigned by the producer from the same `passes` slice
+        // that pass_configs was built from; indices are valid.
+        #[allow(clippy::indexing_slicing)]
         let effective_config = &pass_configs[*pass_index];
 
         if let Some(reason) = filter::is_asset_filtered(asset, effective_config) {

--- a/src/download/paths.rs
+++ b/src/download/paths.rs
@@ -335,6 +335,8 @@ pub(crate) fn generate_fingerprint_filename(asset_id: &str, asset_type: &str) ->
     let hash = Sha256::digest(asset_id.as_bytes());
     let ext = item_type_extension(asset_type);
     let mut result = String::with_capacity(12 + 1 + ext.len());
+    // SHA-256 output is always 32 bytes; 6 is unconditionally in-bounds.
+    #[allow(clippy::indexing_slicing)]
     for &b in &hash[..6] {
         let _ = Write::write_fmt(&mut result, format_args!("{b:02x}"));
     }
@@ -352,6 +354,10 @@ pub(crate) fn generate_fingerprint_filename(asset_id: &str, asset_type: &str) ->
 ///
 /// This function strips any of these to produce a consistent `1.40.01PM` form,
 /// enabling matching between files created with different locale settings.
+// Every `bytes[i + k]` read below is preceded by an `i + k < len` check or a
+// `bytes[i] < 0x80` ASCII guard that makes `i + 1 <= len`. The UTF-8 fallback
+// slice `s[i..]` is valid because `i < len` and we land on a char boundary.
+#[allow(clippy::indexing_slicing)]
 pub(crate) fn normalize_ampm(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let bytes = s.as_bytes();
@@ -531,6 +537,9 @@ impl DirCache {
         // self.dirs immutably, which the borrow checker cannot release
         // before the mutable entry() call below.
         if self.dirs.contains_key(dir) {
+            // contains_key() above proves `dir` is present; two-lookup dance
+            // avoids the borrow-checker complaint the comment describes.
+            #[allow(clippy::indexing_slicing)]
             return &self.dirs[dir];
         }
         self.dirs

--- a/src/icloud/photos/album.rs
+++ b/src/icloud/photos/album.rs
@@ -168,7 +168,12 @@ impl PhotoAlbum {
             .batch
             .first()
             .and_then(|q| q.records.first())
-            .and_then(|r| r.fields["itemCount"]["value"].as_u64())
+            .and_then(|r| {
+                r.fields
+                    .get("itemCount")
+                    .and_then(|f| f.get("value"))
+                    .and_then(Value::as_u64)
+            })
             .unwrap_or(0);
         Ok(count)
     }
@@ -631,8 +636,12 @@ impl PhotoAlbum {
                 for rec in records {
                     tracing::debug!(record_type = %rec.record_type, "  record");
                     if rec.record_type == "CPLAsset" {
-                        if let Some(master_id) =
-                            rec.fields["masterRef"]["value"]["recordName"].as_str()
+                        if let Some(master_id) = rec
+                            .fields
+                            .get("masterRef")
+                            .and_then(|f| f.get("value"))
+                            .and_then(|v| v.get("recordName"))
+                            .and_then(Value::as_str)
                         {
                             let master_id = master_id.to_string();
                             // Try to pair with a buffered master from a previous page

--- a/src/icloud/photos/asset.rs
+++ b/src/icloud/photos/asset.rs
@@ -95,11 +95,20 @@ pub(crate) fn f64_to_millis_datetime(ms: f64) -> Option<DateTime<Utc>> {
     }
 }
 
+/// True when `fields.key` is a non-null `Value`.
+fn field_present(fields: &Value, key: &str) -> bool {
+    fields.get(key).is_some_and(|v| !v.is_null())
+}
+
 /// Determine asset type from the `itemType` `CloudKit` field, falling back to
 /// file extension heuristics. Defaults to Movie for unknown types because
 /// videos are more likely to have non-standard UTI strings.
 fn resolve_item_type(fields: &Value, filename: Option<&str>) -> AssetItemType {
-    if let Some(s) = fields["itemType"]["value"].as_str() {
+    if let Some(s) = fields
+        .get("itemType")
+        .and_then(|f| f.get("value"))
+        .and_then(Value::as_str)
+    {
         if let Some(t) = item_type_from_str(s) {
             return t;
         }
@@ -137,20 +146,23 @@ fn extract_versions(
     for (key, res_field, type_field) in lookup {
         // Asset record has adjusted versions; master has originals.
         // Prefer asset record so adjusted/edited versions take priority.
-        let fields = if !asset_fields[res_field].is_null() {
+        let fields = if field_present(asset_fields, res_field) {
             asset_fields
-        } else if !master_fields[res_field].is_null() {
+        } else if field_present(master_fields, res_field) {
             master_fields
         } else {
             continue;
         };
 
-        let res_entry = &fields[res_field]["value"];
+        let res_entry = fields
+            .get(res_field)
+            .and_then(|f| f.get("value"))
+            .unwrap_or(&Value::Null);
         if res_entry.is_null() {
             continue;
         }
 
-        let size = if let Some(s) = res_entry["size"].as_u64() {
+        let size = if let Some(s) = res_entry.get("size").and_then(Value::as_u64) {
             s
         } else {
             tracing::warn!(
@@ -161,7 +173,7 @@ fn extract_versions(
             continue;
         };
 
-        let url: Box<str> = match res_entry["downloadURL"].as_str() {
+        let url: Box<str> = match res_entry.get("downloadURL").and_then(Value::as_str) {
             Some(u) => match validate_download_url(u) {
                 Ok(()) => u.into(),
                 Err(reason) => {
@@ -185,18 +197,23 @@ fn extract_versions(
             }
         };
 
-        let checksum: Box<str> = if let Some(c) = res_entry["fileChecksum"].as_str() {
-            c.into()
-        } else {
-            tracing::warn!(
-                asset = %record_name,
-                field = format_args!("{res_field}.fileChecksum"),
-                "Missing fileChecksum, skipping version"
-            );
-            continue;
-        };
+        let checksum: Box<str> =
+            if let Some(c) = res_entry.get("fileChecksum").and_then(Value::as_str) {
+                c.into()
+            } else {
+                tracing::warn!(
+                    asset = %record_name,
+                    field = format_args!("{res_field}.fileChecksum"),
+                    "Missing fileChecksum, skipping version"
+                );
+                continue;
+            };
 
-        let asset_type: Box<str> = match fields[type_field]["value"].as_str() {
+        let asset_type: Box<str> = match fields
+            .get(type_field)
+            .and_then(|f| f.get("value"))
+            .and_then(Value::as_str)
+        {
             Some(s) if !s.is_empty() => s.into(),
             _ => {
                 tracing::warn!(
@@ -282,8 +299,16 @@ impl PhotoAsset {
     pub fn from_records(master: super::cloudkit::Record, asset: super::cloudkit::Record) -> Self {
         let filename = decode_filename(&master.fields).map(String::into_boxed_str);
         let item_type_val = Some(resolve_item_type(&master.fields, filename.as_deref()));
-        let asset_date_ms = asset.fields["assetDate"]["value"].as_f64();
-        let added_date_ms = asset.fields["addedDate"]["value"].as_f64();
+        let asset_date_ms = asset
+            .fields
+            .get("assetDate")
+            .and_then(|f| f.get("value"))
+            .and_then(Value::as_f64);
+        let added_date_ms = asset
+            .fields
+            .get("addedDate")
+            .and_then(|f| f.get("value"))
+            .and_then(Value::as_f64);
         let versions = extract_versions(
             item_type_val,
             &master.fields,

--- a/src/icloud/photos/library.rs
+++ b/src/icloud/photos/library.rs
@@ -143,7 +143,12 @@ impl PhotoLibrary {
         let indexing_state = query
             .records
             .first()
-            .and_then(|r| r.fields["state"]["value"].as_str())
+            .and_then(|r| {
+                r.fields
+                    .get("state")
+                    .and_then(|f| f.get("value"))
+                    .and_then(Value::as_str)
+            })
             .unwrap_or("");
         if indexing_state != "FINISHED" {
             tracing::warn!(
@@ -197,8 +202,11 @@ impl PhotoLibrary {
                 if record_name == ROOT_FOLDER || record_name == PROJECT_ROOT_FOLDER {
                     continue;
                 }
-                if folder.fields["isDeleted"]["value"]
-                    .as_bool()
+                if folder
+                    .fields
+                    .get("isDeleted")
+                    .and_then(|f| f.get("value"))
+                    .and_then(Value::as_bool)
                     .unwrap_or(false)
                 {
                     continue;
@@ -207,7 +215,12 @@ impl PhotoLibrary {
                 let folder_obj_type =
                     format!("CPLContainerRelationNotDeletedByAssetDate:{record_name}");
 
-                let folder_name = match folder.fields["albumNameEnc"]["value"].as_str() {
+                let folder_name = match folder
+                    .fields
+                    .get("albumNameEnc")
+                    .and_then(|f| f.get("value"))
+                    .and_then(Value::as_str)
+                {
                     Some(enc) => {
                         let decoded = base64::engine::general_purpose::STANDARD
                             .decode(enc)

--- a/src/icloud/photos/queries.rs
+++ b/src/icloud/photos/queries.rs
@@ -260,7 +260,9 @@ pub(crate) fn build_changes_zone_request(
         "resultsLimit": results_limit,
     });
     if let Some(token) = sync_token {
-        zone_entry["syncToken"] = json!(token);
+        if let Some(obj) = zone_entry.as_object_mut() {
+            obj.insert("syncToken".into(), json!(token));
+        }
     }
     json!({"zones": [zone_entry]})
 }

--- a/src/icloud/photos/session.rs
+++ b/src/icloud/photos/session.rs
@@ -198,10 +198,11 @@ fn is_service_not_activated(code: &str, reason: &str) -> bool {
 /// Returns `Err` if a server error is found, `Ok(response)` otherwise.
 fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
     // Top-level serverErrorCode (e.g. from CAS Op-Lock)
-    if let Some(code) = response["serverErrorCode"].as_str() {
-        let reason = response["reason"]
-            .as_str()
-            .or_else(|| response["serverErrorMessage"].as_str())
+    if let Some(code) = response.get("serverErrorCode").and_then(Value::as_str) {
+        let reason = response
+            .get("reason")
+            .and_then(Value::as_str)
+            .or_else(|| response.get("serverErrorMessage").and_then(Value::as_str))
             .unwrap_or("unknown");
         let retryable = RETRYABLE_SERVER_ERRORS
             .iter()
@@ -224,11 +225,11 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
 
     // Per-record errors: filter out errored records and keep valid ones.
     // Only return Err if ALL records are errored.
-    if let Some(records) = response["records"].as_array() {
+    if let Some(records) = response.get("records").and_then(Value::as_array) {
         // Check if any records have errors before taking the mutable path
         let has_errors = records
             .iter()
-            .any(|r| r["serverErrorCode"].as_str().is_some());
+            .any(|r| r.get("serverErrorCode").and_then(Value::as_str).is_some());
 
         if has_errors {
             // Log each errored record and capture the last error
@@ -236,9 +237,15 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
             let mut permanent_errors = 0usize;
             let mut retryable_errors = 0usize;
             for record in records {
-                if let Some(code) = record["serverErrorCode"].as_str() {
-                    let reason = record["reason"].as_str().unwrap_or("unknown");
-                    let record_name = record["recordName"].as_str().unwrap_or("(unknown)");
+                if let Some(code) = record.get("serverErrorCode").and_then(Value::as_str) {
+                    let reason = record
+                        .get("reason")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown");
+                    let record_name = record
+                        .get("recordName")
+                        .and_then(Value::as_str)
+                        .unwrap_or("(unknown)");
                     let retryable = RETRYABLE_SERVER_ERRORS
                         .iter()
                         .any(|&s| s.eq_ignore_ascii_case(code));
@@ -278,9 +285,12 @@ fn check_cloudkit_errors(response: Value) -> anyhow::Result<Value> {
 
             // Now mutate in-place: retain only valid records
             let mut response = response;
-            let total = response["records"].as_array().map_or(0, Vec::len);
-            if let Some(records) = response["records"].as_array_mut() {
-                records.retain(|r| r["serverErrorCode"].as_str().is_none());
+            let total = response
+                .get("records")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            if let Some(records) = response.get_mut("records").and_then(Value::as_array_mut) {
+                records.retain(|r| r.get("serverErrorCode").and_then(Value::as_str).is_none());
                 let valid_count = records.len();
                 if valid_count == 0 {
                     // Control only reaches here because the loop above walked

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@
         clippy::cast_possible_truncation,
         clippy::cast_precision_loss,
         clippy::cast_sign_loss,
+        clippy::indexing_slicing,
     )
 )]
 

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -509,10 +509,11 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
         // In watch mode with incremental sync, use changes/database as a
         // cheap pre-check to skip cycles when nothing has changed.
         // Only used for single-library mode; multi-library skips this optimization.
-        let skip_cycle = if is_watch_mode && !config.no_incremental && library_states.len() == 1 {
-            check_changes_database(&state_db, &library_states[0], &mut photos_service).await
-        } else {
-            false
+        let skip_cycle = match library_states.as_slice() {
+            [only] if is_watch_mode && !config.no_incremental => {
+                check_changes_database(&state_db, only, &mut photos_service).await
+            }
+            _ => false,
         };
 
         if skip_cycle {

--- a/tests/state_auth.rs
+++ b/tests/state_auth.rs
@@ -15,7 +15,8 @@
     clippy::print_stderr,
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::indexing_slicing
 )]
 
 mod common;

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -21,7 +21,8 @@
     clippy::print_stderr,
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::indexing_slicing
 )]
 
 mod common;


### PR DESCRIPTION
Deferred from #254. Turns on `clippy::indexing_slicing` at `warn` under `[lints.clippy]` so every `[]` / `[..]` panic footgun surfaces in CI. All 68 prod sites are cleaned up.

## Approach per site

**Refactor to `.get()` / pattern-match**, where it reads naturally:

- CloudKit JSON walks in `icloud/photos/{album,asset,library,queries,session}.rs`: `r.fields[\"x\"][\"value\"].as_str()` becomes `r.fields.get(\"x\").and_then(|f| f.get(\"value\")).and_then(Value::as_str)`. Same short-circuit semantics as `serde_json::Value::Index<&str>` (which returns `Null` for missing keys); no behavior change.
- `auth/srp.rs` SRP M1 XOR: indexed fixed-array write becomes a triple-zip `iter_mut().zip(h_n.iter()).zip(h_g.iter())`.
- `sync_loop.rs` single-library fast path: `library_states[0]` guarded by `.len() == 1` becomes a slice pattern `[only] if ...`.
- `icloud/photos/queries.rs` `zone_entry[\"syncToken\"] = ...` becomes `zone_entry.as_object_mut().map(|o| o.insert(...))`.
- `download/heif.rs::extract_xmp_bytes` switches to `checked_add` + `bytes.get(start..end)`.

**Scoped `#[allow(clippy::indexing_slicing)]` with invariant comment**, where restructuring hurts readability:

- `download/file.rs::classify_magic` and `detect_error_sentinel`: magic-byte / HTML / JSON prefix checks are guarded by `n >= N` / `trimmed.len() >= prefix.len()` one line up; `validate_downloaded_content`'s `&buf[..n]` and `&header[..n.min(8)]` take point allows.
- `download/heif.rs::insert_xmp` and `locate_stale_kei_mdat`: `meta_idx` comes from `.position()`, `new_mdat_idx` from `atoms.len() - 1` after a push, `original_offsets` is parallel to `atoms`.
- `download/paths.rs::normalize_ampm`: hand-rolled UTF-8 walker with `i + k < len` guards at every branch.
- `download/paths.rs::generate_fingerprint_filename` and `download/mod.rs::finalize_hash`: `&hash[..N]` on a 32-byte SHA-256 output.
- `download/paths.rs::DirCache::ensure_dir`: the two-lookup `contains_key` then index dance, with the original comment explaining why `get()` can't be used.
- `download/mod.rs`: two `pass_configs[pass_index]` sites - `pass_configs` is built 1:1 from the same `passes` slice.
- `download/filter.rs::apply_raw_policy`: `orig_idx` / `alt_idx` come from `enumerate()` over the very slice being indexed.
- `download/metadata.rs::exif_datetime_to_iso`: 19-byte length guard pins indices 4 / 7 / 10.

No blanket file-level `#![allow]` in prod modules; each allow names the invariant it relies on.

## Test code

`clippy::indexing_slicing` is appended to the existing crate-root `#![cfg_attr(test, allow(...))]` list in `src/main.rs`, matching the pattern #254 established for the other test-exempt lints. `tests/sync.rs` and `tests/state_auth.rs` (separate test crates) get `clippy::indexing_slicing` added to their existing file-top allow lists.

## Piggybacked dep bump

Commit \`be9bdfb\` bumps \`rustls-webpki\` 0.103.12 -> 0.103.13 in \`Cargo.lock\` to clear RUSTSEC-2026-0104, which was published between main's last CI run and this PR's and was blocking the Security Audit job on every branch. One-line patch bump on a transitive of reqwest (via rustls and rustls-platform-verifier). Happy to split into its own PR if preferred.

## Verification

- Lint verified to fire: temporarily inserted \`fn _canary(xs: &[u8]) -> u8 { xs[0] }\` in \`sync_loop.rs\`; \`cargo clippy --bin kei\` reported \`indexing may panic\` at the expected line, then the canary was removed.
- \`cargo clippy --all-targets --all-features -- -D warnings\` clean.
- \`cargo fmt --check\` clean.
- \`cargo test --release\`: 1576 \`--bin kei\`, 95 \`--test cli\`, 118 \`--test behavioral\`. Total 1789 passed.
- Release binary smoke: \`--version\`, \`--help\`, \`config show\`, \`status\`.
- Docker: \`docker build --platform linux/amd64\` built clean; \`docker run\` exercises \`--version\`, \`config show\`, and the default \`sync\` CMD without creds (clean "--username is required" exit for the first-run / non-TTY path).
- CI: all jobs green on \`be9bdfb\`: Build + Test on linux / macos / windows, Clippy, Format, Lockfile, Docs, Coverage (base + head), Unused Dependencies, Docker Build, Security Audit, Typos.

### Live iCloud

Against the rebuilt binary, every refactored site that processes real Apple response data was exercised end-to-end:

- \`list libraries\` / \`list albums\`: SRP auth, \`PhotoLibrary::new\` \`state.value\` check, \`fetch_folders\` \`isDeleted\` / \`albumNameEnc\` walk, \`session.rs::check_cloudkit_errors\` on every response.
- \`sync --album icloudpd-test\`: 3 assets (4.5 MiB JPG, 65 MiB MOV, 107 KiB JPG), 2s, 0 failed. \`masterRef\` pairing, \`assetDate\`/\`addedDate\`/\`itemType\` walks, \`extract_versions\` (\`downloadURL\`, \`fileChecksum\`, \`size\`), \`classify_magic\` on each downloaded extension.
- Second-run idempotence: "No new photos to download", 0 re-transferred.
- Incremental sync: second cycle with stored sync token hit \`queries.rs::build_changes_zone_request\` with \`Some(token)\`, returned \`changes/zone\` page with 0 events. Exercises both the \`zone_entry.as_object_mut()\` insert refactor and the \`sync_loop.rs\` \`[only]\` slice pattern.
- 500-asset dry-run enumeration (\`--recent 500 --skip-videos --dry-run\`): \`masterRef\` pairing across multiple paginated pages.
- HEIC write path: \`--embed-xmp --set-exif-rating --set-exif-gps --set-exif-description\` on an HEIC asset ran \`heif.rs::extract_xmp_bytes\` (reads Apple's existing XMP) and \`heif.rs::insert_xmp\` (appends kei's XMP mdat). HEIC stayed byte-identical across re-downloads; \`file\` reports valid HEIF/HEVC; XMP packet present with both Apple and kei namespaces.
- \`status\` and \`verify\`: state DB reads, sync_runs table, per-row existence scan.

Not exercised (cannot force on a healthy account): CloudKit server errors (\`RETRY_LATER\` / \`ACCESS_DENIED\` / \`ZONE_NOT_FOUND\` / per-record errors), ADP-enabled path, 421 recovery, 2FA flow. These are covered by \`MockPhotosSession\`-backed unit tests.

## Reproduce the original scope

\`\`\`
cargo clippy --bin kei --message-format=short -- -W clippy::indexing_slicing
\`\`\`

Returns clean on this branch.

Closes #253.