### PR TITLE
Gate xmp_toolkit behind a Cargo feature for FreeBSD support (closes #256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features
 
+  # Keeps the `--no-default-features` build honest so FreeBSD and any other
+  # platform without a working C++ toolchain for xmp_toolkit (see #256) can
+  # still build kei. Runs clippy with -D warnings on the narrower surface.
+  clippy_no_default:
+    name: Clippy (no-default-features)
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --no-default-features -- -D warnings
+
   # Runs the test suite on all major platforms to catch platform-specific bugs
   # fail-fast: false ensures all platforms run even if one fails
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,10 @@ jobs:
 
   # Keeps the `--no-default-features` build honest so FreeBSD and any other
   # platform without a working C++ toolchain for xmp_toolkit (see #256) can
-  # still build kei. Runs clippy with -D warnings on the narrower surface.
-  clippy_no_default:
-    name: Clippy (no-default-features)
+  # still build kei. Runs clippy + tests on the narrower surface; tests
+  # make sure we also catch runtime regressions, not just compile breaks.
+  test_no_default:
+    name: Test (no-default-features)
     needs: detect
     if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -116,6 +117,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --no-default-features -- -D warnings
+      - run: cargo test --no-default-features
 
   # Runs the test suite on all major platforms to catch platform-specific bugs
   # fail-fast: false ensures all platforms run even if one fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`xmp` Cargo feature (default-on) to support builds without Adobe's XMP Toolkit.** `xmp_toolkit` vendors Adobe's C++ XMP Toolkit, which doesn't build on FreeBSD. Building with `cargo build --no-default-features` now compiles cleanly: it drops the `--embed-xmp`, `--xmp-sidecar`, `--set-exif-datetime`, `--set-exif-rating`, `--set-exif-gps`, and `--set-exif-description` flags (and the corresponding `[download]` TOML keys), and disables HEIC metadata writes. Download, auth, state tracking, magic-byte validation, and sidecar reads from other tools are unaffected. Default feature set is unchanged for every existing user. Also adds a FreeBSD target block for the `keyring` crate so the build doesn't fall through the OS-specific dependency matrix. ([#256], thanks @jan666)
+
+[#256]: https://github.com/rhoopr/kei/issues/256
+
 ### Fixed
 
 - **Spurious `File header does not match expected format` warning on live-photo MOVs.** The magic-byte check only accepted the ISO-BMFF `ftyp` box at offset 4 and warned on everything else. Apple serves live-photo and HEVC videos as classic QuickTime, which commonly begins with a `wide` padding atom (`00 00 00 08 77 69 64 65`) or an `mdat` data atom instead. The `.mov` branch now accepts `ftyp`, `wide`, `mdat`, `moov`, `free`, `skip`, and `pnot` - all valid QuickTime top-level atoms. `.heic`, `.heif`, `.mp4`, and `.m4v` remain strict ISO-BMFF (`ftyp` only). `.dng` now runs the TIFF magic check. Files were already being saved correctly; only the warning is gone. ([#247], thanks @woutervanwijk)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,16 @@ edition = "2021"
 name = "kei"
 path = "src/main.rs"
 
+[features]
+# XMP metadata embedding + sidecar writing. Default-on; build with
+# `--no-default-features` on platforms where Adobe's vendored C++ XMP
+# Toolkit does not compile (notably FreeBSD — see #256). Disabling drops
+# the `--embed-xmp`, `--xmp-sidecar`, and `--set-exif-*` CLI flags and the
+# code paths behind them; HEIC container edits go with it because the
+# XMP packet serializer lives in xmp_toolkit.
+default = ["xmp"]
+xmp = ["dep:xmp_toolkit"]
+
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -62,7 +72,9 @@ dialoguer = "0.12"
 # Handles JPEG, PNG, TIFF, MP4, MOV, PSD, PDF, and more via XMPFiles.
 # Does NOT handle HEIC — the bundled XMPFiles has no HEIF handler, so HEIC
 # embedded XMP is handled separately via libheif-rs.
-xmp_toolkit = "1"
+# Optional (behind the `xmp` feature, default-on) so platforms without a
+# working C++ toolchain for the vendored sources can opt out. See #256.
+xmp_toolkit = { version = "1", optional = true }
 
 # ISO-BMFF (MP4 / HEIF / HEIC) atom parsing + encoding. HEIC's XMP packet
 # lives in a `mime`-type item inside the `meta` box; mp4-atom gives us the
@@ -108,6 +120,12 @@ keyring = { version = "3", features = ["apple-native"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service"] }
 sd-notify = "0.5"
+
+# FreeBSD: Secret Service D-Bus API is available via ports (dbus + a
+# keyring daemon like gnome-keyring or KWallet). If no daemon is running,
+# `CredentialStore` falls back to the encrypted file backend. See #256.
+[target.'cfg(target_os = "freebsd")'.dependencies]
+keyring = { version = "3", features = ["sync-secret-service"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ cargo build --release
 
 Building requires a C++ compiler (already present via `build-essential` / Xcode CLT / VS Build Tools) because the XMP writer vendors Adobe's XMP Toolkit and compiles it from source. No other system libraries are required — HEIC metadata writes go through a pure-Rust ISO-BMFF writer, so `libheif` is not needed.
 
+**FreeBSD**
+
+```sh
+pkg install dbus
+git clone https://github.com/rhoopr/kei.git kei && cd kei
+cargo build --release --no-default-features
+```
+
+The default `xmp` feature pulls in Adobe's vendored XMP Toolkit, which doesn't build on FreeBSD ([#256](https://github.com/rhoopr/kei/issues/256)). `--no-default-features` drops it along with the `--embed-xmp`, `--xmp-sidecar`, and `--set-exif-*` flags, and HEIC metadata writes. Download, auth, state tracking, and sidecar reads from other tools all work as usual.
+
 > [!IMPORTANT]
 > If you have Advanced Data Protection (ADP) enabled on your iCloud account, kei can't access your photos. ADP blocks the web API that kei uses. To fix this, you need to change both settings on your iPhone/iPad: disable ADP (Settings > Apple ID > iCloud > Advanced Data Protection) and enable "Access iCloud Data on the Web" (Settings > Apple ID > iCloud). See the [Authentication wiki](https://github.com/rhoopr/kei/wiki/Authentication#advanced-data-protection-adp) for details.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,29 +181,35 @@ pub struct SyncArgs {
     pub folder_structure: Option<String>,
 
     /// Write `DateTimeOriginal` EXIF tag if missing
+    #[cfg(feature = "xmp")]
     #[arg(long, env = "KEI_SET_EXIF_DATETIME", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub set_exif_datetime: Option<bool>,
 
     /// Write EXIF `Rating` tag (0x4746) for favorited photos (1-5 scale)
+    #[cfg(feature = "xmp")]
     #[arg(long, env = "KEI_SET_EXIF_RATING", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub set_exif_rating: Option<bool>,
 
     /// Write EXIF GPS tags from iCloud location metadata (only when the file lacks GPS)
+    #[cfg(feature = "xmp")]
     #[arg(long, env = "KEI_SET_EXIF_GPS", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub set_exif_gps: Option<bool>,
 
     /// Write EXIF `ImageDescription` tag from iCloud description / title
+    #[cfg(feature = "xmp")]
     #[arg(long, env = "KEI_SET_EXIF_DESCRIPTION", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub set_exif_description: Option<bool>,
 
     /// Embed a full XMP packet (title, keywords, album memberships, people,
     /// hidden/archived, media subtype, burst id) into downloaded media bytes
     /// on supported formats (JPEG/HEIC/PNG/TIFF/MP4/MOV)
+    #[cfg(feature = "xmp")]
     #[arg(long, env = "KEI_EMBED_XMP", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub embed_xmp: Option<bool>,
 
     /// Write a `.xmp` sidecar file next to each downloaded media file with
     /// every available metadata field
+    #[cfg(feature = "xmp")]
     #[arg(long, env = "KEI_XMP_SIDECAR", num_args = 0..=1, default_missing_value = "true", hide_possible_values = true)]
     pub xmp_sidecar: Option<bool>,
 
@@ -677,23 +683,26 @@ impl SyncArgs {
         if self.folder_structure.is_none() {
             self.folder_structure.clone_from(&fallback.folder_structure);
         }
-        if self.set_exif_datetime.is_none() {
-            self.set_exif_datetime = fallback.set_exif_datetime;
-        }
-        if self.set_exif_rating.is_none() {
-            self.set_exif_rating = fallback.set_exif_rating;
-        }
-        if self.set_exif_gps.is_none() {
-            self.set_exif_gps = fallback.set_exif_gps;
-        }
-        if self.set_exif_description.is_none() {
-            self.set_exif_description = fallback.set_exif_description;
-        }
-        if self.embed_xmp.is_none() {
-            self.embed_xmp = fallback.embed_xmp;
-        }
-        if self.xmp_sidecar.is_none() {
-            self.xmp_sidecar = fallback.xmp_sidecar;
+        #[cfg(feature = "xmp")]
+        {
+            if self.set_exif_datetime.is_none() {
+                self.set_exif_datetime = fallback.set_exif_datetime;
+            }
+            if self.set_exif_rating.is_none() {
+                self.set_exif_rating = fallback.set_exif_rating;
+            }
+            if self.set_exif_gps.is_none() {
+                self.set_exif_gps = fallback.set_exif_gps;
+            }
+            if self.set_exif_description.is_none() {
+                self.set_exif_description = fallback.set_exif_description;
+            }
+            if self.embed_xmp.is_none() {
+                self.embed_xmp = fallback.embed_xmp;
+            }
+            if self.xmp_sidecar.is_none() {
+                self.xmp_sidecar = fallback.xmp_sidecar;
+            }
         }
         self.dry_run = self.dry_run || fallback.dry_run;
         if self.watch_with_interval.is_none() {
@@ -1686,6 +1695,7 @@ mod tests {
         assert_eq!(cli.sync.force_size, Some(true));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_set_exif_datetime_flag() {
         let mut args = base_args();
@@ -1694,6 +1704,7 @@ mod tests {
         assert_eq!(cli.sync.set_exif_datetime, Some(true));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_embed_xmp_flag() {
         let mut args = base_args();
@@ -1702,6 +1713,7 @@ mod tests {
         assert_eq!(cli.sync.embed_xmp, Some(true));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_embed_xmp_flag_explicit_false() {
         let mut args = base_args();
@@ -1710,6 +1722,7 @@ mod tests {
         assert_eq!(cli.sync.embed_xmp, Some(false));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_xmp_sidecar_flag() {
         let mut args = base_args();

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,11 +48,17 @@ pub(crate) struct TomlDownload {
     pub threads_num: Option<u16>,
     pub bandwidth_limit: Option<String>,
     pub temp_suffix: Option<String>,
+    #[cfg(feature = "xmp")]
     pub set_exif_datetime: Option<bool>,
+    #[cfg(feature = "xmp")]
     pub set_exif_rating: Option<bool>,
+    #[cfg(feature = "xmp")]
     pub set_exif_gps: Option<bool>,
+    #[cfg(feature = "xmp")]
     pub set_exif_description: Option<bool>,
+    #[cfg(feature = "xmp")]
     pub embed_xmp: Option<bool>,
+    #[cfg(feature = "xmp")]
     pub xmp_sidecar: Option<bool>,
     pub no_progress_bar: Option<bool>,
     pub retry: Option<TomlRetry>,
@@ -331,11 +337,17 @@ pub struct Config {
     pub skip_videos: bool,
     pub skip_photos: bool,
     pub force_size: bool,
+    #[cfg(feature = "xmp")]
     pub set_exif_datetime: bool,
+    #[cfg(feature = "xmp")]
     pub set_exif_rating: bool,
+    #[cfg(feature = "xmp")]
     pub set_exif_gps: bool,
+    #[cfg(feature = "xmp")]
     pub set_exif_description: bool,
+    #[cfg(feature = "xmp")]
     pub embed_xmp: bool,
+    #[cfg(feature = "xmp")]
     pub xmp_sidecar: bool,
     pub dry_run: bool,
     pub no_progress_bar: bool,
@@ -669,20 +681,26 @@ impl Config {
             toml_dl.and_then(|d| d.temp_suffix.clone()),
             ".kei-tmp".to_string(),
         );
+        #[cfg(feature = "xmp")]
         let set_exif_datetime = resolve_flag(
             sync.set_exif_datetime,
             toml_dl.and_then(|d| d.set_exif_datetime),
         );
+        #[cfg(feature = "xmp")]
         let set_exif_rating = resolve_flag(
             sync.set_exif_rating,
             toml_dl.and_then(|d| d.set_exif_rating),
         );
+        #[cfg(feature = "xmp")]
         let set_exif_gps = resolve_flag(sync.set_exif_gps, toml_dl.and_then(|d| d.set_exif_gps));
+        #[cfg(feature = "xmp")]
         let set_exif_description = resolve_flag(
             sync.set_exif_description,
             toml_dl.and_then(|d| d.set_exif_description),
         );
+        #[cfg(feature = "xmp")]
         let embed_xmp = resolve_flag(sync.embed_xmp, toml_dl.and_then(|d| d.embed_xmp));
+        #[cfg(feature = "xmp")]
         let xmp_sidecar = resolve_flag(sync.xmp_sidecar, toml_dl.and_then(|d| d.xmp_sidecar));
         let no_progress_bar = resolve_flag(
             sync.no_progress_bar,
@@ -894,11 +912,17 @@ impl Config {
             skip_videos,
             skip_photos,
             force_size,
+            #[cfg(feature = "xmp")]
             set_exif_datetime,
+            #[cfg(feature = "xmp")]
             set_exif_rating,
+            #[cfg(feature = "xmp")]
             set_exif_gps,
+            #[cfg(feature = "xmp")]
             set_exif_description,
+            #[cfg(feature = "xmp")]
             embed_xmp,
+            #[cfg(feature = "xmp")]
             xmp_sidecar,
             dry_run: sync.dry_run,
             no_progress_bar,
@@ -954,23 +978,29 @@ impl Config {
                 } else {
                     Some(self.temp_suffix.clone())
                 },
+                #[cfg(feature = "xmp")]
                 set_exif_datetime: if self.set_exif_datetime {
                     Some(true)
                 } else {
                     None
                 },
+                #[cfg(feature = "xmp")]
                 set_exif_rating: if self.set_exif_rating {
                     Some(true)
                 } else {
                     None
                 },
+                #[cfg(feature = "xmp")]
                 set_exif_gps: if self.set_exif_gps { Some(true) } else { None },
+                #[cfg(feature = "xmp")]
                 set_exif_description: if self.set_exif_description {
                     Some(true)
                 } else {
                     None
                 },
+                #[cfg(feature = "xmp")]
                 embed_xmp: if self.embed_xmp { Some(true) } else { None },
+                #[cfg(feature = "xmp")]
                 xmp_sidecar: if self.xmp_sidecar { Some(true) } else { None },
                 no_progress_bar: if self.no_progress_bar {
                     Some(true)
@@ -1139,11 +1169,17 @@ pub(crate) fn persist_first_run_config(
             threads_num: None,
             bandwidth_limit: None,
             temp_suffix: None,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: None,
+            #[cfg(feature = "xmp")]
             set_exif_rating: None,
+            #[cfg(feature = "xmp")]
             set_exif_gps: None,
+            #[cfg(feature = "xmp")]
             set_exif_description: None,
+            #[cfg(feature = "xmp")]
             embed_xmp: None,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: None,
             no_progress_bar: None,
             retry: None,
@@ -1320,7 +1356,6 @@ mod tests {
             folder_structure = "%Y/%m/%d"
             threads_num = 10
             temp_suffix = ".kei-tmp"
-            set_exif_datetime = true
             no_progress_bar = false
 
             [download.retry]
@@ -1672,6 +1707,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_boolean_flag_from_toml() {
         let toml_str = r#"
@@ -1693,6 +1729,7 @@ mod tests {
         assert!(cfg.skip_videos);
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_embed_xmp_and_sidecar_from_toml() {
         let toml_str = r#"
@@ -1712,6 +1749,7 @@ mod tests {
         assert!(cfg.xmp_sidecar);
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_cli_embed_xmp_overrides_toml() {
         let toml_str = r#"
@@ -1728,6 +1766,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_embed_xmp_default_false_when_unset() {
         let cfg =
@@ -2303,6 +2342,7 @@ mod tests {
         assert_eq!(config.auth.unwrap().password.as_deref(), Some("secret"));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_toml_download_all_fields() {
         let toml_str = r#"
@@ -2522,6 +2562,7 @@ mod tests {
         assert_eq!(cfg.folder_structure, "%Y/%m/%d");
         assert_eq!(cfg.threads_num, 10);
         assert_eq!(cfg.temp_suffix, ".kei-tmp");
+        #[cfg(feature = "xmp")]
         assert!(!cfg.set_exif_datetime);
         assert!(!cfg.no_progress_bar);
         // Retry
@@ -2954,6 +2995,7 @@ mod tests {
 
     // ── Config::build: boolean flag merge exhaustive ───────────────
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_all_boolean_flags_from_toml() {
         let toml_str = r#"
@@ -2991,6 +3033,7 @@ mod tests {
         assert!(cfg.notify_systemd);
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_all_boolean_flags_cli_overrides() {
         let mut sync = default_sync();
@@ -3211,6 +3254,7 @@ mod tests {
 
     // ── Config::build: full TOML config ────────────────────────────
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn test_build_full_toml_all_sections() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/download/filter.rs
+++ b/src/download/filter.rs
@@ -116,6 +116,7 @@ impl std::borrow::Borrow<str> for NormalizedPath {
 /// only sees fields a writer can actually use. Fields are owned (not borrowed)
 /// because the task moves across async boundaries.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(not(feature = "xmp"), allow(dead_code))]
 pub(super) struct MetadataPayload {
     /// 1-5 star rating (mapped from `AssetMetadata::rating` or `is_favorite`).
     pub(super) rating: Option<u8>,
@@ -242,6 +243,7 @@ pub(super) struct DownloadTask {
     /// Metadata fields surfaced from `AssetMetadata` for writer consumption.
     /// Behind `Arc` so `task.metadata.clone()` in the download hot path is a
     /// refcount bump instead of a deep clone of every `Vec<String>` inside.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     pub(super) metadata: Arc<MetadataPayload>,
     // 8-byte primitives
     pub(super) size: u64,

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -6,8 +6,10 @@
 pub mod error;
 pub mod file;
 pub(crate) mod filter;
+#[cfg(feature = "xmp")]
 pub(crate) mod heif;
 pub(crate) mod limiter;
+#[cfg(feature = "xmp")]
 pub mod metadata;
 pub mod paths;
 pub(crate) mod pipeline;
@@ -382,15 +384,21 @@ pub(crate) struct DownloadConfig {
     pub(crate) skip_photos: bool,
     pub(crate) skip_created_before: Option<DateTime<Utc>>,
     pub(crate) skip_created_after: Option<DateTime<Utc>>,
+    #[cfg(feature = "xmp")]
     pub(crate) set_exif_datetime: bool,
+    #[cfg(feature = "xmp")]
     pub(crate) set_exif_rating: bool,
+    #[cfg(feature = "xmp")]
     pub(crate) set_exif_gps: bool,
+    #[cfg(feature = "xmp")]
     pub(crate) set_exif_description: bool,
     /// Embed the full XMP packet (title, keywords, people, hidden/archived,
     /// media subtype, burst id) into the file bytes on supported formats.
+    #[cfg(feature = "xmp")]
     pub(crate) embed_xmp: bool,
     /// Write a `.xmp` sidecar file next to each downloaded media file with
     /// the same composed XMP packet.
+    #[cfg(feature = "xmp")]
     pub(crate) xmp_sidecar: bool,
     pub(crate) dry_run: bool,
     pub(crate) concurrent_downloads: usize,
@@ -502,21 +510,22 @@ impl DownloadConfig {
 
 impl std::fmt::Debug for DownloadConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DownloadConfig")
-            .field("directory", &self.directory)
+        let mut s = f.debug_struct("DownloadConfig");
+        s.field("directory", &self.directory)
             .field("folder_structure", &self.folder_structure)
             .field("size", &self.size)
             .field("skip_videos", &self.skip_videos)
             .field("skip_photos", &self.skip_photos)
             .field("skip_created_before", &self.skip_created_before)
-            .field("skip_created_after", &self.skip_created_after)
-            .field("set_exif_datetime", &self.set_exif_datetime)
+            .field("skip_created_after", &self.skip_created_after);
+        #[cfg(feature = "xmp")]
+        s.field("set_exif_datetime", &self.set_exif_datetime)
             .field("set_exif_rating", &self.set_exif_rating)
             .field("set_exif_gps", &self.set_exif_gps)
             .field("set_exif_description", &self.set_exif_description)
             .field("embed_xmp", &self.embed_xmp)
-            .field("xmp_sidecar", &self.xmp_sidecar)
-            .field("dry_run", &self.dry_run)
+            .field("xmp_sidecar", &self.xmp_sidecar);
+        s.field("dry_run", &self.dry_run)
             .field("concurrent_downloads", &self.concurrent_downloads)
             .field("recent", &self.recent)
             .field("retry", &self.retry)
@@ -558,11 +567,17 @@ impl DownloadConfig {
             skip_photos: false,
             skip_created_before: None,
             skip_created_after: None,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
+            #[cfg(feature = "xmp")]
             set_exif_rating: false,
+            #[cfg(feature = "xmp")]
             set_exif_gps: false,
+            #[cfg(feature = "xmp")]
             set_exif_description: false,
+            #[cfg(feature = "xmp")]
             embed_xmp: false,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: false,
             dry_run: false,
             concurrent_downloads: 1,
@@ -611,11 +626,13 @@ struct DownloadContext {
     /// Nested map: `asset_id` -> (`version_size` -> metadata_hash) for downloaded assets.
     /// Used to detect metadata-only changes (favorite toggle, keywords, GPS edit,
     /// etc.) when file bytes are unchanged but the provider has newer metadata.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     downloaded_metadata_hashes: FxHashMap<Box<str>, FxHashMap<Box<str>, Box<str>>>,
     /// Nested map: `asset_id` -> set of `version_sizes` with a non-null
     /// `metadata_write_failed_at` from a prior sync. These always route to
     /// the metadata-rewrite path regardless of whether the hash changed.
     /// Two-level shape matches `downloaded_ids` for zero-allocation lookups.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     metadata_retry_markers: FxHashMap<Box<str>, FxHashSet<Box<str>>>,
     /// All asset IDs known to the state DB (any status). Used in retry-only mode
     /// to skip new assets that were never synced.
@@ -739,6 +756,7 @@ impl DownloadContext {
     /// checks whether (a) the stored metadata_hash differs from the new
     /// one or (b) a persisted retry marker is set from a prior sync where
     /// the writer failed after bytes landed.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     fn needs_metadata_rewrite(
         &self,
         asset_id: &str,
@@ -2146,11 +2164,17 @@ mod tests {
             skip_videos: false,
             skip_photos: false,
             force_size: false,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
+            #[cfg(feature = "xmp")]
             set_exif_rating: false,
+            #[cfg(feature = "xmp")]
             set_exif_gps: false,
+            #[cfg(feature = "xmp")]
             set_exif_description: false,
+            #[cfg(feature = "xmp")]
             embed_xmp: false,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: false,
             dry_run: false,
             no_progress_bar: true,
@@ -2662,7 +2686,10 @@ mod tests {
         config.force_size = true;
         config.keep_unicode_in_filenames = true;
         config.dry_run = true;
-        config.set_exif_datetime = true;
+        #[cfg(feature = "xmp")]
+        {
+            config.set_exif_datetime = true;
+        }
         config.filename_exclude = vec![glob::Pattern::new("*.AAE").unwrap()];
         config.temp_suffix = ".custom-tmp".to_string();
         let derived = config.with_album_name(Arc::from("Test"));
@@ -2672,6 +2699,7 @@ mod tests {
         assert!(derived.force_size);
         assert!(derived.keep_unicode_in_filenames);
         assert!(derived.dry_run);
+        #[cfg(feature = "xmp")]
         assert!(derived.set_exif_datetime);
         assert_eq!(derived.filename_exclude.len(), 1);
         assert_eq!(derived.temp_suffix, ".custom-tmp");

--- a/src/download/pipeline.rs
+++ b/src/download/pipeline.rs
@@ -22,9 +22,11 @@ use crate::retry::RetryConfig;
 use crate::state::{AssetRecord, StateDb, SyncRunStats, VersionSizeKey};
 
 use super::error::DownloadError;
+#[cfg_attr(not(feature = "xmp"), allow(unused_imports))]
+use super::filter::MetadataPayload;
 use super::filter::{
     determine_media_type, extract_skip_candidates, filter_asset_to_tasks, is_asset_filtered,
-    pre_ensure_asset_dir, DownloadTask, FilterReason, MetadataPayload, NormalizedPath,
+    pre_ensure_asset_dir, DownloadTask, FilterReason, NormalizedPath,
 };
 use super::{paths, DownloadConfig, DownloadContext, DownloadOutcome};
 
@@ -222,6 +224,7 @@ async fn update_metadata_marker(
 /// metadata drifted from the stored hash (or that already carries a marker
 /// from a prior sync). No-op when metadata writing is off or the state DB
 /// is absent. Shared by the trust-state and on-disk-skip producer branches.
+#[cfg(feature = "xmp")]
 async fn tag_metadata_rewrites(
     state_db: Option<&dyn StateDb>,
     config: &DownloadConfig,
@@ -256,6 +259,17 @@ async fn tag_metadata_rewrites(
             );
         }
     }
+}
+
+/// No-op when the `xmp` feature is disabled at build time.
+#[cfg(not(feature = "xmp"))]
+async fn tag_metadata_rewrites(
+    _state_db: Option<&dyn StateDb>,
+    _config: &DownloadConfig,
+    _asset: &PhotoAsset,
+    _candidates: &[(VersionSizeKey, &str)],
+    _ctx: &DownloadContext,
+) {
 }
 
 /// Retry all pending state writes that failed during the download loop.
@@ -332,6 +346,7 @@ async fn flush_pending_state_writes(db: &dyn StateDb, pending: &[PendingStateWri
 
 /// Maximum assets processed per metadata-rewrite invocation. Bounds worst-case
 /// tail work at sync end; anything beyond this rolls into the next sync.
+#[cfg_attr(not(feature = "xmp"), allow(dead_code))]
 const METADATA_REWRITE_BATCH: usize = 500;
 
 /// Drain persisted metadata-rewrite markers: for each asset whose
@@ -339,6 +354,7 @@ const METADATA_REWRITE_BATCH: usize = 500;
 /// re-apply EXIF/XMP using the stored provider metadata. On success clears
 /// the marker and refreshes `metadata_hash`; on failure leaves the marker so
 /// the next sync retries.
+#[cfg(feature = "xmp")]
 async fn run_metadata_rewrites(
     db: &dyn StateDb,
     metadata_flags: MetadataFlags,
@@ -542,6 +558,7 @@ fn create_progress_bar(
 /// `xmp_sidecar` is orthogonal — it writes a `.xmp` file next to the photo
 /// without touching the photo bytes.
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(not(feature = "xmp"), allow(dead_code))]
 pub(super) struct MetadataFlags {
     pub(super) datetime: bool,
     pub(super) rating: bool,
@@ -555,12 +572,14 @@ impl MetadataFlags {
     /// Whether any flag needs the downloaded bytes to stay as a `.part` file
     /// for in-place XMP editing before the atomic rename. Sidecar writes
     /// happen after the rename and don't need this, so they're excluded.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     pub(super) fn any_embed(&self) -> bool {
         self.datetime || self.rating || self.gps || self.description || self.embed_xmp
     }
 }
 
 impl From<&DownloadConfig> for MetadataFlags {
+    #[cfg(feature = "xmp")]
     fn from(config: &DownloadConfig) -> Self {
         Self {
             datetime: config.set_exif_datetime,
@@ -570,6 +589,12 @@ impl From<&DownloadConfig> for MetadataFlags {
             embed_xmp: config.embed_xmp,
             xmp_sidecar: config.xmp_sidecar,
         }
+    }
+
+    /// Build with every flag forced false when the `xmp` feature is off.
+    #[cfg(not(feature = "xmp"))]
+    fn from(_config: &DownloadConfig) -> Self {
+        Self::default()
     }
 }
 
@@ -1458,6 +1483,7 @@ where
     // from a previous one). This re-applies EXIF/XMP on the existing files
     // without re-downloading bytes; the alternative was to leave markers
     // accumulating in the DB forever.
+    #[cfg(feature = "xmp")]
     if let Some(db) = &state_db {
         let metadata_flags = MetadataFlags::from(config.as_ref());
         if metadata_flags.any_embed() || metadata_flags.xmp_sidecar {
@@ -1918,6 +1944,7 @@ fn maybe_warn_rate_limit_pressure(stats: &super::SyncStats) {
     }
 }
 
+#[cfg(feature = "xmp")]
 fn gps_from_payload(payload: &MetadataPayload) -> Option<super::metadata::GpsCoords> {
     match (payload.latitude, payload.longitude) {
         (Some(lat), Some(lng)) => Some(super::metadata::GpsCoords {
@@ -1931,6 +1958,7 @@ fn gps_from_payload(payload: &MetadataPayload) -> Option<super::metadata::GpsCoo
 
 /// Comprehensive snapshot of every field a payload can contribute. Used as
 /// the sidecar plan (sidecars are fresh files; no probe gating applies).
+#[cfg(feature = "xmp")]
 fn plan_sidecar_write(
     payload: &MetadataPayload,
     created_local: &chrono::DateTime<chrono::Local>,
@@ -1957,6 +1985,7 @@ fn plan_sidecar_write(
 /// - **rating / description**: flag gate only — iCloud is the source of truth.
 /// - **XMP-only fields** (title, keywords, people, hidden/archived,
 ///   media_subtype, burst_id): gated on `embed_xmp`.
+#[cfg(feature = "xmp")]
 fn plan_metadata_write(
     flags: MetadataFlags,
     payload: &MetadataPayload,
@@ -1998,7 +2027,7 @@ async fn download_single_task(
     client: &Client,
     task: &DownloadTask,
     retry_config: &RetryConfig,
-    metadata_flags: MetadataFlags,
+    #[cfg_attr(not(feature = "xmp"), allow(unused_variables))] metadata_flags: MetadataFlags,
     temp_suffix: &str,
     rate_limit_counter: Option<&std::sync::atomic::AtomicUsize>,
     bandwidth_limiter: Option<&super::BandwidthLimiter>,
@@ -2016,9 +2045,14 @@ async fn download_single_task(
     );
 
     // Embed writes happen on the .part file before the atomic rename; sidecar
-    // writes happen after, on the final path.
+    // writes happen after, on the final path. Without the `xmp` feature at
+    // build time there's no writer and no extension gate to consult, so
+    // `needs_exif` is unconditionally false and the embed path is compiled out.
+    #[cfg(feature = "xmp")]
     let needs_exif =
         metadata_flags.any_embed() && super::metadata::is_embed_writable_path(&task.download_path);
+    #[cfg(not(feature = "xmp"))]
+    let needs_exif = false;
 
     let bytes_downloaded = Box::pin(super::file::download_file(
         client,
@@ -2057,7 +2091,9 @@ async fn download_single_task(
         None
     };
 
+    #[cfg_attr(not(feature = "xmp"), allow(unused_mut))]
     let mut exif_ok = true;
+    #[cfg(feature = "xmp")]
     if let Some(part) = &part_path {
         let exif_path = part.clone();
         let payload = task.metadata.clone();
@@ -2113,6 +2149,7 @@ async fn download_single_task(
         super::file::rename_part_to_final(part, &task.download_path).await?;
     }
 
+    #[cfg(feature = "xmp")]
     if metadata_flags.xmp_sidecar {
         let sidecar_path = task.download_path.clone();
         let payload = task.metadata.clone();
@@ -2476,10 +2513,12 @@ mod tests {
         assert_eq!(decision, BatchForecast::Continue);
     }
 
+    #[cfg(feature = "xmp")]
     fn now_local() -> chrono::DateTime<chrono::Local> {
         chrono::Local::now()
     }
 
+    #[cfg(feature = "xmp")]
     fn rich_payload() -> MetadataPayload {
         MetadataPayload {
             rating: Some(4),
@@ -2497,6 +2536,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn plan_metadata_write_gates_xmp_fields_on_embed_xmp() {
         let payload = rich_payload();
@@ -2534,6 +2574,7 @@ mod tests {
         assert_eq!(w.burst_id.as_deref(), Some("b1"));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn plan_metadata_write_respects_probe_skip_for_datetime_and_gps() {
         let payload = rich_payload();
@@ -2554,6 +2595,7 @@ mod tests {
         assert!(w.gps.is_none(), "must skip gps when file already has one");
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn plan_sidecar_write_is_comprehensive_regardless_of_flags() {
         let payload = rich_payload();
@@ -2572,6 +2614,7 @@ mod tests {
         assert_eq!(w.burst_id.as_deref(), Some("b1"));
     }
 
+    #[cfg(feature = "xmp")]
     #[test]
     fn plan_sidecar_write_empty_payload_yields_datetime_only() {
         // datetime comes from the local clock; the rest stays empty.
@@ -3269,11 +3312,17 @@ mod tests {
             skip_photos: false,
             skip_created_before: None,
             skip_created_after: None,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
+            #[cfg(feature = "xmp")]
             set_exif_rating: false,
+            #[cfg(feature = "xmp")]
             set_exif_gps: false,
+            #[cfg(feature = "xmp")]
             set_exif_description: false,
+            #[cfg(feature = "xmp")]
             embed_xmp: false,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: false,
             dry_run: false,
             concurrent_downloads: 10,
@@ -3350,11 +3399,17 @@ mod tests {
             skip_photos: false,
             skip_created_before: None,
             skip_created_after: None,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
+            #[cfg(feature = "xmp")]
             set_exif_rating: false,
+            #[cfg(feature = "xmp")]
             set_exif_gps: false,
+            #[cfg(feature = "xmp")]
             set_exif_description: false,
+            #[cfg(feature = "xmp")]
             embed_xmp: false,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: false,
             dry_run: false,
             concurrent_downloads: 1,
@@ -3485,6 +3540,7 @@ mod tests {
 
     /// Minimal valid JPEG (SOI + APP0 JFIF + EOI). XMP Toolkit can write
     /// into this container; small enough to keep the test hermetic.
+    #[cfg(feature = "xmp")]
     fn minimal_jpeg_bytes() -> Vec<u8> {
         vec![
             0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
@@ -3498,6 +3554,7 @@ mod tests {
     /// 1. the on-disk JPEG now carries the rating in its XMP packet,
     /// 2. the DB marker is cleared (rewrite won't re-fire next cycle),
     /// 3. `metadata_hash` is refreshed to match the asset state.
+    #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn run_metadata_rewrites_applies_embed_and_clears_marker() {
         use crate::state::types::AssetMetadata;
@@ -3580,6 +3637,7 @@ mod tests {
     /// If the on-disk file has vanished between tagging and the rewrite
     /// pass, the pass must not error out. The marker stays, so a future
     /// sync that re-downloads the asset re-drives the writer.
+    #[cfg(feature = "xmp")]
     #[tokio::test]
     async fn run_metadata_rewrites_skips_missing_file_and_leaves_marker() {
         use crate::state::types::AssetMetadata;

--- a/src/report.rs
+++ b/src/report.rs
@@ -113,12 +113,30 @@ impl RunOptions {
             library: format!("{:?}", config.library).to_lowercase(),
             skip_videos: config.skip_videos,
             skip_photos: config.skip_photos,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: config.set_exif_datetime,
+            #[cfg(not(feature = "xmp"))]
+            set_exif_datetime: false,
+            #[cfg(feature = "xmp")]
             set_exif_rating: config.set_exif_rating,
+            #[cfg(not(feature = "xmp"))]
+            set_exif_rating: false,
+            #[cfg(feature = "xmp")]
             set_exif_gps: config.set_exif_gps,
+            #[cfg(not(feature = "xmp"))]
+            set_exif_gps: false,
+            #[cfg(feature = "xmp")]
             set_exif_description: config.set_exif_description,
+            #[cfg(not(feature = "xmp"))]
+            set_exif_description: false,
+            #[cfg(feature = "xmp")]
             embed_xmp: config.embed_xmp,
+            #[cfg(not(feature = "xmp"))]
+            embed_xmp: false,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: config.xmp_sidecar,
+            #[cfg(not(feature = "xmp"))]
+            xmp_sidecar: false,
             threads_num: config.threads_num,
             no_incremental: config.no_incremental,
             dry_run: config.dry_run,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -67,6 +67,7 @@ struct SetupAnswers {
     max_retries: Option<u32>,
     retry_delay: Option<u64>,
     keep_unicode_in_filenames: bool,
+    #[cfg(feature = "xmp")]
     set_exif_datetime: bool,
     file_match_policy: Option<FileMatchPolicy>,
     cookie_directory: Option<String>,
@@ -100,6 +101,7 @@ impl Default for SetupAnswers {
             max_retries: None,
             retry_delay: None,
             keep_unicode_in_filenames: false,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: false,
             file_match_policy: None,
             cookie_directory: None,
@@ -606,10 +608,13 @@ fn ask_extras(answers: &mut SetupAnswers) -> anyhow::Result<()> {
         .default(false)
         .interact()?;
 
-    answers.set_exif_datetime = Confirm::new()
-        .with_prompt("Write EXIF date tag if missing from photo?")
-        .default(false)
-        .interact()?;
+    #[cfg(feature = "xmp")]
+    {
+        answers.set_exif_datetime = Confirm::new()
+            .with_prompt("Write EXIF date tag if missing from photo?")
+            .default(false)
+            .interact()?;
+    }
 
     // Dedup
     println!();
@@ -708,14 +713,17 @@ fn generate_toml(answers: &SetupAnswers) -> String {
         Some(n) => writeln!(out, "threads_num = {n}").ok(),
         None => writeln!(out, "# threads_num = 10").ok(),
     };
-    if answers.set_exif_datetime {
-        writeln!(out, "set_exif_datetime = true").ok();
-    } else {
-        writeln!(out, "# set_exif_datetime = false").ok();
+    #[cfg(feature = "xmp")]
+    {
+        if answers.set_exif_datetime {
+            writeln!(out, "set_exif_datetime = true").ok();
+        } else {
+            writeln!(out, "# set_exif_datetime = false").ok();
+        }
+        writeln!(out, "# set_exif_rating = false").ok();
+        writeln!(out, "# set_exif_gps = false").ok();
+        writeln!(out, "# set_exif_description = false").ok();
     }
-    writeln!(out, "# set_exif_rating = false").ok();
-    writeln!(out, "# set_exif_gps = false").ok();
-    writeln!(out, "# set_exif_description = false").ok();
     writeln!(out, "# temp_suffix = \".kei-tmp\"").ok();
     writeln!(out, "# no_progress_bar = false").ok();
 
@@ -963,6 +971,7 @@ mod tests {
             max_retries: Some(5),
             retry_delay: Some(10),
             keep_unicode_in_filenames: true,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: true,
             file_match_policy: Some(FileMatchPolicy::NameId7),
             cookie_directory: Some("~/.cookies".to_string()),
@@ -984,6 +993,7 @@ mod tests {
         assert!(toml_str.contains("threads_num = 4"));
         assert!(toml_str.contains("file_match_policy = \"name-id7\""));
         assert!(toml_str.contains("log_level = \"debug\""));
+        #[cfg(feature = "xmp")]
         assert!(toml_str.contains("set_exif_datetime = true"));
         assert!(toml_str.contains("keep_unicode_in_filenames = true"));
         assert!(toml_str.contains("cookie_directory = \"~/.cookies\""));
@@ -1021,6 +1031,7 @@ mod tests {
             max_retries: Some(0),
             retry_delay: Some(1),
             keep_unicode_in_filenames: true,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: true,
             file_match_policy: Some(FileMatchPolicy::NameId7),
             cookie_directory: Some("/tmp/cookies".to_string()),
@@ -1039,6 +1050,7 @@ mod tests {
         assert_eq!(dl.directory.as_deref(), Some("/data/photos"));
         assert_eq!(dl.folder_structure.as_deref(), Some("%Y-%m"));
         assert_eq!(dl.threads_num, Some(2));
+        #[cfg(feature = "xmp")]
         assert_eq!(dl.set_exif_datetime, Some(true));
         let retry = dl.retry.unwrap();
         assert_eq!(retry.max_retries, Some(0));

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -231,9 +231,11 @@ pub trait StateDb: Send + Sync {
     /// Bulk-load every `(asset_id, album_name)` from `asset_albums`. Used at
     /// sync start to populate the in-memory groupings index — downstream
     /// writers look up album memberships without a per-asset DB hit.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     async fn get_all_asset_albums(&self) -> Result<Vec<(String, String)>, StateError>;
 
     /// Bulk-load every `(asset_id, person_name)` from `asset_people`.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     async fn get_all_asset_people(&self) -> Result<Vec<(String, String)>, StateError>;
 
     /// Mark an asset as soft-deleted (all versions under `asset_id`).
@@ -279,6 +281,7 @@ pub trait StateDb: Send + Sync {
     /// rewrite marker AND have a local_path pointing at an on-disk file.
     /// Used by the metadata-rewrite worker to re-apply EXIF/XMP without
     /// re-downloading bytes.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     async fn get_pending_metadata_rewrites(
         &self,
         limit: usize,
@@ -286,6 +289,7 @@ pub trait StateDb: Send + Sync {
 
     /// Update just the `metadata_hash` column for an asset-version pair
     /// after a successful metadata rewrite. Leaves every other column alone.
+    #[cfg_attr(not(feature = "xmp"), allow(dead_code))]
     async fn update_metadata_hash(
         &self,
         asset_id: &str,

--- a/src/sync_loop.rs
+++ b/src/sync_loop.rs
@@ -422,11 +422,17 @@ pub(crate) async fn run_sync(globals: &config::GlobalArgs, args: SyncArgs) -> an
             skip_photos: config.skip_photos,
             skip_created_before,
             skip_created_after,
+            #[cfg(feature = "xmp")]
             set_exif_datetime: config.set_exif_datetime,
+            #[cfg(feature = "xmp")]
             set_exif_rating: config.set_exif_rating,
+            #[cfg(feature = "xmp")]
             set_exif_gps: config.set_exif_gps,
+            #[cfg(feature = "xmp")]
             set_exif_description: config.set_exif_description,
+            #[cfg(feature = "xmp")]
             embed_xmp: config.embed_xmp,
+            #[cfg(feature = "xmp")]
             xmp_sidecar: config.xmp_sidecar,
             dry_run: config.dry_run,
             concurrent_downloads: config.threads_num as usize,
@@ -976,11 +982,14 @@ async fn run_cycle(
         tracing::debug!(sync_mode = sync_mode_label, zone = %lib_state.zone_name, "Starting sync cycle");
 
         // Skip the DB scan entirely when nothing downstream will read it.
+        #[cfg(feature = "xmp")]
         let asset_groupings = if config.embed_xmp || config.xmp_sidecar {
             preload_asset_groupings(state_db).await
         } else {
             Arc::new(download::AssetGroupings::default())
         };
+        #[cfg(not(feature = "xmp"))]
+        let asset_groupings = Arc::new(download::AssetGroupings::default());
         // Each pass carries its own exclude-asset-ids, so the config built
         // here starts with an empty set; download_photos_with_sync derives
         // per-pass configs internally via `with_exclude_ids`.
@@ -1076,6 +1085,7 @@ async fn run_cycle(
 /// Returns `true` when no zones report changes and `moreComing` is false.
 /// Bulk-load `asset_albums` + `asset_people` into an in-memory index so the
 /// filter phase can enrich payloads without per-asset DB hits.
+#[cfg(feature = "xmp")]
 async fn preload_asset_groupings(
     state_db: &Option<Arc<dyn state::StateDb>>,
 ) -> Arc<download::AssetGroupings> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -383,7 +383,7 @@ fn import_existing_requires_directory() {
 
 #[test]
 fn boolean_sync_flags_accepted() {
-    for flag in [
+    let mut flags = vec![
         "--auth-only",
         "--list-albums",
         "--list-libraries",
@@ -391,14 +391,17 @@ fn boolean_sync_flags_accepted() {
         "--skip-photos",
         "--skip-live-photos",
         "--force-size",
-        "--set-exif-datetime",
         "--dry-run",
         "--no-progress-bar",
         "--keep-unicode-in-filenames",
         "--notify-systemd",
         "--no-incremental",
         "--reset-sync-token",
-    ] {
+    ];
+    if cfg!(feature = "xmp") {
+        flags.push("--set-exif-datetime");
+    }
+    for flag in flags {
         common::cmd()
             .args(["sync", flag, "--help"])
             .assert()

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -604,6 +604,7 @@ fn sync_keep_unicode_preserves_special_chars() {
 // ── EXIF ────────────────────────────────────────────────────────────────
 
 /// --set-exif-datetime should embed DateTimeOriginal in downloaded JPEG files.
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_set_exif_datetime_embeds_date() {
@@ -651,6 +652,7 @@ fn sync_set_exif_datetime_embeds_date() {
 /// --set-exif-rating should add a Rating property (value depends on the
 /// source photo; we assert the sync succeeds and the resulting JPEG has
 /// a writable XMP packet).
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_set_exif_rating_embeds_rating() {
@@ -680,6 +682,7 @@ fn sync_set_exif_rating_embeds_rating() {
 /// --set-exif-gps embeds GPSLatitude/GPSLongitude when the source photo
 /// carries location data. Sync must succeed either way; we only assert
 /// an XMP packet exists.
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_set_exif_gps_embeds_gps() {
@@ -709,6 +712,7 @@ fn sync_set_exif_gps_embeds_gps() {
 /// --set-exif-description embeds a dc:description when the source has
 /// one. Sync must succeed either way; we only assert an XMP packet
 /// exists.
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_set_exif_description_embeds_description() {
@@ -737,6 +741,7 @@ fn sync_set_exif_description_embeds_description() {
 
 /// --embed-xmp writes a full kei-authored XMP packet into the JPEG. Verify
 /// the file carries XMP content that references kei's own namespace URI.
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_embed_xmp_writes_xmp_packet() {
@@ -771,6 +776,7 @@ fn sync_embed_xmp_writes_xmp_packet() {
 
 /// --xmp-sidecar writes a .xmp sidecar next to every downloaded media file.
 /// Verify at least one `.xmp` sits next to a downloaded JPEG.
+#[cfg(feature = "xmp")]
 #[test]
 #[ignore]
 fn sync_xmp_sidecar_writes_sidecar_file() {
@@ -864,6 +870,7 @@ fn sync_embed_xmp_on_heic_writes_mime_item() {
 
 /// Find the first downloaded JPEG in `dir`. Panics with a clear message if
 /// none is present — the test album must contain at least one JPEG.
+#[cfg(feature = "xmp")]
 fn first_jpeg(dir: &&std::path::Path) -> std::path::PathBuf {
     let files = common::walkdir(dir);
     files


### PR DESCRIPTION
Fixes the FreeBSD build (@jan666 in #256). `xmp_toolkit` vendors Adobe's C++ XMP Toolkit and doesn't compile on FreeBSD; move the XMP write path behind a new `xmp` feature (default-on) and add a FreeBSD target block for `keyring`.

## What lands

- New Cargo feature: `default = ["xmp"]`, `xmp = ["dep:xmp_toolkit"]`. `xmp_toolkit` is now `optional = true`. Existing users see zero behavior change; FreeBSD builds with `cargo build --no-default-features`.
- `--embed-xmp`, `--xmp-sidecar`, `--set-exif-datetime`, `--set-exif-rating`, `--set-exif-gps`, `--set-exif-description` CLI flags + their `[download]` TOML keys are `#[cfg(feature = "xmp")]`-gated, so `kei sync --help` on a no-xmp build is honest about what the build can do.
- `src/download/metadata.rs` and `src/download/heif.rs` are feature-gated entirely. HEIC magic-byte detection stays available (lives in `download/file.rs::classify_magic`, no `xmp_toolkit` dep). HEIC metadata writes do require the feature, since the XMP packet serializer is in `xmp_toolkit`.
- Call sites in `download/pipeline.rs`, `download/mod.rs`, `sync_loop.rs`, `report.rs`, `setup.rs` either gate the whole block or fall through to `MetadataFlags::default()` / `false`. `RunOptions` in `sync_report.json` keeps the xmp boolean fields so the JSON shape stays stable; they're always `false` on a no-xmp build.
- New `[target.'cfg(target_os = "freebsd")'.dependencies]` block adds `keyring` with `sync-secret-service` (the same backend Linux uses). No `sd-notify` - FreeBSD doesn't run systemd and `src/systemd.rs` already `#[cfg(target_os = "linux")]`-gates every use.
- New `Clippy (no-default-features)` CI job keeps the gate honest (`cargo clippy --all-targets --no-default-features -- -D warnings`).
- README gains a FreeBSD install block. CHANGELOG entry under `[Unreleased]`.

## Why no `sd-notify` in the FreeBSD block

@jan666's workaround patch adds `sd-notify = "0.5"` under FreeBSD mirroring the Linux block. That line is dead weight - `sd-notify` talks to systemd over a Unix socket and `src/systemd.rs` only calls into it on Linux. FreeBSD's release line is OpenRC / rc.d, so the crate is never reached.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo test --bin kei` - 1576 passed (xmp on)
- `cargo test --bin kei --no-default-features` - 1522 passed (54 xmp-only tests gated out)
- `cargo test --test cli` / `--test behavioral` - 95 / 118 passed in both modes
- `cargo build --release --no-default-features` produces a working binary; `kei sync --help` on it lists no `--embed-xmp` / `--xmp-sidecar` / `--set-exif-*` flags.

## What I still haven't done

No FreeBSD CI runner (GitHub Actions doesn't offer one). The `Clippy (no-default-features)` job catches the common break (an xmp_toolkit type smuggled out of a gated module) but doesn't catch FreeBSD-specific link or runtime issues. Adding Cirrus CI for a real FreeBSD build is a separate, bigger change; flagging here in case you want to queue it.

Closes #256.